### PR TITLE
Adding a new method to the XSSFConditionalFormatting class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFConditionalFormatting.java
+++ b/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFConditionalFormatting.java
@@ -25,6 +25,7 @@ import org.apache.poi.ss.util.CellRangeAddress;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTConditionalFormatting;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * @author Yegor Kozlov
@@ -33,73 +34,94 @@ public class XSSFConditionalFormatting implements ConditionalFormatting {
     private final CTConditionalFormatting _cf;
     private final XSSFSheet _sh;
 
-    /*package*/ XSSFConditionalFormatting(XSSFSheet sh){
+    /*package*/ XSSFConditionalFormatting(XSSFSheet sh) {
         _cf = CTConditionalFormatting.Factory.newInstance();
         _sh = sh;
     }
 
-    /*package*/ XSSFConditionalFormatting(XSSFSheet sh, CTConditionalFormatting cf){
+    /*package*/ XSSFConditionalFormatting(
+            XSSFSheet sh, CTConditionalFormatting cf) {
         _cf = cf;
         _sh = sh;
     }
 
-    /*package*/  CTConditionalFormatting getCTConditionalFormatting(){
+    /*package*/  CTConditionalFormatting getCTConditionalFormatting() {
         return _cf;
     }
 
     /**
-      * @return array of <tt>CellRangeAddress</tt>s. Never <code>null</code>
-      */
-     public CellRangeAddress[] getFormattingRanges(){
-         ArrayList<CellRangeAddress> lst = new ArrayList<CellRangeAddress>();
-         for (Object stRef : _cf.getSqref()) {
-             String[] regions = stRef.toString().split(" ");
-             for (int i = 0; i < regions.length; i++) {
-                 lst.add(CellRangeAddress.valueOf(regions[i]));
-             }
-         }
-         return lst.toArray(new CellRangeAddress[lst.size()]);
-     }
+     * @return array of <tt>CellRangeAddress</tt>s. Never <code>null</code>
+     */
+    @Override
+    public CellRangeAddress[] getFormattingRanges() {
+        ArrayList<CellRangeAddress> lst = new ArrayList<CellRangeAddress>();
+        for (Object stRef : _cf.getSqref()) {
+            String[] regions = stRef.toString().split(" ");
+            for (final String region : regions) {
+                lst.add(CellRangeAddress.valueOf(region));
+            }
+        }
+        return lst.toArray(new CellRangeAddress[lst.size()]);
+    }
 
-     /**
-      * Replaces an existing Conditional Formatting rule at position idx.
-      * Excel allows to create up to 3 Conditional Formatting rules.
-      * This method can be useful to modify existing  Conditional Formatting rules.
-      *
-      * @param idx position of the rule. Should be between 0 and 2.
-      * @param cfRule - Conditional Formatting rule
-      */
-     public void setRule(int idx, ConditionalFormattingRule cfRule){
-         XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule)cfRule;
-         _cf.getCfRuleArray(idx).set(xRule.getCTCfRule());
-     }
+    public void setFormattingRanges(CellRangeAddress[] ranges) {
+        final StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (CellRangeAddress range : ranges) {
+            if (!first) {
+                sb.append(" ");
+            } else {
+                first = false;
+            }
+            sb.append(range.formatAsString());
+        }
+        _cf.setSqref(Collections.singletonList(sb.toString()));
+    }
 
-     /**
-      * Add a Conditional Formatting rule.
-      * Excel allows to create up to 3 Conditional Formatting rules.
-      *
-      * @param cfRule - Conditional Formatting rule
-      */
-     public void addRule(ConditionalFormattingRule cfRule){
-        XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule)cfRule;
-         _cf.addNewCfRule().set(xRule.getCTCfRule());
-     }
+    /**
+     * Replaces an existing Conditional Formatting rule at position idx.
+     * Excel allows to create up to 3 Conditional Formatting rules.
+     * This method can be useful to modify existing  Conditional Formatting rules.
+     *
+     * @param idx    position of the rule. Should be between 0 and 2.
+     * @param cfRule - Conditional Formatting rule
+     */
+    @Override
+    public void setRule(int idx, ConditionalFormattingRule cfRule) {
+        XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule) cfRule;
+        _cf.getCfRuleArray(idx).set(xRule.getCTCfRule());
+    }
 
-     /**
-      * @return the Conditional Formatting rule at position idx.
-      */
-     public XSSFConditionalFormattingRule getRule(int idx){
-         return new XSSFConditionalFormattingRule(_sh, _cf.getCfRuleArray(idx));
-     }
+    /**
+     * Add a Conditional Formatting rule.
+     * Excel allows to create up to 3 Conditional Formatting rules.
+     *
+     * @param cfRule - Conditional Formatting rule
+     */
+    @Override
+    public void addRule(ConditionalFormattingRule cfRule) {
+        XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule) cfRule;
+        _cf.addNewCfRule().set(xRule.getCTCfRule());
+    }
 
