### PR TITLE
Bug 55555 fix

### DIFF
--- a/src/java/org/apache/poi/ss/util/CellUtil.java
+++ b/src/java/org/apache/poi/ss/util/CellUtil.java
@@ -363,9 +363,9 @@ public final class CellUtil {
         style.setBorderTop(getBorderStyle(properties, BORDER_TOP));
         style.setBottomBorderColor(getShort(properties, BOTTOM_BORDER_COLOR));
         style.setDataFormat(getShort(properties, DATA_FORMAT));
-        style.setFillBackgroundColor(getShort(properties, FILL_BACKGROUND_COLOR));
-        style.setFillForegroundColor(getShort(properties, FILL_FOREGROUND_COLOR));
         style.setFillPattern(getShort(properties, FILL_PATTERN));
+        style.setFillForegroundColor(getShort(properties, FILL_FOREGROUND_COLOR));
+        style.setFillBackgroundColor(getShort(properties, FILL_BACKGROUND_COLOR));
         style.setFont(workbook.getFontAt(getShort(properties, FONT)));
         style.setHidden(getBoolean(properties, HIDDEN));
         style.setIndention(getShort(properties, INDENTION));


### PR DESCRIPTION
This is a fix for [bug 55555](https://bz.apache.org/bugzilla/show_bug.cgi?id=55555) (background color is reset to black after calls to CellUtil).

Javadoc for `HSSFCellStyle.setFillBackgroundColor` says "Note: Ensure Foreground color is set prior to background". So, the order of operations in `CellUtil.setFormatProperties` should be different. It's ordered lexicographically now:

``` java
style.setFillBackgroundColor(getShort(properties, FILL_BACKGROUND_COLOR));
style.setFillForegroundColor(getShort(properties, FILL_FOREGROUND_COLOR));
style.setFillPattern(getShort(properties, FILL_PATTERN));
```

According to HSSFCellStyle's javadoc, it should be so:

``` java
style.setFillPattern(getShort(properties, FILL_PATTERN));
style.setFillForegroundColor(getShort(properties, FILL_FOREGROUND_COLOR));
style.setFillBackgroundColor(getShort(properties, FILL_BACKGROUND_COLOR));
```

Also, bugs [50849](https://bz.apache.org/bugzilla/show_bug.cgi?id=50849) and [59442](https://bz.apache.org/bugzilla/show_bug.cgi?id=59442) _may_ have the same cause (I didn't check).
