### PR TITLE
Remove the method invocation of toString on a string.

### DIFF
--- a/src/ooxml/java/org/apache/poi/xdgf/extractor/XDGFVisioExtractor.java
+++ b/src/ooxml/java/org/apache/poi/xdgf/extractor/XDGFVisioExtractor.java
@@ -48,7 +48,7 @@ public class XDGFVisioExtractor extends POIXMLTextExtractor {
             page.getContent().visitShapes(visitor);
         }
         
-        return visitor.getText().toString();
+        return visitor.getText();
     }
     
     public static void main(String [] args) throws IOException {

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -352,7 +352,7 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
                 }
                 if (level != null && level.getLvlText() != null
                         && level.getLvlText().getVal() != null) {
-                    return level.getLvlText().getVal().toString();
+                    return level.getLvlText().getVal();
                 }
             }
         }


### PR DESCRIPTION
Calling String.toString() is just a redundant operation. Just use the String.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_STRING_TOSTRING