-     /**
-      * @return number of Conditional Formatting rules.
-      */
-     public int getNumberOfRules(){
-         return _cf.sizeOfCfRuleArray();
-     }
-     
-     public String toString() {
-         return _cf.toString();
-     }
+    /**
+     * @return the Conditional Formatting rule at position idx.
+     */
+    @Override
+    public XSSFConditionalFormattingRule getRule(int idx) {
+        return new XSSFConditionalFormattingRule(_sh, _cf.getCfRuleArray(idx));
+    }
+
+    /**
+     * @return number of Conditional Formatting rules.
+     */
+    @Override
+    public int getNumberOfRules() {
+        return _cf.sizeOfCfRuleArray();
+    }
+
+    @Override
+    public String toString() {
+        return _cf.toString();
+    }
 }

--- a/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
@@ -18,15 +18,15 @@
  */
 package org.apache.poi.xssf.usermodel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.XSSFITestDataProvider;
+import org.junit.Test;
 
 import java.io.IOException;
 
-import org.apache.poi.ss.usermodel.BaseTestConditionalFormatting;
-import org.apache.poi.ss.usermodel.Color;
-import org.apache.poi.xssf.XSSFITestDataProvider;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * XSSF-specific Conditional Formatting tests
@@ -55,5 +55,40 @@ public class TestXSSFConditionalFormatting extends BaseTestConditionalFormatting
     @Test
     public void testReadOffice2007() throws IOException {
         testReadOffice2007("NewStyleConditionalFormattings.xlsx");
+    }
+
+    @Test
+    public void testSetCellRangeAddress() throws Exception {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        final XSSFSheet sheet = wb.createSheet("S1");
+        final XSSFSheetConditionalFormatting cf = sheet.getSheetConditionalFormatting();
+        assertEquals(0, cf.getNumConditionalFormattings());
+        ExtendedColor color = wb.getCreationHelper().createExtendedColor();
+        color.setARGBHex("FF63BE7B");
+        ConditionalFormattingRule rule1 = cf.createConditionalFormattingRule(color);
+        DataBarFormatting db1 = rule1.getDataBarFormatting();
+        db1.getMinThreshold().setRangeType(ConditionalFormattingThreshold.RangeType.MIN);
+        db1.getMaxThreshold().setRangeType(ConditionalFormattingThreshold.RangeType.MAX);
+
+        cf.addConditionalFormatting(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A5")
+        }, rule1);
+
+        assertEquals(1, cf.getNumConditionalFormattings());
+        XSSFConditionalFormatting readCf = cf.getConditionalFormattingAt(0);
+        CellRangeAddress[] formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        CellRangeAddress formattingRange = formattingRanges[0];
+        assertEquals("A1:A5", formattingRange.formatAsString());
+
+        readCf.setFormattingRanges(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A6")
+        });
+
+        readCf = cf.getConditionalFormattingAt(0);
+        formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        formattingRange = formattingRanges[0];
+        assertEquals("A1:A6", formattingRange.formatAsString());
     }
 }


### PR DESCRIPTION
This pull request addresses [Bug #60314](https://bz.apache.org/bugzilla/show_bug.cgi?id=60314).
The new method can be used to change the formatting range of an existing XSSFConditionalFormatting without the need of removing and then re-adding the rule.

If someone is able to provide an implementation for the HSSF format, the method could be added to the interface ConditionalFormatting.
