### PR TITLE
Remove the 'public' modifier to make fields package protected.

### DIFF
--- a/src/scratchpad/src/org/apache/poi/hmef/CompressedRTF.java
+++ b/src/scratchpad/src/org/apache/poi/hmef/CompressedRTF.java
@@ -33,9 +33,9 @@ import org.apache.poi.util.LittleEndian;
  *  handles decompressing it for you.
  */
 public final class CompressedRTF extends LZWDecompresser {
-   public static final byte[] COMPRESSED_SIGNATURE =
+   static final byte[] COMPRESSED_SIGNATURE =
       new byte[] { (byte)'L', (byte)'Z', (byte)'F', (byte)'u' };
-   public static final byte[] UNCOMPRESSED_SIGNATURE =
+   static final byte[] UNCOMPRESSED_SIGNATURE =
       new byte[] { (byte)'M', (byte)'E', (byte)'L', (byte)'A' };
    public static final int COMPRESSED_SIGNATURE_INT =
       LittleEndian.getInt(COMPRESSED_SIGNATURE);


### PR DESCRIPTION
The two mutable static fields could be changed by malicious code or by accident. These fields could be made package protected to avoid this vulnerability.
http://findbugs.sourceforge.net/bugDescriptions.html#MS_PKGPROTECT