### PR TITLE
Replace the inefficient Number constructor with static Number.valueOf() method.

### DIFF
--- a/src/java/org/apache/poi/hssf/usermodel/DVConstraint.java
+++ b/src/java/org/apache/poi/hssf/usermodel/DVConstraint.java
@@ -228,7 +228,7 @@ public class DVConstraint implements DataValidationConstraint {
 			return null;
 		}
 		try {
-			return new Double(numberStr);
+			return Double.valueOf(numberStr);
 		} catch (NumberFormatException e) {
 			throw new RuntimeException("The supplied text '" + numberStr 
 					+ "' could not be parsed as a number");
@@ -242,7 +242,7 @@ public class DVConstraint implements DataValidationConstraint {
 		if (timeStr == null) {
 			return null;
 		}
-		return new Double(HSSFDateUtil.convertTime(timeStr));
+		return Double.valueOf(HSSFDateUtil.convertTime(timeStr));
 	}
 	/**
 	 * @param dateFormat pass <code>null</code> for default YYYYMMDD
@@ -263,7 +263,7 @@ public class DVConstraint implements DataValidationConstraint {
 						+ "' using specified format '" + dateFormat + "'", e);
 			}
 		}
-		return new Double(HSSFDateUtil.getExcelDate(dateVal));
+		return Double.valueOf(HSSFDateUtil.getExcelDate(dateVal));
 	}
 
 	public static DVConstraint createCustomFormulaConstraint(String formula) {
@@ -363,7 +363,7 @@ public class DVConstraint implements DataValidationConstraint {
 	 */
 	public void setValue1(double value1) {
 		_formula1 = null;
-		_value1 = new Double(value1);
+		_value1 = Double.valueOf(value1);
 	}
 
 	/**
@@ -377,7 +377,7 @@ public class DVConstraint implements DataValidationConstraint {
 	 */
 	public void setValue2(double value2) {
 		_formula2 = null;
-		_value2 = new Double(value2);
+		_value2 = Double.valueOf(value2);
 	}
 	
 	/**
@@ -484,7 +484,7 @@ public class DVConstraint implements DataValidationConstraint {
             if (_value == null) {
                 return null;
             }
-            return new Double(_value);
+            return Double.valueOf(_value);
         }
 
         public String string() {

--- a/src/java/org/apache/poi/ss/formula/EvaluationConditionalFormatRule.java
+++ b/src/java/org/apache/poi/ss/formula/EvaluationConditionalFormatRule.java
@@ -505,10 +505,10 @@ public class EvaluationConditionalFormatRule implements Comparable<EvaluationCon
                     }
 
                     final Set<ValueAndFormat> avgSet = new LinkedHashSet<>(1);
-                    avgSet.add(new ValueAndFormat(new Double(allValues.size() == 0 ? 0 : total / allValues.size()), null));
+                    avgSet.add(new ValueAndFormat(Double.valueOf(allValues.size() == 0 ? 0 : total / allValues.size()), null));
 
                     final double stdDev = allValues.size() <= 1 ? 0 : ((NumberEval) AggregateFunction.STDEV.evaluate(pop, 0, 0)).getNumberValue();
-                    avgSet.add(new ValueAndFormat(new Double(stdDev), null));
+                    avgSet.add(new ValueAndFormat(Double.valueOf(stdDev), null));
                     return avgSet;
                 }
             }));
@@ -527,7 +527,7 @@ public class EvaluationConditionalFormatRule implements Comparable<EvaluationCon
              * operator type
              */
             
-            Double comp = new Double(conf.getStdDev() > 0 ? (avg + (conf.getAboveAverage() ? 1 : -1) * stdDev * conf.getStdDev()) : avg) ;
+            Double comp = Double.valueOf(conf.getStdDev() > 0 ? (avg + (conf.getAboveAverage() ? 1 : -1) * stdDev * conf.getStdDev()) : avg) ;
             
             OperatorEnum op = null;
             if (conf.getAboveAverage()) {
@@ -625,7 +625,7 @@ public class EvaluationConditionalFormatRule implements Comparable<EvaluationCon
         if (cell != null) {
             final CellType type = cell.getCellType();
             if (type == CellType.NUMERIC || (type == CellType.FORMULA && cell.getCachedFormulaResultType() == CellType.NUMERIC) ) {
-                return new ValueAndFormat(new Double(cell.getNumericCellValue()), cell.getCellStyle().getDataFormatString());
+                return new ValueAndFormat(Double.valueOf(cell.getNumericCellValue()), cell.getCellStyle().getDataFormatString());
             } else if (type == CellType.STRING || (type == CellType.FORMULA && cell.getCachedFormulaResultType() == CellType.STRING) ) {
                 return new ValueAndFormat(cell.getStringCellValue(), cell.getCellStyle().getDataFormatString());
             } else if (type == CellType.BOOLEAN || (type == CellType.FORMULA && cell.getCachedFormulaResultType() == CellType.BOOLEAN) ) {

--- a/src/java/org/apache/poi/ss/formula/FormulaParser.java
+++ b/src/java/org/apache/poi/ss/formula/FormulaParser.java
@@ -1670,7 +1670,7 @@ public final class FormulaParser {
         if (!isPositive) {
             value = -value;
         }
-        return new Double(value);
+        return Double.valueOf(value);
     }
 
     private Ptg parseNumber() {

--- a/src/java/org/apache/poi/ss/formula/constant/ConstantValueParser.java
+++ b/src/java/org/apache/poi/ss/formula/constant/ConstantValueParser.java
@@ -61,7 +61,7 @@ public final class ConstantValueParser {
 				in.readLong(); // 8 byte 'not used' field
 				return EMPTY_REPRESENTATION; 
 			case TYPE_NUMBER:
-				return new Double(in.readDouble());
+				return Double.valueOf(in.readDouble());
 			case TYPE_STRING:
 				return StringUtil.readUnicodeString(in);
 			case TYPE_BOOLEAN:

--- a/src/java/org/apache/poi/ss/formula/functions/Mode.java
+++ b/src/java/org/apache/poi/ss/formula/functions/Mode.java
@@ -129,7 +129,7 @@ public final class Mode implements Function {
 			return;
 		}
 		if (arg instanceof NumberEval) {
-			temp.add(new Double(((NumberEval) arg).getNumberValue()));
+			temp.add(Double.valueOf(((NumberEval) arg).getNumberValue()));
 			return;
 		}
 		throw new RuntimeException("Unexpected value type (" + arg.getClass().getName() + ")");

--- a/src/java/org/apache/poi/ss/formula/functions/Value.java
+++ b/src/java/org/apache/poi/ss/formula/functions/Value.java
@@ -37,7 +37,7 @@ public final class Value extends Fixed1ArgFunction {
 
 	/** "1,0000" is valid, "1,00" is not */
 	private static final int MIN_DISTANCE_BETWEEN_THOUSANDS_SEPARATOR = 4;
-	private static final Double ZERO = new Double(0.0);
+	private static final Double ZERO = Double.valueOf(0.0);
 
 	public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval arg0) {
 		ValueEval veText;

--- a/src/java/org/apache/poi/ss/usermodel/DataFormatter.java
+++ b/src/java/org/apache/poi/ss/usermodel/DataFormatter.java
@@ -843,7 +843,7 @@ public class DataFormatter implements Observer {
         if (numberFormat == null) {
             return String.valueOf(d);
         }
-        String formatted = numberFormat.format(new Double(d));
+        String formatted = numberFormat.format(Double.valueOf(d));
         return formatted.replaceFirst("E(\\d)", "E+$1"); // to match Excel's E-notation
     }
 
@@ -894,7 +894,7 @@ public class DataFormatter implements Observer {
         String result;
         final String textValue = NumberToTextConverter.toText(value);
         if (textValue.indexOf('E') > -1) {
-            result = numberFormat.format(new Double(value));
+            result = numberFormat.format(Double.valueOf(value));
         }
         else {
             result = numberFormat.format(new BigDecimal(textValue));

--- a/src/java/org/apache/poi/ss/usermodel/ExcelStyleDateFormatter.java
+++ b/src/java/org/apache/poi/ss/usermodel/ExcelStyleDateFormatter.java
@@ -192,6 +192,6 @@ public class ExcelStyleDateFormatter extends SimpleDateFormat {
     
     @Override
     public int hashCode() {
-        return new Double(dateToBeFormatted).hashCode();
+        return Double.valueOf(dateToBeFormatted).hashCode();
     }
 }

--- a/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFRow.java
+++ b/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFRow.java
@@ -74,7 +74,7 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
         for (CTCell c : row.getCArray()) {
             XSSFCell cell = new XSSFCell(this, c);
             // Performance optimization for bug 57840: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-            final Integer colI = new Integer(cell.getColumnIndex()); // NOSONAR
+            final Integer colI = Integer.valueOf(cell.getColumnIndex()); // NOSONAR
             _cells.put(colI, cell);
             sheet.onReadCell(cell);
         }
@@ -230,7 +230,7 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
     @Override
     public XSSFCell createCell(int columnIndex, CellType type) {
         // Performance optimization for bug 57840: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-        final Integer colI = new Integer(columnIndex); // NOSONAR
+        final Integer colI = Integer.valueOf(columnIndex); // NOSONAR
         CTCell ctCell;
         XSSFCell prev = _cells.get(colI);
         if(prev != null){
@@ -270,7 +270,7 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
     	if(cellnum < 0) throw new IllegalArgumentException("Cell index must be >= 0");
 
         // Performance optimization for bug 57840: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-    	final Integer colI = new Integer(cellnum); // NOSONAR
+    	final Integer colI = Integer.valueOf(cellnum); // NOSONAR
         XSSFCell cell = _cells.get(colI);
         switch (policy) {
             case RETURN_NULL_AND_BLANK:
@@ -500,7 +500,7 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
            _sheet.getWorkbook().onDeleteFormula(xcell);
         }
         // Performance optimization for bug 57840: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-        final Integer colI = new Integer(cell.getColumnIndex()); // NOSONAR
+        final Integer colI = Integer.valueOf(cell.getColumnIndex()); // NOSONAR
         _cells.remove(colI);
     }
 

--- a/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
+++ b/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
@@ -266,7 +266,7 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
         for (CTRow row : worksheetParam.getSheetData().getRowArray()) {
             XSSFRow r = new XSSFRow(row, this);
             // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-            final Integer rownumI = new Integer(r.getRowNum()); // NOSONAR
+            final Integer rownumI = Integer.valueOf(r.getRowNum()); // NOSONAR
             _rows.put(rownumI, r);
         }
     }
@@ -751,7 +751,7 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
     @Override
     public XSSFRow createRow(int rownum) {
         // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-        final Integer rownumI = new Integer(rownum); // NOSONAR
+        final Integer rownumI = Integer.valueOf(rownum); // NOSONAR
         CTRow ctRow;
         XSSFRow prev = _rows.get(rownumI);
         if(prev != null){
@@ -1448,7 +1448,7 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
     @Override
     public XSSFRow getRow(int rownum) {
         // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-        final Integer rownumI = new Integer(rownum); // NOSONAR
+        final Integer rownumI = Integer.valueOf(rownum); // NOSONAR
         return _rows.get(rownumI);
     }
     
@@ -1479,8 +1479,8 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
         }
         else {
             // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-            final Integer startI = new Integer(startRowNum); // NOSONAR
-            final Integer endI = new Integer(endRowNum+1); // NOSONAR
+            final Integer startI = Integer.valueOf(startRowNum); // NOSONAR
+            final Integer endI = Integer.valueOf(endRowNum+1); // NOSONAR
             final Collection<XSSFRow> inclusive = _rows.subMap(startI, endI).values();
             rows.addAll(inclusive);
         }
@@ -1982,7 +1982,7 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
 
         // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
         final int rowNum = row.getRowNum();
-        final Integer rowNumI = new Integer(rowNum); // NOSONAR
+        final Integer rowNumI = Integer.valueOf(rowNum); // NOSONAR
         // this is not the physical row number!
         final int idx = _rows.headMap(rowNumI).size();
         _rows.remove(rowNumI);
@@ -2994,7 +2994,7 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
             if (shouldRemoveRow(startRow, endRow, n, rownum)) {
                 // remove row from worksheet.getSheetData row array
                 // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-                final Integer rownumI = new Integer(row.getRowNum()); // NOSONAR
+                final Integer rownumI = Integer.valueOf(row.getRowNum()); // NOSONAR
                 int idx = _rows.headMap(rownumI).size();
                 worksheet.getSheetData().removeRow(idx);
 
@@ -3118,7 +3118,7 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet  {
         Map<Integer, XSSFRow> map = new HashMap<>();
         for(XSSFRow r : _rows.values()) {
             // Performance optimization: explicit boxing is slightly faster than auto-unboxing, though may use more memory
-            final Integer rownumI = new Integer(r.getRowNum()); // NOSONAR
+            final Integer rownumI = Integer.valueOf(r.getRowNum()); // NOSONAR
             map.put(rownumI, r);
         }
         _rows.clear();

--- a/src/scratchpad/src/org/apache/poi/hdgf/chunks/Chunk.java
+++ b/src/scratchpad/src/org/apache/poi/hdgf/chunks/Chunk.java
@@ -172,7 +172,7 @@ public final class Chunk {
 					command.value = Byte.valueOf(contents[offset]);
 					break;
 				case 9:
-					command.value = new Double(
+					command.value = Double.valueOf(
 							LittleEndian.getDouble(contents, offset)
 					);
 					break;


### PR DESCRIPTION
Using new NumberConstructor(num) is guaranteed to always result in a new object whereas Number.valueOf(num) allows caching of values to be done by the compiler, class library, or JVM.
Using of cached values avoids object allocation and the code will be faster.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_NUMBER_CTOR
http://findbugs.sourceforge.net/bugDescriptions.html#DM_FP_NUMBER_CTOR