### PR TITLE
Enhancement to XWPFFootnote and related APIs

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -40,5 +40,6 @@
 	<classpathentry kind="lib" path="lib/byte-buddy-1.7.9.jar"/>
 	<classpathentry kind="lib" path="lib/byte-buddy-agent-1.7.9.jar"/>
 	<classpathentry kind="lib" path="lib/objenesis-2.6.jar"/>
+	<classpathentry kind="lib" path="lib/commons-compress-1.17.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -41,6 +41,8 @@ import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.ooxml.POIXMLProperties;
 import org.apache.poi.ooxml.POIXMLRelation;
+import org.apache.poi.ooxml.util.IdentifierManager;
+import org.apache.poi.ooxml.util.PackageHelper;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
@@ -84,6 +86,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.STDocProtect;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STOnOff;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.StylesDocument;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.*;
 
 /**
  * <p>High(ish) level class for working with .docx files.</p>
@@ -1652,5 +1655,34 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
         //add chart object to chart list
         charts.add(xwpfChart);
         return xwpfChart;
+    }
+
+    /**
+     * Create a new footnote and add it to the document. 
+     * <p>The new note will have one paragraph with the style "FootnoteText"
+     * and one run containing the required footnote reference with the 
+     * style "FootnoteReference".
+     *
+     * @return New XWPFFootnote.
+     */
+    public XWPFFootnote createFootnote() {
+        XWPFFootnotes footnotes = this.createFootnotes();
+        
+        XWPFFootnote footnote = footnotes.createFootnote();
+        return footnote;
+    }
+
+    /**
+     * Remove the specified footnote if present.
+     *
+     * @param pos 
+     * @return True if the footnote was removed.
+     */
+    public boolean removeFootnote(int pos) {
+        if (null != footnotes) {
+            return footnotes.removeFootnote(pos);
+        } else {
+            return false;
+        }
     }
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFFootnotes.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFFootnotes.java
@@ -22,6 +22,7 @@ import static org.apache.poi.ooxml.POIXMLTypeLoader.DEFAULT_XML_OPTIONS;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,10 +36,14 @@ import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFootnotes;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFtnEdn;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTR;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.FootnotesDocument;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.STFtnEdn;
 
 /**
- * Looks after the collection of Footnotes for a document
+ * Looks after the collection of Footnotes for a document.
+ * Manages both bottom-of-the-page footnotes and end notes.
  */
 public class XWPFFootnotes extends POIXMLDocumentPart {
     protected XWPFDocument document;
@@ -156,5 +161,40 @@ public class XWPFFootnotes extends POIXMLDocumentPart {
 
     public void setXWPFDocument(XWPFDocument doc) {
         document = doc;
+    }
+
+    /**
+     * Create a new footnote and add it to the document. 
+     * <p>The new note will have one paragraph with the style "FootnoteText"
+     * and one run containing the required footnote reference with the 
+     * style "FootnoteReference".
+     * </p>
+     * @return New XWPFFootnote
+     */
+    public XWPFFootnote createFootnote() {
+        CTFtnEdn newNote = CTFtnEdn.Factory.newInstance(); 
+        newNote.setType(STFtnEdn.NORMAL);
+
+        XWPFFootnote footnote = addFootnote(newNote);
+        int id = ctFootnotes.sizeOfFootnoteArray();
+        footnote.getCTFtnEdn().setId(BigInteger.valueOf(id));
+        return footnote;
+        
+    }
+
+    /**
+     * Remove the specified footnote if present.
+     *
+     * @param pos 
+     * @return True if the footnote was removed.
+     */
+    public boolean removeFootnote(int pos) {
+        if (ctFootnotes.sizeOfFootnoteArray() >= pos - 1) {
+            ctFootnotes.removeFootnote(pos);
+            listFootnote.remove(pos);
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
+import org.apache.poi.ss.formula.eval.NotImplementedException;
 import org.apache.poi.util.Internal;
 import org.apache.poi.wp.usermodel.Paragraph;
 import org.apache.xmlbeans.XmlCursor;
@@ -1666,5 +1667,18 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
             }
         }
         return null;
+    }
+
+    /**
+     * Add a new run with a reference to the specified footnote.
+     * The footnote reference run will have the style name "FootnoteReference".
+     *
+     * @param footnote Footnote to which to add a reference.
+     */
+    public void addFootnoteReference(XWPFFootnote footnote) {
+        XWPFRun run = createRun();
+        CTR ctRun = run.getCTR();
+        ctRun.addNewRPr().addNewRStyle().setVal("FootnoteReference");
+        ctRun.addNewFootnoteReference().setId(footnote.getId());      
     }
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFFootnote.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFFootnote.java
@@ -1,0 +1,158 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+package org.apache.poi.xwpf.usermodel;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
+
+import org.apache.poi.xwpf.XWPFTestDataSamples;
+import org.junit.Before;
+import org.junit.Test;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFtnEdnRef;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTR;
+
+public class TestXWPFFootnote {
+    
+    private XWPFDocument docOut;
+    private String p1Text;
+    private String p2Text;
+    private BigInteger footnoteId;
+    private XWPFFootnote footnote;
+
+    @Before
+    public void setUp() {
+        docOut = new XWPFDocument();
+        p1Text = "First paragraph in footnote";
+        p2Text = "Second paragraph in footnote";
+
+        // NOTE: XWPFDocument.createFootnote() delegates directly
+        //       to XWPFFootnotes.createFootnote() so this tests
+        //       both creation of new XWPFFootnotes in document
+        //       and XWPFFootnotes.createFootnote();
+        
+        // NOTE: Creating the footnote does not automatically
+        //       create a first paragraph.
+        footnote = docOut.createFootnote();
+        footnoteId = footnote.getId();
+        
+    }
+
+    @Test
+    public void testAddParagraphsToFootnote() throws IOException {
+
+        // Add a run to the first paragraph:    
+        
+        XWPFParagraph p1 = footnote.createParagraph();
+        p1.createRun().setText(p1Text);
+        
+        // Create a second paragraph:
+        
+        XWPFParagraph p = footnote.createParagraph();
+        assertNotNull("Paragraph is null", p);
+        p.createRun().setText(p2Text);
+
+        XWPFDocument docIn = XWPFTestDataSamples.writeOutAndReadBack(docOut);
+        
+        XWPFFootnote testFootnote = docIn.getFootnoteByID(footnoteId.intValue());
+        assertNotNull(testFootnote);
+        
+        assertEquals(2, testFootnote.getParagraphs().size());
+        XWPFParagraph testP1 = testFootnote.getParagraphs().get(0);
+        assertEquals(p1Text, testP1.getText());
+
+        XWPFParagraph testP2 = testFootnote.getParagraphs().get(1);
+        assertEquals(p2Text, testP2.getText());        
+        
+        // The first paragraph added using createParagraph() should
+        // have the required footnote reference added to the first
+        // run.
+        
+        // Verify that we have a footnote reference in the first paragraph and not
+        // in the second paragraph.
+        
+        XWPFRun r1 = testP1.getRuns().get(0);
+        assertNotNull(r1);
+        assertTrue("No footnote reference in testP1", r1.getCTR().getFootnoteRefList().size() > 0);
+        assertNotNull("No footnote reference in testP1", r1.getCTR().getFootnoteRefArray(0));
+
+        XWPFRun r2 = testP2.getRuns().get(0);
+        assertNotNull("Expected a run in testP2", r2);
+        assertTrue("Found a footnote reference in testP2", r2.getCTR().getFootnoteRefList().size() == 0);
+        
+    }
+    
+    @Test
+    public void testAddTableToFootnote() throws IOException {
+        XWPFTable table = footnote.createTable();
+        assertNotNull(table);
+        
+        XWPFDocument docIn = XWPFTestDataSamples.writeOutAndReadBack(docOut);
+        
+        XWPFFootnote testFootnote = docIn.getFootnoteByID(footnoteId.intValue());
+        XWPFTable testTable = testFootnote.getTableArray(0);
+        assertNotNull(testTable);
+        
+        table = footnote.createTable(2, 3);
+        assertEquals(2, table.getNumberOfRows());
+        assertEquals(3, table.getRow(0).getTableCells().size());
+        
+        // If the table is the first body element of the footnote then
+        // a paragraph with the footnote reference should have been
+        // added automatically.
+        
+        assertEquals("Expected 3 body elements", 3, footnote.getBodyElements().size());
+        IBodyElement testP1 = footnote.getBodyElements().get(0);
+        assertTrue("Expected a paragraph, got " + testP1.getClass().getSimpleName() , testP1 instanceof XWPFParagraph);
+        XWPFRun r1 = ((XWPFParagraph)testP1).getRuns().get(0);
+        assertNotNull(r1);
+        assertTrue("No footnote reference in testP1", r1.getCTR().getFootnoteRefList().size() > 0);
+        assertNotNull("No footnote reference in testP1", r1.getCTR().getFootnoteRefArray(0));
+
+    }
+    
+    @Test
+    public void testRemoveFootnote() {
+        // NOTE: XWPFDocument.removeFootnote() delegates directly to 
+        //       XWPFFootnotes.
+        docOut.createFootnote();
+        assertEquals("Expected 2 footnotes", 2, docOut.getFootnotes().size());
+        assertNotNull("Didn't get second footnote", docOut.getFootnotes().get(1));
+        boolean result = docOut.removeFootnote(0);
+        assertTrue("Remove footnote did not return true", result);
+        assertEquals("Expected 1 footnote after removal", 1, docOut.getFootnotes().size());
+    }
+
+    @Test
+    public void testAddFootnoteRefToParagraph() {
+        XWPFParagraph p = docOut.createParagraph();
+        List<XWPFRun> runs = p.getRuns();
+        assertEquals("Expected no runs in new paragraph", 0, runs.size());
+        p.addFootnoteReference(footnote);
+        XWPFRun run = p.getRuns().get(0);
+        CTR ctr = run.getCTR();
+        assertNotNull("Expected a run", run);
+        CTFtnEdnRef ref = ctr.getFootnoteReferenceList().get(0);
+        assertNotNull(ref);
+        assertEquals("Footnote ID and reference ID did not match", footnote.getId(), ref.getId());
+        
+        
+    }
+
+}

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFFootnotes.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFFootnotes.java
@@ -21,28 +21,42 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
 
-import junit.framework.TestCase;
 import org.apache.poi.xwpf.XWPFTestDataSamples;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFtnEdn;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STFtnEdn;
 
+import junit.framework.TestCase;
+
 public class TestXWPFFootnotes extends TestCase {
+    
+    public void testCreateFootnotes() throws IOException{
+        XWPFDocument docOut = new XWPFDocument();
+
+        XWPFFootnotes footnotes = docOut.createFootnotes();
+        
+        assertNotNull(footnotes);
+        
+        XWPFFootnotes secondFootnotes = docOut.createFootnotes();
+        
+        assertSame(footnotes, secondFootnotes);
+        
+        docOut.close();
+    }
 
     public void testAddFootnotesToDocument() throws IOException {
         XWPFDocument docOut = new XWPFDocument();
 
-        BigInteger noteId = BigInteger.valueOf(1);
-
-        XWPFFootnotes footnotes = docOut.createFootnotes();
-        CTFtnEdn ctNote = CTFtnEdn.Factory.newInstance();
-        ctNote.setId(noteId);
-        ctNote.setType(STFtnEdn.NORMAL);
-        footnotes.addFootnote(ctNote);
+        // NOTE: XWPFDocument.createFootnote() delegates directly
+        //       to XWPFFootnotes.createFootnote() so this tests
+        //       both creation of new XWPFFootnotes in document
+        //       and XWPFFootnotes.createFootnote();
+        XWPFFootnote footnote = docOut.createFootnote();
+        BigInteger noteId = footnote.getId();
 
         XWPFDocument docIn = XWPFTestDataSamples.writeOutAndReadBack(docOut);
 
         XWPFFootnote note = docIn.getFootnoteByID(noteId.intValue());
-        assertEquals(note.getCTFtnEdn().getType(), STFtnEdn.NORMAL);
+        assertNotNull(note);
+        assertEquals(STFtnEdn.NORMAL, note.getCTFtnEdn().getType());
     }
 
     /**


### PR DESCRIPTION
My first pass at enhancing the XWPFFootnote API.

Adds new methods createParagraph() and createTable()/createTable(rows, cols) to XWPFFootnote.

Adds new methods createFootnote() and removeFootnote() to XWPFDocument and XWPFFootnotes

Adds new method addFootnoteReference(XWPFFootnote) to XWPFParagraph

Creation of new footnote does not add any body elements. However, adding the first paragraph or table automatically creates the required footnote ref run in the first paragraph (adding the paragraph if necessary).

I also made a pass over the javadocs for XWPFFootnote.

I tested with the included unit tests and also in the context of my real-world project that is driving this update. That verifies, for example, that a multi-paragraph footnote with a table works as it should.
