### PR TITLE
[bugzilla-60422] handle issue with currency format in Germany Locale

### DIFF
--- a/src/java/org/apache/poi/ss/format/CellNumberFormatter.java
+++ b/src/java/org/apache/poi/ss/format/CellNumberFormatter.java
@@ -26,6 +26,7 @@ import java.util.Formatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -444,9 +445,9 @@ public class CellNumberFormatter extends CellFormatter {
             writeFraction(value, null, fractional, output, mods);
         } else {
             StringBuffer result = new StringBuffer();
-            Formatter f = new Formatter(result, LocaleUtil.getUserLocale());
+            Formatter f = new Formatter(result, Locale.US);
             try {
-                f.format(LocaleUtil.getUserLocale(), printfFmt, value);
+                f.format(Locale.US, printfFmt, value);
             } finally {
                 f.close();
             }

--- a/src/testcases/org/apache/poi/ss/usermodel/TestDataFormatter.java
+++ b/src/testcases/org/apache/poi/ss/usermodel/TestDataFormatter.java
@@ -851,4 +851,23 @@ public class TestDataFormatter {
         assertEquals("08:51", dfUS.formatRawCellContents(42605.368761574071, -1, "hh:mm"));
         assertEquals("51:01", dfUS.formatRawCellContents(42605.368761574071, -1, "mm:ss"));
     }
+    
+    /**
+     * bug 60422 : DataFormatter has issues with a specific NumberFormat in Germany locale
+     */
+    @Test
+    public void testBug60422() {
+        Locale defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.GERMANY);
+        try {
+            char euro = '\u20AC';
+            DataFormatter df = new DataFormatter();
+            String formatString = String.format(
+                    "_-* #,##0.00\\ \"%s\"_-;\\-* #,##0.00\\ \"%s\"_-;_-* \"-\"??\\ \"%s\"_-;_-@_-",
+                    euro, euro, euro);
+            assertEquals("4.33 " + euro, df.formatRawCellContents(4.33, 178, formatString));
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
 }


### PR DESCRIPTION
The ant build seems to assume the source is ASCII encoded so that is why I escaped the Euro symbol.