### PR TITLE
Added get/set for mirror margins setting

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -1339,6 +1339,40 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
     }
 
     /**
+     * Returns the even-and-odd-headings setting
+     *
+     * @return True or false indicating whether or not separate even and odd headings is turned on.
+     */
+    public boolean getEvenAndOddHeadings() {
+        return settings.getEvenAndOddHeadings();
+    }
+    
+    /**
+     * Sets the even-and-odd-headings setting
+     * @param enable Set to true to turn on separate even and odd headings.
+     */
+    public void setEvenAndOddHeadings(boolean enable) {
+        settings.setEvenAndOddHeadings(enable);
+    }
+    
+    /**
+     * Returns the mirror margins setting
+     *
+     * @return True or false indicating whether or not mirror margins is turned on.
+     */
+    public boolean getMirrorMargins() {
+        return settings.getMirrorMargins();
+    }
+    
+    /**
+     * Sets the mirror margins setting
+     * @param enable Set to true to turn on mirror margins.
+     */
+    public void setMirrorMargins(boolean enable) {
+        settings.setMirrorMargins(enable);
+    }
+    
+    /**
      * inserts an existing XWPFTable to the arrays bodyElements and tables
      *
      * @param pos
@@ -1758,4 +1792,5 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
             return false;
         }
     }
+
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFSettings.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFSettings.java
@@ -430,4 +430,48 @@ public class XWPFSettings extends POIXMLDocumentPart {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * Check if separate even and odd headings is turned on.
+     *
+     * @return True if even and odd headings is turned on.
+     */
+    public boolean getEvenAndOddHeadings() {
+        return ctSettings.isSetEvenAndOddHeaders();
+    }
+
+    /**
+     * Turn separate even-and-odd headings on or off
+     *
+     * @param enable <code>true</code> to turn on separate even and odd headings, 
+     * <code>false</code> to turn off even and odd headings.
+     */
+    public void setEvenAndOddHeadings(boolean enable) {
+        CTOnOff onOff = CTOnOff.Factory.newInstance();
+        onOff.setVal(enable ? STOnOff.TRUE : STOnOff.FALSE);
+        ctSettings.setEvenAndOddHeaders(onOff);
+    }
+
+    /**
+     * Check if mirrored margins is turned on
+     *
+     * @return True if mirrored margins is turned on.
+     */
+    public boolean getMirrorMargins() {
+        return ctSettings.isSetMirrorMargins();
+    }
+
+    /**
+     * Turn mirrored margins on or off
+     *
+     * @param enable <code>true</code> to turn on mirrored margins, 
+     * <code>false</code> to turn off mirrored marginss.
+     */
+    public void setMirrorMargins(boolean enable) {
+        CTOnOff onOff = CTOnOff.Factory.newInstance();
+        onOff.setVal(enable ? STOnOff.TRUE : STOnOff.FALSE);
+        ctSettings.setMirrorMargins(onOff);
+    }
+
+
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFDocument.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFDocument.java
@@ -402,6 +402,14 @@ public final class TestXWPFDocument {
         assertEquals(100, settings.getZoomPercent());
         settings.setZoomPercent(50);
         assertEquals(50, settings.getZoomPercent());
+        
+        assertEquals(false, settings.getEvenAndOddHeadings());
+        settings.setEvenAndOddHeadings(true);
+        assertEquals(true, settings.getEvenAndOddHeadings());
+
+        assertEquals(false, settings.getMirrorMargins());
+        settings.setMirrorMargins(true);
+        assertEquals(true, settings.getMirrorMargins());
 
         XWPFDocument doc = new XWPFDocument();
         assertEquals(100, doc.getZoomPercent());
@@ -411,6 +419,14 @@ public final class TestXWPFDocument {
 
         doc.setZoomPercent(200);
         assertEquals(200, doc.getZoomPercent());
+
+        assertEquals(false, doc.getEvenAndOddHeadings());
+        doc.setEvenAndOddHeadings(true);
+        assertEquals(true, doc.getEvenAndOddHeadings());
+
+        assertEquals(false, doc.getMirrorMargins());
+        doc.setMirrorMargins(true);
+        assertEquals(true, doc.getMirrorMargins());
 
         XWPFDocument back = XWPFTestDataSamples.writeOutAndReadBack(doc);
         assertEquals(200, back.getZoomPercent());


### PR DESCRIPTION
Added get and set for even-and-odd headings setting.

I couldn't find any other simple settings that seemed useful for exposing on Document.

Added unit test and tested with real-world project.