### PR TITLE
HSSFWorkbook.getAllEmbeddedObjects wasn't getting all embedded objects

### DIFF
--- a/src/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/src/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -1722,11 +1722,7 @@ public final class HSSFWorkbook extends POIDocument implements org.apache.poi.ss
         if (null == patriarch){
             return;
         }
-        for (HSSFShape shape: patriarch.getChildren()){
-            if (shape instanceof HSSFObjectData){
-                objects.add((HSSFObjectData) shape);
-            }
-        }
+        getAllEmbeddedObjects(patriarch, objects);
     }
 
     /**

--- a/src/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/src/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -1729,6 +1729,23 @@ public final class HSSFWorkbook extends POIDocument implements org.apache.poi.ss
         }
     }
 
+    /**
+     * Recursively iterates a shape container to get all embedded objects.
+     * 
+     * @param parent the parent.
+     * @param objects the list of embedded objects to populate.
+     */
+    private void getAllEmbeddedObjects(HSSFShapeContainer parent, List<HSSFObjectData> objects)
+    {
+        for (HSSFShape shape : parent.getChildren()) {
+            if (shape instanceof HSSFObjectData) {
+                objects.add((HSSFObjectData) shape);
+            } else if (shape instanceof HSSFShapeContainer) {
+                getAllEmbeddedObjects((HSSFShapeContainer) shape, objects);
+            }
+    	}
+    }
+
     public HSSFCreationHelper getCreationHelper() {
         return new HSSFCreationHelper(this);
     }


### PR DESCRIPTION
HSSFWorkbook.getAllEmbeddedObjects wasn't getting all embedded objects, only the top-level ones. This fixes it to get them recursively.
