### PR TITLE
add support for Chinese and Japanese date format in DateUtil.isADateFormat(...)

### DIFF
--- a/src/java/org/apache/poi/ss/usermodel/DateUtil.java
+++ b/src/java/org/apache/poi/ss/usermodel/DateUtil.java
@@ -49,9 +49,13 @@ public class DateUtil {
     private static final Pattern date_ptrn1 = Pattern.compile("^\\[\\$\\-.*?\\]");
     private static final Pattern date_ptrn2 = Pattern.compile("^\\[[a-zA-Z]+\\]");
     private static final Pattern date_ptrn3a = Pattern.compile("[yYmMdDhHsS]");
-    private static final Pattern date_ptrn3b = Pattern.compile("^[\\[\\]yYmMdDhHsS\\-T/,. :\"\\\\]+0*[ampAMP/]*$");
+    // add "\u5e74 \u6708 \u65e5"（年月日） for Chinese/Japanese date format:2017年2月7日
+    private static final Pattern date_ptrn3b = Pattern.compile("^[\\[\\]yYmMdDhHsS\\-T/\u5e74\u6708\u65e5,. :\"\\\\]+0*[ampAMP/]*$");
     //  elapsed time patterns: [h],[m] and [s]
     private static final Pattern date_ptrn4 = Pattern.compile("^\\[([hH]+|[mM]+|[sS]+)\\]");
+    
+    // for format which start with "[DBNum1]" or "[DBNum2]" or "[DBNum3]" could be a Chinese date
+    private static final Pattern date_ptrn5 = Pattern.compile("^\\[DBNum(1|2|3)\\]");
 
     /**
      * Given a Date, converts it into a double representing its internal Excel representation,
@@ -426,7 +430,9 @@ public class DateUtil {
             cache(formatString, formatIndex, true);
             return true;
         }
-
+        // If it starts with [DBNum1] or [DBNum2] or [DBNum3]
+        // then it could be a Chinese date 
+        fs = date_ptrn5.matcher(fs).replaceAll("");
         // If it starts with [$-...], then could be a date, but
         //  who knows what that starting bit is all about
         fs = date_ptrn1.matcher(fs).replaceAll("");

--- a/src/testcases/org/apache/poi/ss/usermodel/TestDateUtil.java
+++ b/src/testcases/org/apache/poi/ss/usermodel/TestDateUtil.java
@@ -18,6 +18,7 @@
 package org.apache.poi.ss.usermodel;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -91,5 +92,35 @@ public class TestDateUtil {
         assertEquals(expCal, actCal[1]);
         assertEquals(expCal, actCal[2]);
         assertEquals(expCal, actCal[3]);
+    }
+    
+    @Test
+    public void isADateFormat() {
+        // Cell content 2016-12-8 as an example
+        // Cell show "12/8/2016"
+        assertTrue(DateUtil.isADateFormat(14, "m/d/yy"));
+        // Cell show "Thursday, December 8, 2016"
+        assertTrue(DateUtil.isADateFormat(182, "[$-F800]dddd\\,\\ mmmm\\ dd\\,\\ yyyy"));
+        // Cell show "12/8"
+        assertTrue(DateUtil.isADateFormat(183, "m/d;@"));
+        // Cell show "12/08/16"
+        assertTrue(DateUtil.isADateFormat(184, "mm/dd/yy;@"));
+        // Cell show "8-Dec-16"
+        assertTrue(DateUtil.isADateFormat(185, "[$-409]d\\-mmm\\-yy;@"));
+        // Cell show "D-16"
+        assertTrue(DateUtil.isADateFormat(186, "[$-409]mmmmm\\-yy;@"));
+
+        // Cell show "2016年12月8日"
+        assertTrue(DateUtil.isADateFormat(165, "yyyy\"年\"m\"月\"d\"日\";@"));
+        // Cell show "2016年12月"
+        assertTrue(DateUtil.isADateFormat(164, "yyyy\"年\"m\"月\";@"));
+        // Cell show "12月8日"
+        assertTrue(DateUtil.isADateFormat(168, "m\"月\"d\"日\";@"));
+        // Cell show "十二月八日"
+        assertTrue(DateUtil.isADateFormat(181, "[DBNum1][$-404]m\"月\"d\"日\";@"));
+        // Cell show "贰零壹陆年壹拾贰月捌日"
+        assertTrue(DateUtil.isADateFormat(177, "[DBNum2][$-804]yyyy\"年\"m\"月\"d\"日\";@"));
+        // Cell show "２０１６年１２月８日"
+        assertTrue(DateUtil.isADateFormat(178, "[DBNum3][$-804]yyyy\"年\"m\"月\"d\"日\";@"));
     }
 }


### PR DESCRIPTION
This pull request is relate issue: https://bz.apache.org/bugzilla/show_bug.cgi?id=59227
which about Chinese and Japanese date format can't be support by `DateUtil.isADateFormat(...)`

![image](https://cloud.githubusercontent.com/assets/7733973/22728291/1874c6cc-ee18-11e6-859e-a7361a50aa42.png)

