### PR TITLE
fix: NumberFormatException if XSSFName.setNameName is set with a long name

### DIFF
--- a/src/java/org/apache/poi/ss/util/CellReference.java
+++ b/src/java/org/apache/poi/ss/util/CellReference.java
@@ -19,6 +19,7 @@ package org.apache.poi.ss.util;
 
 import static org.apache.poi.util.StringUtil.endsWithIgnoreCase;
 
+import java.math.BigDecimal;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -359,7 +360,7 @@ public class CellReference {
     }
 
     public static boolean isRowWithinRange(String rowStr, SpreadsheetVersion ssVersion) {
-        int rowNum = Integer.parseInt(rowStr) - 1;
+        int rowNum = new BigDecimal(rowStr).intValue() - 1;
         return 0 <= rowNum && rowNum <= ssVersion.getLastRowIndex();
     }
 

--- a/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFName.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFName.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.*;
 import org.apache.poi.ss.usermodel.BaseTestNamedRange;
 import org.apache.poi.ss.util.CellRangeAddress;
 
+import java.io.IOException;
+
 /**
  * @author Yegor Kozlov
  */
@@ -127,6 +129,24 @@ public final class TestXSSFName extends BaseTestNamedRange {
         assertEquals(2, wb.getNames("name2").size());
         assertTrue(wb.getNames("name2").contains(nameGlobal));
         assertTrue(wb.getNames("name2").contains(nameSheet1));
+
+        wb.close();
+    }
+
+    @Test
+    public void testSetNameNameLongName() throws IOException {
+        // Test that renaming named ranges doesn't break our new named range map
+        XSSFWorkbook wb = new XSSFWorkbook();
+        wb.createSheet("First Sheet");
+
+        //Name with very long name. Looks like a cell reference but this is not a reference.
+        XSSFName nameSheet1 = wb.createName();
+        nameSheet1.setNameName("F04030020010");
+        nameSheet1.setRefersToFormula("'First Sheet'!$A$1");
+        nameSheet1.setSheetIndex(0);
+
+        assertEquals(1, wb.getNames("F04030020010").size());
+        assertEquals(nameSheet1, wb.getName("F04030020010"));
 
         wb.close();
     }


### PR DESCRIPTION
If you call XSSFName.setNameName with a long value consisting of a letter followed by a big number, you will get a NumberFormatException.

**For example:**
I want to set the name "F04030020010". In Excel using name box, I can set the name without any problems. If I want set the same name using poi, I will get the exception mentioned above.  

The reason for the NumberFormatException: 
The method XSSFName.validateName splits the value "F04030020010" in a column part and in a row part. Columns only have letters, rows only numbers. The outcome looks like:
_Column = F_
_Row = 04030020010_

In the next step, row will be converted into a number using _Integer.parseInt_. But the current row value exceeds the max value of an Integer resulting in a NumberFormatException.

Since the logic is fine, I replaced Integer.parseInt with BigDecimal, so there is no problem with parsing big numbers anymore.