### PR TITLE
Bug 55713: Wrong ErrorStyle for DataValidations

### DIFF
--- a/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFDataValidation.java
+++ b/src/ooxml/java/org/apache/poi/xssf/usermodel/XSSFDataValidation.java
@@ -19,6 +19,7 @@ package org.apache.poi.xssf.usermodel;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.collections4.MapUtils;
 import org.apache.poi.ss.usermodel.DataValidation;
 import org.apache.poi.ss.usermodel.DataValidationConstraint;
 import org.apache.poi.ss.usermodel.DataValidationConstraint.ValidationType;
@@ -41,16 +42,19 @@ public class XSSFDataValidation implements DataValidation {
 	private XSSFDataValidationConstraint validationConstraint;
 	private CellRangeAddressList regions;
 
-    static Map<Integer,STDataValidationOperator.Enum> operatorTypeMappings = new HashMap<>();
-	static Map<STDataValidationOperator.Enum,Integer> operatorTypeReverseMappings = new HashMap<>();
-	static Map<Integer,STDataValidationType.Enum> validationTypeMappings = new HashMap<>();
-	static Map<STDataValidationType.Enum,Integer> validationTypeReverseMappings = new HashMap<>();
-	static Map<Integer,STDataValidationErrorStyle.Enum> errorStyleMappings = new HashMap<>();
+    static Map<Integer, STDataValidationOperator.Enum> operatorTypeMappings = new HashMap<>();
+	static Map<STDataValidationOperator.Enum, Integer> operatorTypeReverseMappings = new HashMap<>();
+	static Map<Integer, STDataValidationType.Enum> validationTypeMappings = new HashMap<>();
+	static Map<STDataValidationType.Enum, Integer> validationTypeReverseMappings = new HashMap<>();
+	static Map<Integer, STDataValidationErrorStyle.Enum> errorStyleMappings = new HashMap<>();
+	static Map<STDataValidationErrorStyle.Enum, Integer> reverseErrorStyleMappings;
 
     static {
 		errorStyleMappings.put(DataValidation.ErrorStyle.INFO, STDataValidationErrorStyle.INFORMATION);
 		errorStyleMappings.put(DataValidation.ErrorStyle.STOP, STDataValidationErrorStyle.STOP);
 		errorStyleMappings.put(DataValidation.ErrorStyle.WARNING, STDataValidationErrorStyle.WARNING);
+		
+		reverseErrorStyleMappings = MapUtils.invertMap(errorStyleMappings);
 
 		operatorTypeMappings.put(DataValidationConstraint.OperatorType.BETWEEN,STDataValidationOperator.BETWEEN);
 		operatorTypeMappings.put(DataValidationConstraint.OperatorType.NOT_BETWEEN,STDataValidationOperator.NOT_BETWEEN);
@@ -182,7 +186,7 @@ public class XSSFDataValidation implements DataValidation {
 	 * @see org.apache.poi.ss.usermodel.DataValidation#getErrorStyle()
 	 */
 	public int getErrorStyle() {
-		return ctDdataValidation.getErrorStyle().intValue();
+		return reverseErrorStyleMappings.get(ctDdataValidation.getErrorStyle());
 	}
 
 	/* (non-Javadoc)

--- a/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFDataValidation.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFDataValidation.java
@@ -303,22 +303,23 @@ public class TestXSSFDataValidation extends BaseTestDataValidation {
         try {
             XSSFSheet sheet = wb.createSheet();
     
-            final XSSFDataValidation validation = createValidation(sheet);
+            XSSFDataValidation validation = createValidation(sheet);
             sheet.addValidationData(validation);
+            
+            // extract generated validation from sheet
+            List<XSSFDataValidation> dataValidations = sheet.getDataValidations();
+            validation = dataValidations.get(0);
             
             // test INFO
             validation.setErrorStyle(DataValidation.ErrorStyle.INFO);
-            List<XSSFDataValidation> dataValidations = sheet.getDataValidations();
             assertEquals(DataValidation.ErrorStyle.INFO, dataValidations.get(0).getErrorStyle());
             
             // test WARNING
             validation.setErrorStyle(DataValidation.ErrorStyle.WARNING);
-            dataValidations = sheet.getDataValidations();
             assertEquals(DataValidation.ErrorStyle.WARNING, dataValidations.get(0).getErrorStyle());
             
             // test STOP
             validation.setErrorStyle(DataValidation.ErrorStyle.STOP);
-            dataValidations = sheet.getDataValidations();
             assertEquals(DataValidation.ErrorStyle.STOP, dataValidations.get(0).getErrorStyle());
         } finally {
             wb.close();

--- a/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFDataValidation.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/usermodel/TestXSSFDataValidation.java
@@ -280,6 +280,50 @@ public class TestXSSFDataValidation extends BaseTestDataValidation {
             wb.close();
         }
     }
+	
+	@Test
+    public void testDefaultErrorStyle() throws IOException {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        try {
+            XSSFSheet sheet = wb.createSheet();
+    
+            final XSSFDataValidation validation = createValidation(sheet);
+            sheet.addValidationData(validation);
+    
+            final List<XSSFDataValidation> dataValidations = sheet.getDataValidations();
+            assertEquals(DataValidation.ErrorStyle.STOP, dataValidations.get(0).getErrorStyle());
+        } finally {
+            wb.close();
+        }
+    }
+	
+	@Test
+    public void testSetErrorStyles() throws IOException {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        try {
+            XSSFSheet sheet = wb.createSheet();
+    
+            final XSSFDataValidation validation = createValidation(sheet);
+            sheet.addValidationData(validation);
+            
+            // test INFO
+            validation.setErrorStyle(DataValidation.ErrorStyle.INFO);
+            List<XSSFDataValidation> dataValidations = sheet.getDataValidations();
+            assertEquals(DataValidation.ErrorStyle.INFO, dataValidations.get(0).getErrorStyle());
+            
+            // test WARNING
+            validation.setErrorStyle(DataValidation.ErrorStyle.WARNING);
+            dataValidations = sheet.getDataValidations();
+            assertEquals(DataValidation.ErrorStyle.WARNING, dataValidations.get(0).getErrorStyle());
+            
+            // test STOP
+            validation.setErrorStyle(DataValidation.ErrorStyle.STOP);
+            dataValidations = sheet.getDataValidations();
+            assertEquals(DataValidation.ErrorStyle.STOP, dataValidations.get(0).getErrorStyle());
+        } finally {
+            wb.close();
+        }
+    }
 
 	@Test
     public void testDefaultAllowBlank() throws IOException {


### PR DESCRIPTION
Fix for bug [55713](https://bz.apache.org/bugzilla/show_bug.cgi?id=55713)

Was caused by a missing mapping.

Also added two unit tests.