### PR TITLE
Add strategy class for creating FakeZipEntry

### DIFF
--- a/src/ooxml/java/org/apache/poi/openxml4j/util/DefaultFakeZipEntryCreationStrategy.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/util/DefaultFakeZipEntryCreationStrategy.java
@@ -1,0 +1,77 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+
+public class DefaultFakeZipEntryCreationStrategy implements FakeZipEntryCreationStrategy {
+
+    public FakeZipEntry createFakeZipEntry(final ZipEntry entry, final InputStream inputStream) throws IOException {
+        return new InMemoryZipEntry(entry, inputStream);
+    }
+    
+    /**
+     * So we can close the real zip entry and still
+     *  effectively work with it.
+     * Holds the (decompressed!) data in memory, so
+     *  close this as soon as you can! 
+     */
+    static class InMemoryZipEntry extends FakeZipEntry {
+        private byte[] data;
+        
+        public InMemoryZipEntry(ZipEntry entry, InputStream inp) throws IOException {
+            super(entry.getName());
+            
+            // Grab the de-compressed contents for later
+            ByteArrayOutputStream baos;
+
+            long entrySize = entry.getSize();
+
+            if (entrySize !=-1) {
+                if (entrySize>=Integer.MAX_VALUE) {
+                    throw new IOException("ZIP entry size is too large");
+                }
+
+                baos = new ByteArrayOutputStream((int) entrySize);
+            } else {
+                baos = new ByteArrayOutputStream();
+            }
+
+            byte[] buffer = new byte[4096];
+            int read = 0;
+            while( (read = inp.read(buffer)) != -1 ) {
+                baos.write(buffer, 0, read);
+            }
+            
+            data = baos.toByteArray();
+        }
+        
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(data);
+        }
+
+        public void close() throws IOException {
+            data = null;
+        }
+    }
+
+}

--- a/src/ooxml/java/org/apache/poi/openxml4j/util/FakeZipEntry.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/util/FakeZipEntry.java
@@ -18,6 +18,7 @@
 package org.apache.poi.openxml4j.util;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipEntry;
 
@@ -29,9 +30,12 @@ public abstract class FakeZipEntry extends ZipEntry implements Closeable {
         super(name);
     }
     
-    public abstract InputStream getInputStream();
+    public abstract InputStream getInputStream() throws IOException;
     
     public static void setFakeZipEntryCreationStrategy(final FakeZipEntryCreationStrategy strategy) {
+        if (strategy == null) {
+            throw new IllegalArgumentException("strategy == null");
+        }
         STRATEGY = strategy;
     }
 }

--- a/src/ooxml/java/org/apache/poi/openxml4j/util/FakeZipEntry.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/util/FakeZipEntry.java
@@ -1,0 +1,37 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.util;
+
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+
+public abstract class FakeZipEntry extends ZipEntry implements Closeable {
+    
+    static FakeZipEntryCreationStrategy STRATEGY = new DefaultFakeZipEntryCreationStrategy();
+
+    protected FakeZipEntry(final String name) {
+        super(name);
+    }
+    
+    public abstract InputStream getInputStream();
+    
+    public static void setFakeZipEntryCreationStrategy(final FakeZipEntryCreationStrategy strategy) {
+        STRATEGY = strategy;
+    }
+}

--- a/src/ooxml/java/org/apache/poi/openxml4j/util/FakeZipEntryCreationStrategy.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/util/FakeZipEntryCreationStrategy.java
@@ -1,0 +1,26 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+
+public interface FakeZipEntryCreationStrategy {
+    FakeZipEntry createFakeZipEntry(ZipEntry entry, InputStream inputStream) throws IOException;
+}

--- a/src/ooxml/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
@@ -24,8 +24,7 @@ import java.util.Iterator;
 import java.util.zip.ZipEntry;
 
 import org.apache.poi.openxml4j.util.ZipSecureFile.ThresholdInputStream;
