### PR TITLE
Adding chart in Document of MS-Word File without reading Temp MS-Word File

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFChart.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFChart.java
@@ -27,12 +27,14 @@ import javax.xml.namespace.QName;
 
 import org.apache.poi.POIXMLException;
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.xddf.usermodel.chart.XDDFChart;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTChartSpace;
+import org.openxmlformats.schemas.drawingml.x2006.wordprocessingDrawing.CTInline;
 
 /**
  * Represents a Chart in a .docx file
@@ -40,16 +42,42 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTChartSpace;
 @Beta
 public class XWPFChart extends XDDFChart {
 
+	/**
+	 * default width of chart in emu
+	 */
+    public static final int WIDTH 	= 500000;
+    
+    /**
+	 * default height of chart in emu
+	 */
+	public static final int HEIGHT 	= 500000;
     // lazy initialization
     private Long checksum;
-
+    /**
+	 * this object is used to write embedded part of chart i.e. xlsx file in docx
+	 */
+    private OutputStream sheet;
+    /**
+     * this object is used to modify drawing properties
+     */
+	private CTInline ctInline;
+	
+	/**
+	 * constructor to
+	 * Create a new chart in document
+	 * 
+	 * @since POI 4.0
+	 */
+	protected XWPFChart() {
+		super();
+	}
     /**
      * Construct a chart from a package part.
      *
      * @param part the package part holding the chart data,
      * the content type must be <code>application/vnd.openxmlformats-officedocument.drawingml.chart+xml</code>
      *
-     * @since POI 4.0.0
+     * @since POI 4.0
      */
     protected XWPFChart(PackagePart part) throws IOException, XmlException {
         super(part);
@@ -120,4 +148,196 @@ public class XWPFChart extends XDDFChart {
     public int hashCode() {
         return getChecksum().hashCode();
     }
+    
+    /**
+     * method to create relationship with embedded part
+     * for example writing xlsx file stream into output stream
+     * @param chartSheet
+     * @return return relation part which used to write relation in .rels file and get relation id
+     * @since POI 4.0
+     */
+	public RelationPart createRelationship(XWPFRelation chartRelation,int index) {
+		return createRelationship(chartRelation, XWPFFactory.getInstance(), index, false);
+	}
+	
+	/**
+	 * protected method which used to initialization of sheet output stream 
+	 * @param sheet
+	 * @since POI 4.0
+	 */
+	protected void addEmbeddedWorkSheet(OutputStream sheet) {
+			this.sheet=sheet;
+	}
+	
+	/**
+	 * this method is used to write workbook object in embedded part of chart
+	 * return's true in case of successfully write work book in embedded part or return's false
+	 * @param wb
+	 * @return return's true in case of successfully write work book in embedded part or return's false
+	 * @throws IOException
+	 * @since POI 4.0
+	 */
+	public boolean writeEmbeddedWorkSheet(Workbook wb) throws IOException
+	{
+		if(this.sheet!=null && wb!=null)
+		{
+			wb.write(this.sheet);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * initialize in line object
+	 * @param inline
+	 * @since POI 4.0
+	 */
+	protected void setInLine(CTInline ctInline) {
+		this.ctInline=ctInline;
+	}
+	
+	/**
+	 * set chart height 
+	 * @param height
+	 * @since POI 4.0
+	 */
+	public void setChartHeight(long height)
+	{
+		ctInline.getExtent().setCy(height);
+	}
+	
+	/**
+	 * set chart width 
+	 * @param width
+	 * @since POI 4.0
+	 */
+	public void setChartWidth(long width)
+	{
+		ctInline.getExtent().setCx(width);
+	}
+	/**
+	 * get chart height 
+	 * @since POI 4.0
+	 */
+	public long getChartHeight()
+	{
+		return ctInline.getExtent().getCy();
+	}
+	
+	/**
+	 * get chart width 
+	 * @since POI 4.0
+	 */
+	public long getChartWidth()
+	{
+		return ctInline.getExtent().getCx();
+	}
+	
+	/**
+	 * set chart height and width
+	 * @param width
+	 * @param height 
+	 * @since POI 4.0
+	 */
+	public void setChartWidthHeight(long width,long height)
+	{
+		this.setChartWidth(width);
+		this.setChartHeight(height);
+	}
+	
+	/**
+	 * set margin from top
+	 * @param height
+	 * @since POI 4.0
+	 */
+	public void setChartTopMargin(long margin)
+	{
+		ctInline.setDistT(margin);
+	}
+	
+	/**
+	 * get margin from Top
+	 * @param margin
+	 * @since POI 4.0
+	 */
+	public long getChartTopMargin(long margin)
+	{
+		return ctInline.getDistT();
+	}
+	
+	/**
+	 * set margin from bottom
+	 * @param height
+	 * @since POI 4.0
+	 */
+	public void setChartBottomMargin(long margin)
+	{
+		ctInline.setDistB(margin);
+	}
+	
+	/**
+	 * get margin from Bottom
+	 * @param margin
+	 * @since POI 4.0
+	 */
+	public long getChartBottomMargin(long margin)
+	{
+		return ctInline.getDistB();
+	}
+	
+	/**
+	 * set margin from left
+	 * @param margin
+	 * @since POI 4.0
+	 */
+	public void setChartLeftMargin(long margin)
+	{
+		ctInline.setDistL(margin);
+	}
+	
+	/**
+	 * get margin from left
+	 * @param margin
+	 * @since POI 4.0
+	 */
+	public long getChartLeftMargin(long margin)
+	{
+		return ctInline.getDistL();
+	}
+	
+	/**
+	 * set margin from Right
+	 * @param margin
+	 * @since POI 4.0
+	 */
+	public void setChartRightMargin(long margin)
+	{
+		ctInline.setDistR(margin);
+	}
+	
+	/**
+	 * get margin from Right
+	 * @param margin
+	 * @since POI 4.0
+	 */
+	public long getChartRightMargin(long margin)
+	{
+		return ctInline.getDistR();
+	}
+	
+	/**
+	 * set chart margin
+	 * @param top
+	 * @param right
+	 * @param bottom
+	 * @param left 
+	 * @since POI 4.0
+	 */
+	public void setChartMargin(long top,long right,long bottom,long left)
+	{
+		this.setChartBottomMargin(bottom);
+		this.setChartRightMargin(right);
+		this.setChartLeftMargin(left);
+		this.setChartRightMargin(right);
+	}
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFChart.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFChart.java
@@ -41,58 +41,61 @@ import org.openxmlformats.schemas.drawingml.x2006.wordprocessingDrawing.CTInline
  */
 @Beta
 public class XWPFChart extends XDDFChart {
-
-	/**
-	 * default width of chart in emu
-	 */
-    public static final int WIDTH 	= 500000;
     
     /**
-	 * default height of chart in emu
-	 */
-	public static final int HEIGHT 	= 500000;
+     * default width of chart in emu
+     */
+    public static final int DEFAULT_WIDTH 	= 500000;
+    
+    /**
+     * default height of chart in emu
+     */
+    public static final int DEFAULT_HEIGHT 	= 500000;
     // lazy initialization
     private Long checksum;
     /**
-	 * this object is used to write embedded part of chart i.e. xlsx file in docx
-	 */
+     * this object is used to write embedded part of chart i.e. xlsx file in docx
+     */
     private OutputStream sheet;
     /**
      * this object is used to modify drawing properties
      */
-	private CTInline ctInline;
-	
-	/**
-	 * constructor to
-	 * Create a new chart in document
-	 * 
-	 * @since POI 4.0
-	 */
-	protected XWPFChart() {
-		super();
-	}
+    private CTInline ctInline;
+    
+    /**
+     * constructor to Create a new chart in document
+     * 
+     * @since POI 4.0.0
+     */
+    protected XWPFChart() {
+        super();
+    }
+    
     /**
      * Construct a chart from a package part.
      *
-     * @param part the package part holding the chart data,
-     * the content type must be <code>application/vnd.openxmlformats-officedocument.drawingml.chart+xml</code>
+     * @param part
+     *            the package part holding the chart data, the content type must
+     *            be
+     *            <code>application/vnd.openxmlformats-officedocument.drawingml.chart+xml</code>
      *
-     * @since POI 4.0
+     * @since POI 4.0.0
      */
     protected XWPFChart(PackagePart part) throws IOException, XmlException {
         super(part);
     }
-
+    
     @Override
     protected void commit() throws IOException {
         XmlOptions xmlOptions = new XmlOptions(DEFAULT_XML_OPTIONS);
-        xmlOptions.setSaveSyntheticDocumentElement(new QName(CTChartSpace.type.getName().getNamespaceURI(), "chartSpace", "c"));
-
+        xmlOptions.setSaveSyntheticDocumentElement(
+                new QName(CTChartSpace.type.getName().getNamespaceURI(), "chartSpace", "c"));
+        
         try (OutputStream out = getPackagePart().getOutputStream()) {
             chartSpace.save(out, xmlOptions);
         }
     }
-
+    
     public Long getChecksum() {
         if (this.checksum == null) {
             InputStream is = null;
@@ -115,7 +118,7 @@ public class XWPFChart extends XDDFChart {
         }
         return this.checksum;
     }
-
+    
     @Override
     public boolean equals(Object obj) {
         /**
@@ -133,211 +136,218 @@ public class XWPFChart extends XDDFChart {
         if (obj == this) {
             return true;
         }
-
+        
         if (obj == null) {
             return false;
         }
-
+        
         if (!(obj instanceof XWPFChart)) {
             return false;
         }
         return false;
     }
-
+    
     @Override
     public int hashCode() {
         return getChecksum().hashCode();
     }
     
     /**
-     * method to create relationship with embedded part
-     * for example writing xlsx file stream into output stream
-     * @param chartSheet
-     * @return return relation part which used to write relation in .rels file and get relation id
-     * @since POI 4.0
+     * method to create relationship with embedded part for example writing xlsx
+     * file stream into output stream
+     * 
+     * @param chartRelation chart relationship object which used to create relation with chart
+     * @param index its chart index
+     * @return return relation part which used to write relation in .rels file
+     *         and get relation id
+     * @since POI 4.0.0
      */
-	public RelationPart createRelationship(XWPFRelation chartRelation,int index) {
-		return createRelationship(chartRelation, XWPFFactory.getInstance(), index, false);
-	}
-	
-	/**
-	 * protected method which used to initialization of sheet output stream 
-	 * @param sheet
-	 * @since POI 4.0
-	 */
-	protected void addEmbeddedWorkSheet(OutputStream sheet) {
-			this.sheet=sheet;
-	}
-	
-	/**
-	 * this method is used to write workbook object in embedded part of chart
-	 * return's true in case of successfully write work book in embedded part or return's false
-	 * @param wb
-	 * @return return's true in case of successfully write work book in embedded part or return's false
-	 * @throws IOException
-	 * @since POI 4.0
-	 */
-	public boolean writeEmbeddedWorkSheet(Workbook wb) throws IOException
-	{
-		if(this.sheet!=null && wb!=null)
-		{
-			wb.write(this.sheet);
-			return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * initialize in line object
-	 * @param inline
-	 * @since POI 4.0
-	 */
-	protected void setInLine(CTInline ctInline) {
-		this.ctInline=ctInline;
-	}
-	
-	/**
-	 * set chart height 
-	 * @param height
-	 * @since POI 4.0
-	 */
-	public void setChartHeight(long height)
-	{
-		ctInline.getExtent().setCy(height);
-	}
-	
-	/**
-	 * set chart width 
-	 * @param width
-	 * @since POI 4.0
-	 */
-	public void setChartWidth(long width)
-	{
-		ctInline.getExtent().setCx(width);
-	}
-	/**
-	 * get chart height 
-	 * @since POI 4.0
-	 */
-	public long getChartHeight()
-	{
-		return ctInline.getExtent().getCy();
-	}
-	
-	/**
-	 * get chart width 
-	 * @since POI 4.0
-	 */
-	public long getChartWidth()
-	{
-		return ctInline.getExtent().getCx();
-	}
-	
-	/**
-	 * set chart height and width
-	 * @param width
-	 * @param height 
-	 * @since POI 4.0
-	 */
-	public void setChartWidthHeight(long width,long height)
-	{
-		this.setChartWidth(width);
-		this.setChartHeight(height);
-	}
-	
-	/**
-	 * set margin from top
-	 * @param height
-	 * @since POI 4.0
-	 */
-	public void setChartTopMargin(long margin)
-	{
-		ctInline.setDistT(margin);
-	}
-	
-	/**
-	 * get margin from Top
-	 * @param margin
-	 * @since POI 4.0
-	 */
-	public long getChartTopMargin(long margin)
-	{
-		return ctInline.getDistT();
-	}
-	
-	/**
-	 * set margin from bottom
-	 * @param height
-	 * @since POI 4.0
-	 */
-	public void setChartBottomMargin(long margin)
-	{
-		ctInline.setDistB(margin);
-	}
-	
-	/**
-	 * get margin from Bottom
-	 * @param margin
-	 * @since POI 4.0
-	 */
-	public long getChartBottomMargin(long margin)
-	{
-		return ctInline.getDistB();
-	}
-	
-	/**
-	 * set margin from left
-	 * @param margin
-	 * @since POI 4.0
-	 */
-	public void setChartLeftMargin(long margin)
-	{
-		ctInline.setDistL(margin);
-	}
-	
-	/**
-	 * get margin from left
-	 * @param margin
-	 * @since POI 4.0
-	 */
-	public long getChartLeftMargin(long margin)
-	{
-		return ctInline.getDistL();
-	}
-	
-	/**
-	 * set margin from Right
-	 * @param margin
-	 * @since POI 4.0
-	 */
-	public void setChartRightMargin(long margin)
-	{
-		ctInline.setDistR(margin);
-	}
-	
-	/**
-	 * get margin from Right
-	 * @param margin
-	 * @since POI 4.0
-	 */
-	public long getChartRightMargin(long margin)
-	{
-		return ctInline.getDistR();
-	}
-	
-	/**
-	 * set chart margin
-	 * @param top
-	 * @param right
-	 * @param bottom
-	 * @param left 
-	 * @since POI 4.0
-	 */
-	public void setChartMargin(long top,long right,long bottom,long left)
-	{
-		this.setChartBottomMargin(bottom);
-		this.setChartRightMargin(right);
-		this.setChartLeftMargin(left);
-		this.setChartRightMargin(right);
-	}
+    public RelationPart createRelationship(XWPFRelation chartRelation, int index) {
+        return createRelationship(chartRelation, XWPFFactory.getInstance(), index, false);
+    }
+    
+    /**
+     * protected method which used to initialization of sheet output stream
+     * 
+     * @param sheet output stream of embedded xlsx file
+     * @since POI 4.0.0
+     */
+    protected void addEmbeddedWorkSheet(OutputStream sheet) {
+        this.sheet = sheet;
+    }
+    
+    /**
+     * this method is used to write workbook object in embedded part of chart
+     * return true in case of successfully write work book in embedded part or
+     * return false
+     * 
+     * @param wb this is workbook object which we used to write in embedded xlsx file
+     * @return returns true in case of successfully write workbook in embedded
+     *         part or returns false
+     * @throws IOException
+     * @since POI 4.0.0
+     */
+    public boolean writeEmbeddedWorkSheet(Workbook wb) throws IOException {
+        if (this.sheet != null && wb != null) {
+            wb.write(this.sheet);
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * initialize in line object
+     * 
+     * @param inline this object is used to adjust the margin and dimension of chart 
+     * @since POI 4.0.0
+     */
+    protected void setInLine(CTInline ctInline) {
+        this.ctInline = ctInline;
+    }
+    
+    /**
+     * set chart height
+     * 
+     * @param height height of chart
+     * @since POI 4.0.0
+     */
+    public void setChartHeight(long height) {
+        ctInline.getExtent().setCy(height);
+    }
+    
+    /**
+     * set chart width
+     * 
+     * @param width width of chart
+     * @since POI 4.0.0
+     */
+    public void setChartWidth(long width) {
+        ctInline.getExtent().setCx(width);
+    }
+    
+    /**
+     * get chart height
+     * 
+     * @since POI 4.0.0
+     */
+    public long getChartHeight() {
+        return ctInline.getExtent().getCy();
+    }
+    
+    /**
+     * get chart width
+     * 
+     * @since POI 4.0.0
+     */
+    public long getChartWidth() {
+        return ctInline.getExtent().getCx();
+    }
+    
+    /**
+     * set chart height and width
+     * 
+     * @param width width of chart
+     * @param height height of chart
+     * @since POI 4.0.0
+     */
+    public void setChartBoundingBox(long width, long height) {
+        this.setChartWidth(width);
+        this.setChartHeight(height);
+    }
+    
+    /**
+     * set margin from top
+     * 
+     * @param margin margin from top
+     * @since POI 4.0.0
+     */
+    public void setChartTopMargin(long margin) {
+        ctInline.setDistT(margin);
+    }
+    
+    /**
+     * get margin from Top
+     * 
+     * @param margin
+     * @since POI 4.0.0
+     */
+    public long getChartTopMargin(long margin) {
+        return ctInline.getDistT();
+    }
+    
+    /**
+     * set margin from bottom
+     * 
+     * @param margin margin from Bottom
+     * @since POI 4.0.0
+     */
+    public void setChartBottomMargin(long margin) {
+        ctInline.setDistB(margin);
+    }
+    
+    /**
+     * get margin from Bottom
+     * 
+     * @param margin
+     * @since POI 4.0.0
+     */
+    public long getChartBottomMargin(long margin) {
+        return ctInline.getDistB();
+    }
+    
+    /**
+     * set margin from left
+     * 
+     * @param margin margin from left
+     * @since POI 4.0.0
+     */
+    public void setChartLeftMargin(long margin) {
+        ctInline.setDistL(margin);
+    }
+    
+    /**
+     * get margin from left
+     * 
+     * @param margin
+     * @since POI 4.0.0
+     */
+    public long getChartLeftMargin(long margin) {
+        return ctInline.getDistL();
+    }
+    
+    /**
+     * set margin from Right
+     * 
+     * @param margin from right
+     * @since POI 4.0.0
+     */
+    public void setChartRightMargin(long margin) {
+        ctInline.setDistR(margin);
+    }
+    
+    /**
+     * get margin from Right
+     * 
+     * @param margin
+     * @since POI 4.0.0
+     */
+    public long getChartRightMargin(long margin) {
+        return ctInline.getDistR();
+    }
+    
+    /**
+     * set chart margin
+     * 
+     * @param top margin from top
+     * @param right margin from right
+     * @param bottom margin from bottom
+     * @param left margin from left
+     * @since POI 4.0.0
+     */
+    public void setChartMargin(long top, long right, long bottom, long left) {
+        this.setChartBottomMargin(bottom);
+        this.setChartRightMargin(right);
+        this.setChartLeftMargin(left);
+        this.setChartRightMargin(right);
+    }
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFChartData.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFChartData.java
@@ -1,0 +1,82 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.xwpf.usermodel;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.poi.POIXMLDocumentPart;
+import org.apache.poi.POIXMLException;
+import org.apache.poi.openxml4j.opc.PackagePart;
+
+/**
+ * Raw picture data, normally attached to a WordprocessingML Drawing.
+ * As a rule, embedded xlsx are stored in the /word/embedded/ part of a WordprocessingML package.
+ */
+public class XWPFChartData extends POIXMLDocumentPart {
+
+    /**
+	 * Create a new XWPFChartData node
+	 * @since POI 4.0
+     */
+    protected XWPFChartData() {
+        super();
+    }
+
+    /**
+	 * Construct XWPFChartData from a package part
+     *
+     * @param part the package part holding the drawing data,
+     * 
+     * @since POI 4.0
+     */
+    public XWPFChartData(PackagePart part) {
+        super(part);
+    }
+
+    /**
+     * Gets the WorkBook data as a byte array.
+     * <p>
+	 * Note, that this call might be expensive since excel data is copied into a temporary byte array.
+	 * You can grab the chart data directly from the underlying package part as follows:
+     * <br>
+     * <code>
+     * InputStream is = getPackagePart().getInputStream();
+     * </code>
+     * </p>
+     *
+	 * @return the embedded excel data.
+	 * @since POI 4.0
+     */
+    public InputStream getData() {
+        try {
+            return getPackagePart().getInputStream();
+        } catch (IOException e) {
+            throw new POIXMLException(e);
+        }
+    }
+
+    /**
+     * chartData objects store the actual content in the part directly without keeping a
+     * copy like all others therefore we need to handle them differently.
+     */
+    @Override
+    protected void prepareForCommit() {
+        // do not clear the part here
+    }
+}

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRelation.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRelation.java
@@ -20,6 +20,7 @@ package org.apache.poi.xwpf.usermodel;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.poi.POIXMLDocument;
 import org.apache.poi.POIXMLDocumentPart;
 import org.apache.poi.POIXMLRelation;
 import org.apache.poi.openxml4j.opc.PackageRelationshipTypes;
@@ -112,6 +113,14 @@ public final class XWPFRelation extends POIXMLRelation {
             "/word/theme/theme#.xml",
             null
     );
+    
+    public static final XWPFRelation CHART_SHEET = new XWPFRelation(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            POIXMLDocument.PACK_OBJECT_REL_TYPE,
+            "/word/embeddings/Microsoft_Excel_Worksheet#.xlsx",
+            XWPFChartData.class
+        );
+    
     public static final XWPFRelation CHART = new XWPFRelation(
             "application/vnd.openxmlformats-officedocument.drawingml.chart+xml",
             "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart",

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -39,6 +39,8 @@ import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlString;
 import org.apache.xmlbeans.XmlToken;
 import org.apache.xmlbeans.impl.values.XmlAnyTypeImpl;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTChart;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTRelId;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTBlip;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTBlipFillProperties;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTGraphicalObject;
@@ -1025,6 +1027,63 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         }
     }
 
+    /**
+     * this method add chart template into document
+     * @param width set width of chart object
+     * @param height set height of chart  object
+     * @param chartRelId relation id of chart in document relation file
+     * @throws InvalidFormatException
+     * @throws IOException
+     * @since POI 4.0
+     */
+    public CTInline addChart(int width, int height,String chartRelId)
+            throws InvalidFormatException, IOException {
+    	try {
+    		
+    		CTDrawing drawing = run.addNewDrawing();
+    		
+    		CTInline inline = drawing.addNewInline();
+    		
+    		//xml part of chart in document
+    		String xml =
+    				"<a:graphic xmlns:a=\"" + CTGraphicalObject.type.getName().getNamespaceURI() + "\">" +
+    						"<a:graphicData uri=\"" + CTChart.type.getName().getNamespaceURI() + "\">" +
+    						"<c:chart xmlns:c=\"" + CTChart.type.getName().getNamespaceURI() + "\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" r:id=\""+chartRelId+"\" />" +
+    						"</a:graphicData>" +
+    						"</a:graphic>";
+    		
+    		InputSource is = new InputSource(new StringReader(xml));
+    		
+    		org.w3c.dom.Document doc = DocumentHelper.readDocument(is);
+    		
+    		inline.set(XmlToken.Factory.parse(doc.getDocumentElement(), DEFAULT_XML_OPTIONS));
+
+    		// Setup the inline with 0 margin
+    		inline.setDistT(0);
+    		inline.setDistR(0);
+    		inline.setDistB(0);
+    		inline.setDistL(0);
+
+    		CTNonVisualDrawingProps docPr = inline.addNewDocPr();
+    		long id = getParent().getDocument().getDrawingIdManager().reserveNew();
+    		docPr.setId(id);
+    		//This name is not visible in Word anywhere.
+    		docPr.setName("chart " + id);
+
+    		CTPositiveSize2D extent = inline.addNewExtent();
+    		//set hegiht and width of drawaing object;
+    		extent.setCx(width);
+    		extent.setCy(height);
+    		
+    		return inline;
+    	} catch (XmlException e) {
+            throw new IllegalStateException(e);
+        } catch (SAXException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    
     /**
      * Returns the embedded pictures of the run. These
      * are pictures which reference an external,

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFChart.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFChart.java
@@ -87,4 +87,29 @@ public class TestXWPFChart extends TestCase {
         assertEquals("/word/document.xml", chart.getParent().getPackagePart().getPartName().getName());
         assertEquals("/word/charts/chart1.xml", chart.getPackagePart().getPartName().getName());
     }
+    /**
+	*test method to check adding chart in document
+	*/
+	public static void testAddChartsToNewDocument() throws InvalidFormatException, IOException {
+
+		XWPFDocument document = new XWPFDocument();
+		
+		XWPFChart chart = document.addChart();
+		assertEquals(1, document.getCharts().size());
+		assertNotNull(chart);
+		assertNotNull(chart.getCTChartSpace());
+		assertNotNull(chart.getCTChart());
+		assertEquals(XWPFChart.HEIGHT,chart.getChartHeight());
+		assertEquals(XWPFChart.WIDTH,chart.getChartWidth());
+		
+		XWPFChart chart2 = document.addChart();
+		assertEquals(2, document.getCharts().size());
+		assertNotNull(chart2);
+		assertNotNull(chart2.getCTChartSpace());
+		assertNotNull(chart2.getCTChart());
+		chart.setChartHeight(500500);
+		assertEquals(500500,chart.getChartHeight());
+		
+        assertNotNull(XWPFTestDataSamples.writeOutAndReadBack(document));
+	}
 }


### PR DESCRIPTION
Bug 61972 - Adding chart in Document of MS-Word File without reading Temp MS-Word File 
this patch contains changes for creating XWPFChart object in XWPFDocument object without reading Temp ms-Word File which contains chart and then modifying them.