### PR TITLE
Add getStyleWithName() to XWPFStyles

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -1333,15 +1333,14 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
     }
 
     /**
-     * This method provides a style to the paragraph
-     * This is useful when, e.g. an Heading style has to be assigned
+     * Set the style ID for the paragraph
      *
-     * @param newStyle
+     * @param styleId ID (not name) of the style to set for the paragraph, e.g. "Heading1" (not "Heading 1").
      */
-    public void setStyle(String newStyle) {
+    public void setStyle(String styleId) {
         CTPPr pr = getCTPPr();
         CTString style = pr.getPStyle() != null ? pr.getPStyle() : pr.addNewPStyle();
-        style.setVal(newStyle);
+        style.setVal(styleId);
     }
 
     /**

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -56,33 +56,7 @@ import org.openxmlformats.schemas.drawingml.x2006.picture.CTPicture;
 import org.openxmlformats.schemas.drawingml.x2006.picture.CTPictureNonVisual;
 import org.openxmlformats.schemas.drawingml.x2006.wordprocessingDrawing.CTAnchor;
 import org.openxmlformats.schemas.drawingml.x2006.wordprocessingDrawing.CTInline;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBr;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTColor;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTDrawing;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTEmpty;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFFCheckBox;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFldChar;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFonts;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTFtnEdnRef;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTHpsMeasure;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTOnOff;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPTab;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTR;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTRPr;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTRuby;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTRubyContent;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSignedHpsMeasure;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSignedTwipsMeasure;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTText;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTUnderline;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTVerticalAlignRun;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STBrClear;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STBrType;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STFldCharType;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHighlightColor;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STOnOff;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STUnderline;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.STVerticalAlignRun;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.*;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.InputSource;
@@ -1121,6 +1095,22 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
     public List<XWPFPicture> getEmbeddedPictures() {
         return pictures;
     }
+    
+    /**
+     * Set the style ID for the run.
+     *
+     * @param styleId ID (not name) of the style to set for the run, e.g. "BoldItalic" (not "Bold Italic").
+     */
+    public void setStyle(String styleId) {
+        CTRPr pr = getCTR().getRPr();
+        if (null == pr) {
+           pr = getCTR().addNewRPr();
+        }
+        CTString style = pr.getRStyle() != null ? pr.getRStyle() : pr.addNewRStyle();
+        style.setVal(styleId);
+    }
+
+    
 
     /**
      * Returns the string version of the text and the phonetic string

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFStyles.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFStyles.java
@@ -323,4 +323,21 @@ public class XWPFStyles extends POIXMLDocumentPart {
     public XWPFLatentStyles getLatentStyles() {
         return latentStyles;
     }
+
+    /**
+     * Get the style with the specified name, if any.
+     *
+     * @param styleName The name of the style to get, e.g., "Heading 1"
+     * @return {@link XWPFStyle} with the specified name, or null if not found.
+     */
+    public XWPFStyle getStyleWithName(String styleName) {
+        XWPFStyle style = null;
+        for (XWPFStyle cand : listStyle) {
+            if (styleName.equals(cand.getName())) {
+                style = cand;
+                break;
+            }
+        }
+        return style;
+    }
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -673,4 +673,18 @@ public class TestXWPFRun {
 
         document.close();
     }
+    
+    @Test
+    public void testSetStyleId() throws IOException {
+        XWPFDocument document = XWPFTestDataSamples.openSampleDocument("SampleDoc.docx");
+        final XWPFRun run = document.createParagraph().createRun();
+        
+        String styleId = "bolditalic";
+        run.setStyle(styleId);
+        String candStyleId = run.getCTR().getRPr().getRStyle().getVal();
+        assertNotNull("Expected to find a run style ID", candStyleId);
+        assertEquals(styleId, candStyleId);
+        
+    }
+
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFStyles.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFStyles.java
@@ -219,4 +219,16 @@ public final class TestXWPFStyles {
 
         doc.close();
     }
+    
+    @Test
+    public void testGetStyleByName() throws IOException {
+        XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("SampleDoc.docx");
+        XWPFStyles styles = doc.getStyles();
+        assertNotNull(styles);
+
+        String styleName = "Normal Table";
+        XWPFStyle style = styles.getStyleWithName(styleName);
+        assertNotNull("Expected to find style \"" + styleName + "\"", style);
+        assertEquals(styleName, style.getName());
+    }
 }


### PR DESCRIPTION
Make it possible to look up styles by style name.
Made use of paragraph.setStyle() clearer by refining the javadoc and parameter name
Added setStyle() to XWPFRun since I needed that too.