### PR TITLE
Replace default insecure SHA1 hash algorithm

### DIFF
--- a/src/ooxml/java/org/apache/poi/poifs/crypt/dsig/SignatureConfig.java
+++ b/src/ooxml/java/org/apache/poi/poifs/crypt/dsig/SignatureConfig.java
@@ -234,7 +234,7 @@ public class SignatureConfig {
     }
 
     /**
-     * @return the main digest algorithm, defaults to sha-1
+     * @return the main digest algorithm, defaults to sha-256
      */
     public HashAlgorithm getDigestAlgo() {
         return digestAlgo;

--- a/src/ooxml/java/org/apache/poi/poifs/crypt/dsig/SignatureConfig.java
+++ b/src/ooxml/java/org/apache/poi/poifs/crypt/dsig/SignatureConfig.java
@@ -74,7 +74,7 @@ public class SignatureConfig {
     private ThreadLocal<Provider> provider = new ThreadLocal<>();
     
     private List<SignatureFacet> signatureFacets = new ArrayList<>();
-    private HashAlgorithm digestAlgo = HashAlgorithm.sha1;
+    private HashAlgorithm digestAlgo = HashAlgorithm.sha256;
     private Date executionTime = new Date();
     private PrivateKey key;
     private List<X509Certificate> signingCertificateChain;


### PR DESCRIPTION
Replace default insecure SHA1 hash algorithm with SHA256.

SHA1 has been broken and should not be used anymore for signatures and should not be the default, cf. also https://security.googleblog.com/2016/11/sha-1-certificates-in-chrome.html