### PR TITLE
[Bug-60422] fix issue with number formatting in German locale

### DIFF
--- a/src/java/org/apache/poi/ss/usermodel/DataFormatter.java
+++ b/src/java/org/apache/poi/ss/usermodel/DataFormatter.java
@@ -292,10 +292,6 @@ public class DataFormatter implements Observer {
      * @param cell The cell to retrieve a Format for
      * @return A Format for the format String
      */
-    private Format getFormat(Cell cell) {
-        return getFormat(cell, null);
-    }
-    
     private Format getFormat(Cell cell, ConditionalFormattingEvaluator cfEvaluator) {
         if (cell == null) return null;
         
@@ -315,62 +311,72 @@ public class DataFormatter implements Observer {
 
     private Format getFormat(double cellValue, int formatIndex, String formatStrIn) {
         localeChangedObservable.checkForLocaleChange();
-        
-//      // Might be better to separate out the n p and z formats, falling back to p when n and z are not set.
-//      // That however would require other code to be re factored.
-//      String[] formatBits = formatStrIn.split(";");
-//      int i = cellValue > 0.0 ? 0 : cellValue < 0.0 ? 1 : 2; 
-//      String formatStr = (i < formatBits.length) ? formatBits[i] : formatBits[0];
+        Locale originalUserLocale = LocaleUtil.getUserLocale();
+        if (originalUserLocale != locale) {
+            LocaleUtil.setUserLocale(locale);
+        }
 
-        String formatStr = formatStrIn;
-        
-        // Excel supports 2+ part conditional data formats, eg positive/negative/zero,
-        //  or (>1000),(>0),(0),(negative). As Java doesn't handle these kinds
-        //  of different formats for different ranges, just +ve/-ve, we need to 
-        //  handle these ourselves in a special way.
-        // For now, if we detect 2+ parts, we call out to CellFormat to handle it
-        // TODO Going forward, we should really merge the logic between the two classes
-        if (formatStr.contains(";") && 
-                (formatStr.indexOf(';') != formatStr.lastIndexOf(';')
-                 || rangeConditionalPattern.matcher(formatStr).matches()
-                ) ) {
-            try {
-                // Ask CellFormat to get a formatter for it
-                CellFormat cfmt = CellFormat.getInstance(formatStr);
-                // CellFormat requires callers to identify date vs not, so do so
-                Object cellValueO = Double.valueOf(cellValue);
-                if (DateUtil.isADateFormat(formatIndex, formatStr) && 
-                        // don't try to handle Date value 0, let a 3 or 4-part format take care of it 
-                        ((Double)cellValueO).doubleValue() != 0.0) {
-                    cellValueO = DateUtil.getJavaDate(cellValue);
+        try {
+            // Might be better to separate out the n p and z formats, falling back to p when n and z are not set.
+            // That however would require other code to be re factored.
+            // String[] formatBits = formatStrIn.split(";");
+            // int i = cellValue > 0.0 ? 0 : cellValue < 0.0 ? 1 : 2; 
+            // String formatStr = (i < formatBits.length) ? formatBits[i] : formatBits[0];
+
+            String formatStr = formatStrIn;
+            
+            // Excel supports 2+ part conditional data formats, eg positive/negative/zero,
+            //  or (>1000),(>0),(0),(negative). As Java doesn't handle these kinds
+            //  of different formats for different ranges, just +ve/-ve, we need to 
+            //  handle these ourselves in a special way.
+            // For now, if we detect 2+ parts, we call out to CellFormat to handle it
+            // TODO Going forward, we should really merge the logic between the two classes
+            if (formatStr.contains(";") && 
+                    (formatStr.indexOf(';') != formatStr.lastIndexOf(';')
+                     || rangeConditionalPattern.matcher(formatStr).matches()
+                    ) ) {
+                try {
+                    // Ask CellFormat to get a formatter for it
+                    CellFormat cfmt = CellFormat.getInstance(formatStr);
+                    // CellFormat requires callers to identify date vs not, so do so
+                    Object cellValueO = Double.valueOf(cellValue);
+                    if (DateUtil.isADateFormat(formatIndex, formatStr) && 
+                            // don't try to handle Date value 0, let a 3 or 4-part format take care of it 
+                            ((Double)cellValueO).doubleValue() != 0.0) {
+                        cellValueO = DateUtil.getJavaDate(cellValue);
+                    }
+                    // Wrap and return (non-cachable - CellFormat does that)
+                    return new CellFormatResultWrapper( cfmt.apply(cellValueO) );
+                } catch (Exception e) {
+                    logger.log(POILogger.WARN, "Formatting failed for format " + formatStr + ", falling back", e);
                 }
-                // Wrap and return (non-cachable - CellFormat does that)
-                return new CellFormatResultWrapper( cfmt.apply(cellValueO) );
-            } catch (Exception e) {
-                logger.log(POILogger.WARN, "Formatting failed for format " + formatStr + ", falling back", e);
+            }
+            
+           // Excel's # with value 0 will output empty where Java will output 0. This hack removes the # from the format.
+           if (emulateCSV && cellValue == 0.0 && formatStr.contains("#") && !formatStr.contains("0")) {
+               formatStr = formatStr.replaceAll("#", "");
+           }
+           
+            // See if we already have it cached
+            Format format = formats.get(formatStr);
+            if (format != null) {
+                return format;
+            }
+            
+            // Is it one of the special built in types, General or @?
+            if ("General".equalsIgnoreCase(formatStr) || "@".equals(formatStr)) {
+                return generalNumberFormat;
+            }
+            
+            // Build a formatter, and cache it
+            format = createFormat(cellValue, formatIndex, formatStr);
+            formats.put(formatStr, format);
+            return format;
+        } finally {
+            if (originalUserLocale != locale) {
+                LocaleUtil.setUserLocale(originalUserLocale);
             }
         }
-        
-       // Excel's # with value 0 will output empty where Java will output 0. This hack removes the # from the format.
-       if (emulateCSV && cellValue == 0.0 && formatStr.contains("#") && !formatStr.contains("0")) {
-           formatStr = formatStr.replaceAll("#", "");
-       }
-       
-        // See if we already have it cached
-        Format format = formats.get(formatStr);
-        if (format != null) {
-            return format;
-        }
-        
-        // Is it one of the special built in types, General or @?
-        if ("General".equalsIgnoreCase(formatStr) || "@".equals(formatStr)) {
-            return generalNumberFormat;
-        }
-        
-        // Build a formatter, and cache it
-        format = createFormat(cellValue, formatIndex, formatStr);
-        formats.put(formatStr, format);
-        return format;
     }
 
     /**
@@ -607,7 +613,7 @@ public class DataFormatter implements Observer {
         try {
             return new ExcelStyleDateFormatter(formatStr, dateSymbols);
         } catch(IllegalArgumentException iae) {
-
+            logger.log(POILogger.DEBUG, "Formatting failed for format " + formatStr + ", falling back", iae);
             // the pattern could not be parsed correctly,
             // so fall back to the default number format
             return getDefaultFormat(cellValue);
@@ -718,7 +724,7 @@ public class DataFormatter implements Observer {
             setExcelStyleRoundingMode(df);
             return df;
         } catch(IllegalArgumentException iae) {
-
+            logger.log(POILogger.DEBUG, "Formatting failed for format " + formatStr + ", falling back", iae);
             // the pattern could not be parsed correctly,
             // so fall back to the default number format
             return getDefaultFormat(cellValue);

--- a/src/testcases/org/apache/poi/ss/usermodel/TestDataFormatter.java
+++ b/src/testcases/org/apache/poi/ss/usermodel/TestDataFormatter.java
@@ -818,7 +818,6 @@ public class TestDataFormatter {
         CellReference ref = new CellReference("D47");
 
         Cell cell = wb.getSheetAt(0).getRow(ref.getRow()).getCell(ref.getCol());
-        //noinspection deprecation
         assertEquals(CellType.FORMULA, cell.getCellTypeEnum());
         assertEquals("G9:K9 I7:I12", cell.getCellFormula());
 
@@ -856,7 +855,7 @@ public class TestDataFormatter {
 
     /**
      * bug 60422 : simple number formats seem ok
-≈     */
+     */
     @Test
     public void testSimpleNumericFormatsInGermanyLocale() {
         List<Locale> locales = Arrays.asList(new Locale[] {Locale.GERMANY, Locale.US, Locale.ROOT} );
@@ -882,18 +881,12 @@ public class TestDataFormatter {
 ≈    */
     @Test
     public void testBug60422() {
-        //when this is set to Locale.Germany, the result is 
-        LocaleUtil.setUserLocale(Locale.ROOT);
-        try {
-            char euro = '\u20AC';
-            DataFormatter df = new DataFormatter(Locale.GERMANY);
-            String formatString = String.format(Locale.ROOT,
-                    "_-* #,##0.00\\ \"%s\"_-;\\-* #,##0.00\\ \"%s\"_-;_-* \"-\"??\\ \"%s\"_-;_-@_-",
-                    euro, euro, euro);
-            //this should be 4,33
-            assertEquals("4.33 " + euro, df.formatRawCellContents(4.33, 178, formatString));
-        } finally {
-            LocaleUtil.resetUserLocale();
-        }
+        char euro = '\u20AC';
+        DataFormatter df = new DataFormatter(Locale.GERMANY);
+        String formatString = String.format(Locale.ROOT,
+                "_-* #,##0.00\\ \"%s\"_-;\\-* #,##0.00\\ \"%s\"_-;_-* \"-\"??\\ \"%s\"_-;_-@_-",
+                euro, euro, euro);
+        assertEquals("4,33 " + euro, df.formatRawCellContents(4.33, 178, formatString));
+        assertEquals("1.234,33 " + euro, df.formatRawCellContents(1234.33, 178, formatString));
     }
 }


### PR DESCRIPTION
Initial stab at fixing this [issue](https://bz.apache.org/bugzilla/show_bug.cgi?id=60422) - needs plenty of extra testing.

* DataFormatter should set the LocaleUtils user locale to match the DataFormatter locale if set (and if LocaleUtils does not have an explicit locale set already)
* org.apache.poi.ss.format.CellNumberFormatter has a lot of hardcoding about commas for grouping separators and dots for decimal separators - should use DecimalFormatSymbols class
* org.apache.poi.ss.format.CellNumberFormatter also applies the separator from the format string but my understanding is that "#,##0.00" means to apply locale specific separators, that the '.' is assumed to mean apply locale specific decimal separator as opposed to specifically apply '.' as the decimal separator.