### PR TITLE
rename text segment class

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/TextSegment.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/TextSegment.java
@@ -20,23 +20,23 @@ package org.apache.poi.xwpf.usermodel;
 /**
  * saves the begin and end position  of a text in a Paragraph
  */
-public class TextSegement {
+public class TextSegment {
     private PositionInParagraph beginPos;
     private PositionInParagraph endPos;
 
-    public TextSegement() {
+    public TextSegment() {
         this.beginPos = new PositionInParagraph();
         this.endPos = new PositionInParagraph();
     }
 
-    public TextSegement(int beginRun, int endRun, int beginText, int endText, int beginChar, int endChar) {
+    public TextSegment(int beginRun, int endRun, int beginText, int endText, int beginChar, int endChar) {
         PositionInParagraph beginPos = new PositionInParagraph(beginRun, beginText, beginChar);
         PositionInParagraph endPos = new PositionInParagraph(endRun, endText, endChar);
         this.beginPos = beginPos;
         this.endPos = endPos;
     }
 
-    public TextSegement(PositionInParagraph beginPos, PositionInParagraph endPos) {
+    public TextSegment(PositionInParagraph beginPos, PositionInParagraph endPos) {
         this.beginPos = beginPos;
         this.endPos = endPos;
     }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -1468,7 +1468,7 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
      * @param searched
      * @param startPos
      */
-    public TextSegement searchText(String searched, PositionInParagraph startPos) {
+    public TextSegment searchText(String searched, PositionInParagraph startPos) {
         int startRun = startPos.getRun(),
             startText = startPos.getText(),
             startChar = startPos.getChar();
@@ -1504,7 +1504,7 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
                                     if (candCharPos + 1 < searched.length()) {
                                         candCharPos++;
                                     } else if (newList) {
-                                        TextSegement segement = new TextSegement();
+                                        TextSegment segement = new TextSegment();
                                         segement.setBeginRun(beginRunPos);
                                         segement.setBeginText(beginTextPos);
                                         segement.setBeginChar(beginCharPos);
@@ -1539,7 +1539,7 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
      *
      * @param segment
      */
-    public String getText(TextSegement segment) {
+    public String getText(TextSegment segment) {
         int runBegin = segment.getBeginRun();
         int textBegin = segment.getBeginText();
         int charBegin = segment.getBeginChar();

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
@@ -559,7 +559,7 @@ public final class TestXWPFParagraph {
 
         XWPFParagraph p = ps.get(0);
 
-        TextSegement segment = p.searchText("sample word document", new PositionInParagraph());
+        TextSegment segment = p.searchText("sample word document", new PositionInParagraph());
         assertNotNull(segment);
 
         assertEquals("sample word document", p.getText(segment));


### PR DESCRIPTION
With 4.0.0 release, it would be nice to fix the class name.
There aren't too many nice approaches to retaining compatibility for the old name of the class `TextSegement`.