### PR TITLE
BUG-60288: removes defensive copy for internal relationships usage

### DIFF
--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -1409,7 +1409,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
 	 */
 	@Override
     public boolean isRelationshipExists(PackageRelationship rel) {
-        for (PackageRelationship r : this.getRelationships()) {
+        for (PackageRelationship r : relationships) {
             if (r == rel) {
                 return true;
             }

--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/PackagePart.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/PackagePart.java
@@ -447,12 +447,9 @@ public abstract class PackagePart implements RelationshipSource, Comparable<Pack
 	 * @see org.apache.poi.openxml4j.opc.RelationshipSource#isRelationshipExists(org.apache.poi.openxml4j.opc.PackageRelationship)
 	 */
 	public boolean isRelationshipExists(PackageRelationship rel) {
-        try {
-            for (PackageRelationship r : this.getRelationships()) {
-                if (r == rel)
-                    return true;
-            }
-        } catch (InvalidFormatException e){
+		for (PackageRelationship r : _relationships) {
+			if (r == rel)
+				return true;
 		}
         return false;
 	}


### PR DESCRIPTION
Fix for https://bz.apache.org/bugzilla/show_bug.cgi?id=60288

Since we're not returning `_relationships` from this method we can just use it directly. Avoids quadratic slowdowns when this is (transitively/directly) used in a loop of these relationships.
