### PR TITLE
Adding a new method to the XSSFConditionalFormatting class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Created by .ignore support plugin (hsz.mobi)
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/src/java/org/apache/poi/hssf/usermodel/HSSFConditionalFormatting.java
+++ b/src/java/org/apache/poi/hssf/usermodel/HSSFConditionalFormatting.java
@@ -94,8 +94,15 @@ public final class HSSFConditionalFormatting  implements ConditionalFormatting {
     /**
      * @return array of <tt>CellRangeAddress</tt>s. never <code>null</code> 
      */
+    @Override
     public CellRangeAddress[] getFormattingRanges() {
         return cfAggregate.getHeader().getCellRanges();
+    }
+
+    @Override
+    public void setFormattingRanges(
+            final CellRangeAddress[] ranges) {
+        cfAggregate.getHeader().setCellRanges(ranges);
     }
 
     /**
@@ -111,6 +118,7 @@ public final class HSSFConditionalFormatting  implements ConditionalFormatting {
         cfAggregate.setRule(idx, cfRule.getCfRuleRecord());
     }
 
+    @Override
     public void setRule(int idx, ConditionalFormattingRule cfRule){
         setRule(idx, (HSSFConditionalFormattingRule)cfRule);
     }
@@ -124,6 +132,7 @@ public final class HSSFConditionalFormatting  implements ConditionalFormatting {
         cfAggregate.addRule(cfRule.getCfRuleRecord());
     }
 
+    @Override
     public void addRule(ConditionalFormattingRule cfRule){
         addRule((HSSFConditionalFormattingRule)cfRule);
     }
@@ -131,6 +140,7 @@ public final class HSSFConditionalFormatting  implements ConditionalFormatting {
     /**
      * @return the Conditional Formatting rule at position idx.
      */
+    @Override
     public HSSFConditionalFormattingRule getRule(int idx) {
         CFRuleBase ruleRecord = cfAggregate.getRule(idx);
         return new HSSFConditionalFormattingRule(sheet, ruleRecord);
@@ -139,10 +149,12 @@ public final class HSSFConditionalFormatting  implements ConditionalFormatting {
     /**
      * @return number of Conditional Formatting rules.
      */
+    @Override
     public int getNumberOfRules() {
         return cfAggregate.getNumberOfRules();
     }
 
+    @Override
     public String toString() {
         return cfAggregate.toString();
     }

--- a/src/java/org/apache/poi/ss/usermodel/ConditionalFormatting.java
+++ b/src/java/org/apache/poi/ss/usermodel/ConditionalFormatting.java
@@ -81,6 +81,12 @@ public interface ConditionalFormatting {
     CellRangeAddress[] getFormattingRanges();
 
     /**
+     * Sets the cell ranges the rule conditional formatting must be applied to.
+     * @param ranges non-null array of <tt>CellRangeAddress</tt>s
+     */
+    void setFormattingRanges(CellRangeAddress[] ranges);
+
+    /**
      * Replaces an existing Conditional Formatting rule at position idx.
      * Excel pre-2007 allows to create up to 3 Conditional Formatting rules,
      *  2007 and later allow unlimited numbers.

--- a/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFConditionalFormatting.java
+++ b/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFConditionalFormatting.java
@@ -25,6 +25,7 @@ import org.apache.poi.ss.util.CellRangeAddress;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTConditionalFormatting;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * @author Yegor Kozlov
@@ -33,73 +34,94 @@ public class XSSFConditionalFormatting implements ConditionalFormatting {
     private final CTConditionalFormatting _cf;
     private final XSSFSheet _sh;
 
-    /*package*/ XSSFConditionalFormatting(XSSFSheet sh){
+    /*package*/ XSSFConditionalFormatting(XSSFSheet sh) {
         _cf = CTConditionalFormatting.Factory.newInstance();
         _sh = sh;
     }
 
-    /*package*/ XSSFConditionalFormatting(XSSFSheet sh, CTConditionalFormatting cf){
+    /*package*/ XSSFConditionalFormatting(
+            XSSFSheet sh, CTConditionalFormatting cf) {
         _cf = cf;
         _sh = sh;
     }
 
-    /*package*/  CTConditionalFormatting getCTConditionalFormatting(){
+    /*package*/  CTConditionalFormatting getCTConditionalFormatting() {
         return _cf;
     }
 
     /**
-      * @return array of <tt>CellRangeAddress</tt>s. Never <code>null</code>
-      */
-     public CellRangeAddress[] getFormattingRanges(){
-         ArrayList<CellRangeAddress> lst = new ArrayList<CellRangeAddress>();
-         for (Object stRef : _cf.getSqref()) {
-             String[] regions = stRef.toString().split(" ");
-             for (int i = 0; i < regions.length; i++) {
-                 lst.add(CellRangeAddress.valueOf(regions[i]));
-             }
-         }
-         return lst.toArray(new CellRangeAddress[lst.size()]);
-     }
+     * @return array of <tt>CellRangeAddress</tt>s. Never <code>null</code>
+     */
+    @Override
+    public CellRangeAddress[] getFormattingRanges() {
+        ArrayList<CellRangeAddress> lst = new ArrayList<CellRangeAddress>();
+        for (Object stRef : _cf.getSqref()) {
+            String[] regions = stRef.toString().split(" ");
+            for (final String region : regions) {
+                lst.add(CellRangeAddress.valueOf(region));
+            }
+        }
+        return lst.toArray(new CellRangeAddress[lst.size()]);
+    }
 
-     /**
-      * Replaces an existing Conditional Formatting rule at position idx.
-      * Excel allows to create up to 3 Conditional Formatting rules.
-      * This method can be useful to modify existing  Conditional Formatting rules.
-      *
-      * @param idx position of the rule. Should be between 0 and 2.
-      * @param cfRule - Conditional Formatting rule
-      */
-     public void setRule(int idx, ConditionalFormattingRule cfRule){
-         XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule)cfRule;
-         _cf.getCfRuleArray(idx).set(xRule.getCTCfRule());
-     }
+    public void setFormattingRanges(CellRangeAddress[] ranges) {
+        final StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (CellRangeAddress range : ranges) {
+            if (!first) {
+                sb.append(" ");
+            } else {
+                first = false;
+            }
+            sb.append(range.formatAsString());
+        }
+        _cf.setSqref(Collections.singletonList(sb.toString()));
+    }
 
-     /**
-      * Add a Conditional Formatting rule.
-      * Excel allows to create up to 3 Conditional Formatting rules.
-      *
-      * @param cfRule - Conditional Formatting rule
-      */
-     public void addRule(ConditionalFormattingRule cfRule){
-        XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule)cfRule;
-         _cf.addNewCfRule().set(xRule.getCTCfRule());
-     }
+    /**
+     * Replaces an existing Conditional Formatting rule at position idx.
+     * Excel allows to create up to 3 Conditional Formatting rules.
+     * This method can be useful to modify existing  Conditional Formatting rules.
+     *
+     * @param idx    position of the rule. Should be between 0 and 2.
+     * @param cfRule - Conditional Formatting rule
+     */
+    @Override
+    public void setRule(int idx, ConditionalFormattingRule cfRule) {
+        XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule) cfRule;
+        _cf.getCfRuleArray(idx).set(xRule.getCTCfRule());
+    }
 
-     /**
-      * @return the Conditional Formatting rule at position idx.
-      */
-     public XSSFConditionalFormattingRule getRule(int idx){
-         return new XSSFConditionalFormattingRule(_sh, _cf.getCfRuleArray(idx));
-     }
+    /**
+     * Add a Conditional Formatting rule.
+     * Excel allows to create up to 3 Conditional Formatting rules.
+     *
+     * @param cfRule - Conditional Formatting rule
+     */
+    @Override
+    public void addRule(ConditionalFormattingRule cfRule) {
+        XSSFConditionalFormattingRule xRule = (XSSFConditionalFormattingRule) cfRule;
+        _cf.addNewCfRule().set(xRule.getCTCfRule());
+    }
 
-     /**
-      * @return number of Conditional Formatting rules.
-      */
-     public int getNumberOfRules(){
-         return _cf.sizeOfCfRuleArray();
-     }
-     
-     public String toString() {
-         return _cf.toString();
-     }
+    /**
+     * @return the Conditional Formatting rule at position idx.
+     */
+    @Override
+    public XSSFConditionalFormattingRule getRule(int idx) {
+        return new XSSFConditionalFormattingRule(_sh, _cf.getCfRuleArray(idx));
+    }
+
+    /**
+     * @return number of Conditional Formatting rules.
+     */
+    @Override
+    public int getNumberOfRules() {
+        return _cf.sizeOfCfRuleArray();
+    }
+
+    @Override
+    public String toString() {
+        return _cf.toString();
+    }
 }

--- a/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFConditionalFormatting.java
+++ b/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFConditionalFormatting.java
@@ -64,7 +64,11 @@ public class XSSFConditionalFormatting implements ConditionalFormatting {
         return lst.toArray(new CellRangeAddress[lst.size()]);
     }
 
+    @Override
     public void setFormattingRanges(CellRangeAddress[] ranges) {
+        if (ranges == null) {
+            throw new IllegalArgumentException("cellRanges must not be null");
+        }
         final StringBuilder sb = new StringBuilder();
         boolean first = true;
         for (CellRangeAddress range : ranges) {

--- a/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
@@ -18,8 +18,8 @@
  */
 package org.apache.poi.xssf.usermodel;
 
-import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.usermodel.BaseTestConditionalFormatting;
+import org.apache.poi.ss.usermodel.Color;
 import org.apache.poi.xssf.XSSFITestDataProvider;
 import org.junit.Test;
 
@@ -55,40 +55,5 @@ public class TestXSSFConditionalFormatting extends BaseTestConditionalFormatting
     @Test
     public void testReadOffice2007() throws IOException {
         testReadOffice2007("NewStyleConditionalFormattings.xlsx");
-    }
-
-    @Test
-    public void testSetCellRangeAddress() throws Exception {
-        XSSFWorkbook wb = new XSSFWorkbook();
-        final XSSFSheet sheet = wb.createSheet("S1");
-        final XSSFSheetConditionalFormatting cf = sheet.getSheetConditionalFormatting();
-        assertEquals(0, cf.getNumConditionalFormattings());
-        ExtendedColor color = wb.getCreationHelper().createExtendedColor();
-        color.setARGBHex("FF63BE7B");
-        ConditionalFormattingRule rule1 = cf.createConditionalFormattingRule(color);
-        DataBarFormatting db1 = rule1.getDataBarFormatting();
-        db1.getMinThreshold().setRangeType(ConditionalFormattingThreshold.RangeType.MIN);
-        db1.getMaxThreshold().setRangeType(ConditionalFormattingThreshold.RangeType.MAX);
-
-        cf.addConditionalFormatting(new CellRangeAddress[] {
-                CellRangeAddress.valueOf("A1:A5")
-        }, rule1);
-
-        assertEquals(1, cf.getNumConditionalFormattings());
-        XSSFConditionalFormatting readCf = cf.getConditionalFormattingAt(0);
-        CellRangeAddress[] formattingRanges = readCf.getFormattingRanges();
-        assertEquals(1, formattingRanges.length);
-        CellRangeAddress formattingRange = formattingRanges[0];
-        assertEquals("A1:A5", formattingRange.formatAsString());
-
-        readCf.setFormattingRanges(new CellRangeAddress[] {
-                CellRangeAddress.valueOf("A1:A6")
-        });
-
-        readCf = cf.getConditionalFormattingAt(0);
-        formattingRanges = readCf.getFormattingRanges();
-        assertEquals(1, formattingRanges.length);
-        formattingRange = formattingRanges[0];
-        assertEquals("A1:A6", formattingRange.formatAsString());
     }
 }

--- a/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
@@ -18,15 +18,15 @@
  */
 package org.apache.poi.xssf.usermodel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.XSSFITestDataProvider;
+import org.junit.Test;
 
 import java.io.IOException;
 
-import org.apache.poi.ss.usermodel.BaseTestConditionalFormatting;
-import org.apache.poi.ss.usermodel.Color;
-import org.apache.poi.xssf.XSSFITestDataProvider;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * XSSF-specific Conditional Formatting tests
@@ -55,5 +55,40 @@ public class TestXSSFConditionalFormatting extends BaseTestConditionalFormatting
     @Test
     public void testReadOffice2007() throws IOException {
         testReadOffice2007("NewStyleConditionalFormattings.xlsx");
+    }
+
+    @Test
+    public void testSetCellRangeAddress() throws Exception {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        final XSSFSheet sheet = wb.createSheet("S1");
+        final XSSFSheetConditionalFormatting cf = sheet.getSheetConditionalFormatting();
+        assertEquals(0, cf.getNumConditionalFormattings());
+        ExtendedColor color = wb.getCreationHelper().createExtendedColor();
+        color.setARGBHex("FF63BE7B");
+        ConditionalFormattingRule rule1 = cf.createConditionalFormattingRule(color);
+        DataBarFormatting db1 = rule1.getDataBarFormatting();
+        db1.getMinThreshold().setRangeType(ConditionalFormattingThreshold.RangeType.MIN);
+        db1.getMaxThreshold().setRangeType(ConditionalFormattingThreshold.RangeType.MAX);
+
+        cf.addConditionalFormatting(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A5")
+        }, rule1);
+
+        assertEquals(1, cf.getNumConditionalFormattings());
+        XSSFConditionalFormatting readCf = cf.getConditionalFormattingAt(0);
+        CellRangeAddress[] formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        CellRangeAddress formattingRange = formattingRanges[0];
+        assertEquals("A1:A5", formattingRange.formatAsString());
+
+        readCf.setFormattingRanges(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A6")
+        });
+
+        readCf = cf.getConditionalFormattingAt(0);
+        formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        formattingRange = formattingRanges[0];
+        assertEquals("A1:A6", formattingRange.formatAsString());
     }
 }

--- a/src/testcases/org/apache/poi/ss/usermodel/BaseTestConditionalFormatting.java
+++ b/src/testcases/org/apache/poi/ss/usermodel/BaseTestConditionalFormatting.java
@@ -19,15 +19,6 @@
 
 package org.apache.poi.ss.usermodel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-
 import org.apache.poi.hssf.usermodel.HSSFConditionalFormatting;
 import org.apache.poi.hssf.usermodel.HSSFConditionalFormattingRule;
 import org.apache.poi.ss.ITestDataProvider;
@@ -35,6 +26,10 @@ import org.apache.poi.ss.usermodel.ConditionalFormattingThreshold.RangeType;
 import org.apache.poi.ss.usermodel.IconMultiStateFormatting.IconSet;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
 
 /**
  * Base tests for Conditional Formatting, for both HSSF and XSSF
@@ -1270,5 +1265,82 @@ public abstract class BaseTestConditionalFormatting {
         ConditionalFormattingRule rule = sheet.getSheetConditionalFormatting().createConditionalFormattingRule("$A$1>0");
         sheet.getSheetConditionalFormatting().addConditionalFormatting(ranges, rule);
         wb.close();
+    }
+
+    @Test
+    public void testSetCellRangeAddresswithSingleRange() throws Exception {
+        Workbook wb = _testDataProvider.createWorkbook();
+        final Sheet sheet = wb.createSheet("S1");
+        final SheetConditionalFormatting cf = sheet.getSheetConditionalFormatting();
+        assertEquals(0, cf.getNumConditionalFormattings());
+        ConditionalFormattingRule rule1 = cf.createConditionalFormattingRule("$A$1>0");
+        cf.addConditionalFormatting(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A5")
+        }, rule1);
+
+        assertEquals(1, cf.getNumConditionalFormattings());
+        ConditionalFormatting readCf = cf.getConditionalFormattingAt(0);
+        CellRangeAddress[] formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        CellRangeAddress formattingRange = formattingRanges[0];
+        assertEquals("A1:A5", formattingRange.formatAsString());
+
+        readCf.setFormattingRanges(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A6")
+        });
+
+        readCf = cf.getConditionalFormattingAt(0);
+        formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        formattingRange = formattingRanges[0];
+        assertEquals("A1:A6", formattingRange.formatAsString());
+    }
+
+    @Test
+    public void testSetCellRangeAddressWithMultipleRanges() throws Exception {
+        Workbook wb = _testDataProvider.createWorkbook();
+        final Sheet sheet = wb.createSheet("S1");
+        final SheetConditionalFormatting cf = sheet.getSheetConditionalFormatting();
+        assertEquals(0, cf.getNumConditionalFormattings());
+        ConditionalFormattingRule rule1 = cf.createConditionalFormattingRule("$A$1>0");
+        cf.addConditionalFormatting(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A5")
+        }, rule1);
+
+        assertEquals(1, cf.getNumConditionalFormattings());
+        ConditionalFormatting readCf = cf.getConditionalFormattingAt(0);
+        CellRangeAddress[] formattingRanges = readCf.getFormattingRanges();
+        assertEquals(1, formattingRanges.length);
+        CellRangeAddress formattingRange = formattingRanges[0];
+        assertEquals("A1:A5", formattingRange.formatAsString());
+
+        readCf.setFormattingRanges(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A6"),
+                CellRangeAddress.valueOf("B1:B6")
+        });
+
+        readCf = cf.getConditionalFormattingAt(0);
+        formattingRanges = readCf.getFormattingRanges();
+        assertEquals(2, formattingRanges.length);
+        formattingRange = formattingRanges[0];
+        assertEquals("A1:A6", formattingRange.formatAsString());
+        formattingRange = formattingRanges[1];
+        assertEquals("B1:B6", formattingRange.formatAsString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetCellRangeAddressWithNullRanges() throws Exception {
+        Workbook wb = _testDataProvider.createWorkbook();
+        final Sheet sheet = wb.createSheet("S1");
+        final SheetConditionalFormatting cf = sheet.getSheetConditionalFormatting();
+        assertEquals(0, cf.getNumConditionalFormattings());
+        ConditionalFormattingRule rule1 = cf.createConditionalFormattingRule("$A$1>0");
+        cf.addConditionalFormatting(new CellRangeAddress[] {
+                CellRangeAddress.valueOf("A1:A5")
+        }, rule1);
+
+        assertEquals(1, cf.getNumConditionalFormattings());
+        ConditionalFormatting readCf = cf.getConditionalFormattingAt(0);
+        readCf.setFormattingRanges(null);
     }
 }


### PR DESCRIPTION
This pull request addresses [Bug #60314](https://bz.apache.org/bugzilla/show_bug.cgi?id=60314).
The new method can be used to change the formatting range of an existing XSSFConditionalFormatting without the need of removing and then re-adding the rule.

If someone is able to provide an implementation for the HSSF format, the method could be added to the interface ConditionalFormatting.