-import org.apache.poi.util.POILogFactory;
-import org.apache.poi.util.POILogger;
+import org.apache.poi.util.IOUtils;
 
 /**
  * Provides a way to get at all the ZipEntries
@@ -36,7 +35,6 @@ import org.apache.poi.util.POILogger;
  *  done, to free up that memory!
  */
 public class ZipInputStreamZipEntrySource implements ZipEntrySource {
-    private static POILogger logger = POILogFactory.getLogger(ZipInputStreamZipEntrySource.class);
 	private ArrayList<FakeZipEntry> zipEntries;
 	
 	/**
@@ -76,11 +74,7 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
 	public void close() {
 	    if(zipEntries != null) {
     	    for(FakeZipEntry zipEntry : zipEntries) {
-    	        try {
-    	            zipEntry.close();
-    	        } catch(Throwable t) {
-    	            logger.log(POILogger.WARN, "Cannot close zip entry", t);
-    	        }
+    	        IOUtils.closeQuietly(zipEntry);
     	    }
             // Free the memory
             zipEntries = null;

--- a/src/ooxml/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
@@ -65,7 +65,7 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
 		return new EntryEnumerator();
 	}
 	
-	public InputStream getInputStream(ZipEntry zipEntry) {
+	public InputStream getInputStream(ZipEntry zipEntry) throws IOException {
 	    assert (zipEntry instanceof FakeZipEntry);
 		FakeZipEntry entry = (FakeZipEntry)zipEntry;
 		return entry.getInputStream();

--- a/src/ooxml/testcases/org/apache/poi/openxml4j/util/TestFakeZipEntryCreationStrategy.java
+++ b/src/ooxml/testcases/org/apache/poi/openxml4j/util/TestFakeZipEntryCreationStrategy.java
@@ -1,0 +1,107 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+import java.util.zip.ZipEntry;
+
+import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.TempFile;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestFakeZipEntryCreationStrategy {
+    
+    private int fileCount = 0;
+    
+    @Before
+    public void setUp() {
+        fileCount = 0;
+        FakeZipEntry.setFakeZipEntryCreationStrategy(new TempFileFakeZipEntryCreationStrategy());
+    }
+
+    @After
+    public void tearDown() {
+        FakeZipEntry.setFakeZipEntryCreationStrategy(new DefaultFakeZipEntryCreationStrategy());
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetNullStrategy() throws Exception {
+        FakeZipEntry.setFakeZipEntryCreationStrategy(null);
+    }
+    
+    @Test
+    public void testCustomStrategy() throws Exception {
+        byte[] bytes = new byte[16];
+        new Random().nextBytes(bytes);
+        assertTrue(FakeZipEntry.STRATEGY instanceof TempFileFakeZipEntryCreationStrategy);
+        FakeZipEntry zipEntry = FakeZipEntry.STRATEGY.createFakeZipEntry(new ZipEntry("name"), new ByteArrayInputStream(bytes));
+        assertEquals(1, fileCount);
+        assertNotNull(zipEntry);
+        assertNotNull(zipEntry.getInputStream());
+    }
+    
+    private class TempFileFakeZipEntryCreationStrategy implements FakeZipEntryCreationStrategy {
+
+        public FakeZipEntry createFakeZipEntry(ZipEntry entry, InputStream inputStream) throws IOException {
+            return new TempFileZipEntry(entry, inputStream);
+        }    
+    }
+    
+    private class TempFileZipEntry extends FakeZipEntry {
+        private File file;
+        
+        public TempFileZipEntry(ZipEntry entry, InputStream inp) throws IOException {
+            super(entry.getName());
+            fileCount++;
+            file = TempFile.createTempFile("fakezipentry", ".tmp");
+            FileOutputStream fos = new FileOutputStream(file);
+            try {
+                byte[] buffer = new byte[4096];
+                int read = 0;
+                while( (read = inp.read(buffer)) != -1 ) {
+                    fos.write(buffer, 0, read);
+                }
+            } finally {
+                IOUtils.closeQuietly(fos);
+            }
+        }
+        
+        public InputStream getInputStream() throws IOException {
+            return new FileInputStream(file);
+        }
+
+        public void close() throws IOException {
+            if(file != null) {
+                file.delete();
+                file = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Relate to https://bz.apache.org/bugzilla/show_bug.cgi?id=59841
I would like to be able to override the FakeZipEntry behaviour. This code is based on the POI TempFile creation strategy.
The suggested solution for 59841 is to read the xlsx from file but I need to decrypt it and don't want to store the unencrypted data on disk.
I have access to temp file class that uses keeps small data loads in memory and larger ones are pushed to disk but encrypted. I can create a custom FakeZipEntry that uses this class under the hood.
If this approach is acceptable, I can add extra test coverage.
