### PR TITLE
Implemented a number of new set and get methods for useful formatting…

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/FootnoteEndnoteIdManager.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/FootnoteEndnoteIdManager.java
@@ -41,10 +41,10 @@ public class FootnoteEndnoteIdManager {
     public BigInteger nextId() {
         
         List<BigInteger> ids = new ArrayList<BigInteger>();
-        for (AbstractXWPFFootnoteEndnote note : document.getFootnotes()) {
+        for (XWPFAbstractFootnoteEndnote note : document.getFootnotes()) {
             ids.add(note.getId());
         }
-        for (AbstractXWPFFootnoteEndnote note : document.getEndnotes()) {
+        for (XWPFAbstractFootnoteEndnote note : document.getEndnotes()) {
             ids.add(note.getId());
         }
         int cand = ids.size();

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
@@ -42,29 +42,29 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTc;
  * {@link XWPFFootnotes} and end notes are managed by the Endnotes part {@link XWPFEndnotes}.</p>
  * @since 4.0.0
  */
-public abstract class AbstractXWPFFootnoteEndnote  implements Iterable<XWPFParagraph>, IBody {
+public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParagraph>, IBody {
 
     private List<XWPFParagraph> paragraphs = new ArrayList<>();
     private List<XWPFTable> tables = new ArrayList<>();
     private List<XWPFPictureData> pictures = new ArrayList<>();
     private List<IBodyElement> bodyElements = new ArrayList<>();
     protected CTFtnEdn ctFtnEdn;
-    protected AbstractXWPFFootnotesEndnotes footnotes;
+    protected XWPFAbstractFootnotesEndnotes footnotes;
     protected XWPFDocument document;
 
-    public AbstractXWPFFootnoteEndnote() {
+    public XWPFAbstractFootnoteEndnote() {
         super();
     }
 
     @Internal
-    protected AbstractXWPFFootnoteEndnote(XWPFDocument document, CTFtnEdn body) {
+    protected XWPFAbstractFootnoteEndnote(XWPFDocument document, CTFtnEdn body) {
         ctFtnEdn = body;
         this.document = document;
         init();
     }
 
     @Internal
-    protected AbstractXWPFFootnoteEndnote(CTFtnEdn note, AbstractXWPFFootnotesEndnotes footnotes) {
+    protected XWPFAbstractFootnoteEndnote(CTFtnEdn note, XWPFAbstractFootnotesEndnotes footnotes) {
         this.footnotes = footnotes;
         ctFtnEdn = note;
         document = footnotes.getXWPFDocument();

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnotesEndnotes.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnotesEndnotes.java
@@ -27,36 +27,36 @@ import org.apache.poi.openxml4j.opc.PackagePart;
  * Base class for the Footnotes and Endnotes part implementations.
  * @since 4.0.0
  */
-public abstract class AbstractXWPFFootnotesEndnotes extends POIXMLDocumentPart {
+public abstract class XWPFAbstractFootnotesEndnotes extends POIXMLDocumentPart {
 
     protected XWPFDocument document;
-    protected List<AbstractXWPFFootnoteEndnote> listFootnote = new ArrayList<>();
+    protected List<XWPFAbstractFootnoteEndnote> listFootnote = new ArrayList<>();
     private FootnoteEndnoteIdManager idManager;
     
-    public AbstractXWPFFootnotesEndnotes(OPCPackage pkg) {
+    public XWPFAbstractFootnotesEndnotes(OPCPackage pkg) {
         super(pkg);
     }
 
-    public AbstractXWPFFootnotesEndnotes(OPCPackage pkg,
+    public XWPFAbstractFootnotesEndnotes(OPCPackage pkg,
             String coreDocumentRel) {
         super(pkg, coreDocumentRel);
     }
 
-    public AbstractXWPFFootnotesEndnotes() {
+    public XWPFAbstractFootnotesEndnotes() {
         super();
     }
 
-    public AbstractXWPFFootnotesEndnotes(PackagePart part) {
+    public XWPFAbstractFootnotesEndnotes(PackagePart part) {
         super(part);
     }
 
-    public AbstractXWPFFootnotesEndnotes(POIXMLDocumentPart parent, PackagePart part) {
+    public XWPFAbstractFootnotesEndnotes(POIXMLDocumentPart parent, PackagePart part) {
         super(parent, part);
     }
 
 
-    public AbstractXWPFFootnoteEndnote getFootnoteById(int id) {
-        for (AbstractXWPFFootnoteEndnote note : listFootnote) {
+    public XWPFAbstractFootnoteEndnote getFootnoteById(int id) {
+        for (XWPFAbstractFootnoteEndnote note : listFootnote) {
             if (note.getCTFtnEdn().getId().intValue() == id)
                 return note;
         }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractSDT.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractSDT.java
@@ -27,12 +27,12 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTString;
  * <p>
  * These classes have so far been built only for read-only processing.
  */
-public abstract class AbstractXWPFSDT implements ISDTContents {
+public abstract class XWPFAbstractSDT implements ISDTContents {
     private final String title;
     private final String tag;
     private final IBody part;
 
-    public AbstractXWPFSDT(CTSdtPr pr, IBody part) {
+    public XWPFAbstractSDT(CTSdtPr pr, IBody part) {
         if (pr == null) {
             title = "";
             tag = "";

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFEndnote.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFEndnote.java
@@ -34,11 +34,11 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTR;
  * the footnote ID to create a reference to a footnote from within a paragraph.</p>
  * <p>To create a reference to a footnote within a paragraph you create a run
  * with a CTFtnEdnRef that specifies the ID of the target paragraph. 
- * The {@link XWPFParagraph#addFootnoteReference(AbstractXWPFFootnoteEndnote)}
+ * The {@link XWPFParagraph#addFootnoteReference(XWPFAbstractFootnoteEndnote)}
  * method does this for you.</p>
  * @since 4.0.0
  */
-public class XWPFEndnote extends AbstractXWPFFootnoteEndnote {
+public class XWPFEndnote extends XWPFAbstractFootnoteEndnote {
 
     public XWPFEndnote() {}
 
@@ -48,7 +48,7 @@ public class XWPFEndnote extends AbstractXWPFFootnoteEndnote {
     }
 
     @Internal
-    public XWPFEndnote(CTFtnEdn note, AbstractXWPFFootnotesEndnotes footnotes) {
+    public XWPFEndnote(CTFtnEdn note, XWPFAbstractFootnotesEndnotes footnotes) {
         super(note, footnotes);
     }
 
@@ -57,7 +57,7 @@ public class XWPFEndnote extends AbstractXWPFFootnoteEndnote {
      * end note by adding a footnote reference if one is not found.
      * <p>This method is for the first paragraph in the footnote, not 
      * paragraphs that will refer to the footnote. For references to
-     * the footnote, use {@link XWPFParagraph#addFootnoteReference(AbstractXWPFFootnoteEndnote))}.
+     * the footnote, use {@link XWPFParagraph#addFootnoteReference(XWPFAbstractFootnoteEndnote))}.
      * </p>
      * <p>The first run of the first paragraph in a footnote should
      * contain a {@link CTFtnEdnRef} object.</p>

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFEndnotes.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFEndnotes.java
@@ -44,7 +44,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.STFtnEdn;
  * Managed end notes ({@link XWPFEndnote}).
  * @since 4.0.0
  */
-public class XWPFEndnotes extends AbstractXWPFFootnotesEndnotes {
+public class XWPFEndnotes extends XWPFAbstractFootnotesEndnotes {
 
     protected CTEndnotes ctEndnotes;
 
@@ -183,7 +183,7 @@ public class XWPFEndnotes extends AbstractXWPFFootnotesEndnotes {
      */
     public List<XWPFEndnote> getEndnotesList() {
         List<XWPFEndnote> resultList = new ArrayList<XWPFEndnote>();
-        for (AbstractXWPFFootnoteEndnote note : listFootnote) {
+        for (XWPFAbstractFootnoteEndnote note : listFootnote) {
             resultList.add((XWPFEndnote)note);
         }
         return resultList;

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFFootnote.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFFootnote.java
@@ -32,13 +32,13 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTR;
  * the footnote ID to create a reference to a footnote from within a paragraph.</p>
  * <p>To create a reference to a footnote within a paragraph you create a run
  * with a CTFtnEdnRef that specifies the ID of the target paragraph. 
- * The {@link XWPFParagraph#addFootnoteReference(AbstractXWPFFootnoteEndnote)}
+ * The {@link XWPFParagraph#addFootnoteReference(XWPFAbstractFootnoteEndnote)}
  * method does this for you.</p>
  */
-public class XWPFFootnote extends AbstractXWPFFootnoteEndnote {
+public class XWPFFootnote extends XWPFAbstractFootnoteEndnote {
     
     @Internal
-    public XWPFFootnote(CTFtnEdn note, AbstractXWPFFootnotesEndnotes xFootnotes) {
+    public XWPFFootnote(CTFtnEdn note, XWPFAbstractFootnotesEndnotes xFootnotes) {
         super(note, xFootnotes);
     }
 

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFFootnotes.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFFootnotes.java
@@ -43,7 +43,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.STFtnEdn;
  * Looks after the collection of Footnotes for a document.
  * Manages bottom-of-the-page footnotes ({@link XWPFFootnote}).
  */
-public class XWPFFootnotes extends AbstractXWPFFootnotesEndnotes {
+public class XWPFFootnotes extends XWPFAbstractFootnotesEndnotes {
     protected CTFootnotes ctFootnotes;
 
     /**
@@ -173,7 +173,7 @@ public class XWPFFootnotes extends AbstractXWPFFootnotesEndnotes {
      */
     public List<XWPFFootnote> getFootnotesList() {
         List<XWPFFootnote> resultList = new ArrayList<XWPFFootnote>();
-        for (AbstractXWPFFootnoteEndnote note : listFootnote) {
+        for (XWPFAbstractFootnoteEndnote note : listFootnote) {
             resultList.add((XWPFFootnote)note);
         }
         return resultList;

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -76,7 +76,7 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
                 if (o instanceof CTFtnEdnRef) {
                     CTFtnEdnRef ftn = (CTFtnEdnRef) o;
                     footnoteText.append(" [").append(ftn.getId()).append(": ");
-                    AbstractXWPFFootnoteEndnote footnote =
+                    XWPFAbstractFootnoteEndnote footnote =
                             ftn.getDomNode().getLocalName().equals("footnoteReference") ?
                                     document.getFootnoteByID(ftn.getId().intValue()) :
                                     document.getEndnoteByID(ftn.getId().intValue());
@@ -1678,7 +1678,7 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
      * @param footnote Footnote to which to add a reference.
      * @since 4.0.0
      */
-    public void addFootnoteReference(AbstractXWPFFootnoteEndnote footnote) {
+    public void addFootnoteReference(XWPFAbstractFootnoteEndnote footnote) {
         XWPFRun run = createRun();
         CTR ctRun = run.getCTR();
         ctRun.addNewRPr().addNewRStyle().setVal("FootnoteReference");

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -32,6 +32,7 @@ import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ooxml.util.DocumentHelper;
 import org.apache.poi.util.Internal;
+import org.apache.poi.util.Removal;
 import org.apache.poi.wp.usermodel.CharacterRun;
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlException;
@@ -394,11 +395,10 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
     }
 
     /**
-     * Specifies that the contents of this run should be displayed along with an
-     * underline appearing directly below the character heigh
+     * Get the underline setting for the run.
      *
-     * @return the Underline pattern applyed to this run
-     * @see UnderlinePatterns
+     * @return the Underline pattern applied to this run
+     * @see (@link UnderlinePatterns}
      */
     public UnderlinePatterns getUnderline() {
         CTRPr pr = run.getRPr();
@@ -419,7 +419,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      *
      * @param value -
      *              underline type
-     * @see UnderlinePatterns : all possible patterns that could be applied
+     * @see {@link UnderlinePatterns} : all possible patterns that could be applied
      */
     public void setUnderline(UnderlinePatterns value) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -427,6 +427,28 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         underline.setVal(STUnderline.Enum.forInt(value.getValue()));
     }
 
+    /**
+     * Set the underline color for the run's underline, if any.
+     *
+     * @param color An RGB color value (e.g, "a0C6F3") or "auto". 
+     */
+    public void setUnderlineColor(String color) {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTUnderline underline = (pr.getU() == null) ? pr.addNewU() :
+pr.getU();
+        SimpleValue svColor = null;
+        if (color.equals("string")) {
+            STHexColorAuto hexColor = STHexColorAuto.Factory.newInstance();
+            hexColor.set(STHexColorAuto.Enum.forString(color));
+            svColor = (SimpleValue) hexColor;
+        } else {
+            STHexColorRGB rgbColor = STHexColorRGB.Factory.newInstance();
+            rgbColor.setStringValue(color);
+            svColor = (SimpleValue) rgbColor;
+        }
+        underline.setColor(svColor);
+    }
+    
     /**
      * Specifies that the contents of this run shall be displayed with a single
      * horizontal line through the center of the line.
@@ -580,6 +602,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * @see {@link VerticalAlign} all possible value that could be applyed to this run
      * @deprecated use {@link XWPFRun.getVerticalAlignment}
      */
+    @Removal(version = "4.2")
     public VerticalAlign getSubscript() {
         CTRPr pr = run.getRPr();
         return (pr != null && pr.isSetVertAlign()) ? VerticalAlign.valueOf(pr.getVertAlign().getVal().intValue()) : VerticalAlign.BASELINE;
@@ -1284,6 +1307,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Set the text expand/collapse scale value.
      *
      * @param percentage The percentage to expand or compress the text
+     * @since 4.0.0
      */
     public void setTextScale(int percentage) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1295,6 +1319,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Gets the current text scale value.
      *
      * @return Value is an integer percentage
+     * @since 4.0.0
      */
     public int getTextScale() {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1310,6 +1335,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Set the highlight color for the run. Silently does nothing of colorName is not a recognized value.
      *
      * @param colorName The name of the color as defined in the ST_HighlightColor simple type ({@link STHightlightColor})
+     * @since 4.0.0
      */
     public void setTextHighlightColor(String colorName) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1330,6 +1356,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Gets the highlight color for the run
      *
      * @return {@link STHighlightColor} for the run.
+     * @since 4.0.0
      */
     public STHighlightColor.Enum getTextHightlightColor() {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1346,6 +1373,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Get the vanish (hidden text) value
      *
      * @return True if the run is hidden text.
+     * @since 4.0.0
      */
     public boolean isVanish() {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1356,6 +1384,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * The vanish (hidden text) property for the run. 
      *
      * @param value Set to true to make the run hidden text.
+     * @since 4.0.0
      */
     public void setVanish(boolean value) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1367,6 +1396,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Get the vertical alignment value
      *
      * @return {@link STVerticalAlignRun.Enum} value (see 22.9.2.17 ST_VerticalAlignRun (Vertical Positioning Location))
+     * @since 4.0.0
      */
     public STVerticalAlignRun.Enum getVerticalAlignment() {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1382,6 +1412,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Set the vertical alignment of the run.
      *
      * @param verticalAlignment Vertical alignment value, one of "baseline", "superscript", or "subscript".
+     * @since 4.0.0
      */
     public void setVerticalAlignment(String verticalAlignment) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1403,6 +1434,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Get the emphasis mark value for the run.
      *
      * @return {@link STEm.Enum} emphasis mark type enumeration. See 17.18.24 ST_Em (Emphasis Mark Type).
+     * @since 4.0.0
      */
     public STEm.Enum getEmphasisMark() {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
@@ -1420,6 +1452,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * text.
      *
      * @param markType Emphasis mark type name, e.g., "dot" or "none". See 17.18.24 ST_Em (Emphasis Mark Type)
+     * @since 4.0.0
      */
     public void setEmphasisMark(String markType) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -31,9 +31,11 @@ import javax.xml.namespace.QName;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ooxml.util.DocumentHelper;
+import org.apache.poi.util.HexDump;
 import org.apache.poi.util.Internal;
 import org.apache.poi.util.Removal;
 import org.apache.poi.wp.usermodel.CharacterRun;
+import org.apache.xmlbeans.SimpleValue;
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlObject;
@@ -431,13 +433,13 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * Set the underline color for the run's underline, if any.
      *
      * @param color An RGB color value (e.g, "a0C6F3") or "auto". 
+     * @since 4.0.0
      */
     public void setUnderlineColor(String color) {
         CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
-        CTUnderline underline = (pr.getU() == null) ? pr.addNewU() :
-pr.getU();
+        CTUnderline underline = (pr.getU() == null) ? pr.addNewU() : pr.getU();
         SimpleValue svColor = null;
-        if (color.equals("string")) {
+        if (color.equals("auto")) {
             STHexColorAuto hexColor = STHexColorAuto.Factory.newInstance();
             hexColor.set(STHexColorAuto.Enum.forString(color));
             svColor = (SimpleValue) hexColor;
@@ -447,6 +449,28 @@ pr.getU();
             svColor = (SimpleValue) rgbColor;
         }
         underline.setColor(svColor);
+    }
+    
+    /**
+     * Get the underline color for the run's underline, if any.
+     *
+     * @return The RGB color value as as a string of hexadecimal digits (e.g., "A0B2F1") or "auto".
+     * @since 4.0.0
+     */
+    public String getUnderlineColor() {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTUnderline underline = (pr.getU() == null) ? pr.addNewU() : pr.getU();
+        String colorName = "auto";
+        Object rawValue = underline.getColor();
+        if (rawValue != null) {
+            if (rawValue instanceof String) {
+                colorName = (String)rawValue;
+            } else {
+                byte[] rgbColor = (byte[])rawValue;
+                colorName = HexDump.toHex(rgbColor[0]) + HexDump.toHex(rgbColor[1]) + HexDump.toHex(rgbColor[2]);
+            }
+        }
+        return colorName;
     }
     
     /**

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -409,8 +409,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
 
     /**
      * Specifies that the contents of this run should be displayed along with an
-     * underline appearing directly below the character heigh
-     * <p>
+     * underline appearing directly below the character height.
      * <p>
      * If this element is not present, the default value is to leave the
      * formatting applied at previous level in the style hierarchy. If this
@@ -578,7 +577,8 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * altering the font size of the run properties.
      *
      * @return VerticalAlign
-     * @see VerticalAlign all possible value that could be applyed to this run
+     * @see {@link VerticalAlign} all possible value that could be applyed to this run
+     * @deprecated use {@link XWPFRun.getVerticalAlignment}
      */
     public VerticalAlign getSubscript() {
         CTRPr pr = run.getRPr();
@@ -629,7 +629,8 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         if (pr == null || !pr.isSetHighlight()) {
             return false;
         }
-        if (pr.getHighlight().getVal() == STHighlightColor.NONE) {
+        STHighlightColor.Enum val = pr.getHighlight().getVal();
+        if (val == null || val == STHighlightColor.NONE) {
             return false;
         }
         return true;
@@ -1278,4 +1279,162 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         eastAsia /* east asia */,
         hAnsi /* high ansi */
     }
+
+    /**
+     * Set the text expand/collapse scale value.
+     *
+     * @param percentage The percentage to expand or compress the text
+     */
+    public void setTextScale(int percentage) {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTTextScale scale = pr.isSetW() ? pr.getW() : pr.addNewW();
+        scale.setVal(percentage);        
+    }
+
+    /**
+     * Gets the current text scale value.
+     *
+     * @return Value is an integer percentage
+     */
+    public int getTextScale() {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTTextScale scale = pr.isSetW() ? pr.getW() : pr.addNewW();
+        int value = scale.getVal();
+        if (value == 0) {
+            value = 100; // 100% scaling, that is, no change. See 17.3.2.43 w (Expanded/Compressed Text)
+        }
+        return value;
+    }
+
+    /**
+     * Set the highlight color for the run. Silently does nothing of colorName is not a recognized value.
+     *
+     * @param colorName The name of the color as defined in the ST_HighlightColor simple type ({@link STHightlightColor})
+     */
+    public void setTextHighlightColor(String colorName) {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTHighlight highlight = pr.isSetHighlight() ? pr.getHighlight() : pr.addNewHighlight();
+        STHighlightColor color = highlight.xgetVal();
+        if (color == null) {
+            color = STHighlightColor.Factory.newInstance();            
+        }
+        STHighlightColor.Enum val = STHighlightColor.Enum.forString(colorName);
+        if (val != null) {
+            color.setStringValue(val.toString());
+            highlight.xsetVal(color);
+        }
+         
+    }
+
+    /**
+     * Gets the highlight color for the run
+     *
+     * @return {@link STHighlightColor} for the run.
+     */
+    public STHighlightColor.Enum getTextHightlightColor() {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTHighlight highlight = pr.isSetHighlight() ? pr.getHighlight() : pr.addNewHighlight();
+        STHighlightColor color = highlight.xgetVal();
+        if (color == null) {
+            color = STHighlightColor.Factory.newInstance();
+            color.set(STHighlightColor.NONE);
+        }
+        return (STHighlightColor.Enum)(color.enumValue());
+    }
+
+    /**
+     * Get the vanish (hidden text) value
+     *
+     * @return True if the run is hidden text.
+     */
+    public boolean isVanish() {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        return pr != null && pr.isSetVanish() && isCTOnOff(pr.getVanish());
+    }
+
+    /**
+     * The vanish (hidden text) property for the run. 
+     *
+     * @param value Set to true to make the run hidden text.
+     */
+    public void setVanish(boolean value) {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTOnOff vanish = pr.isSetVanish() ? pr.getVanish() : pr.addNewVanish();
+        vanish.setVal(value ? STOnOff.TRUE : STOnOff.FALSE);
+    }
+
+    /**
+     * Get the vertical alignment value
+     *
+     * @return {@link STVerticalAlignRun.Enum} value (see 22.9.2.17 ST_VerticalAlignRun (Vertical Positioning Location))
+     */
+    public STVerticalAlignRun.Enum getVerticalAlignment() {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTVerticalAlignRun vertAlign = pr.isSetVertAlign() ? pr.getVertAlign() : pr.addNewVertAlign();
+        STVerticalAlignRun.Enum val = vertAlign.getVal();
+        if (val == null) {
+            val = STVerticalAlignRun.BASELINE;
+        }
+        return val;
+    }
+
+    /**
+     * Set the vertical alignment of the run.
+     *
+     * @param verticalAlignment Vertical alignment value, one of "baseline", "superscript", or "subscript".
+     */
+    public void setVerticalAlignment(String verticalAlignment) {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTVerticalAlignRun vertAlign = pr.getVertAlign();
+        STVerticalAlignRun align = vertAlign.xgetVal();
+        if (align == null) {
+            align = STVerticalAlignRun.Factory.newInstance();            
+        }
+        STVerticalAlignRun.Enum val = STVerticalAlignRun.Enum.forString(verticalAlignment);
+        if (val != null) {
+            align.setStringValue(val.toString());
+            vertAlign.xsetVal(align);
+        }
+        
+        
+    }
+
+    /**
+     * Get the emphasis mark value for the run.
+     *
+     * @return {@link STEm.Enum} emphasis mark type enumeration. See 17.18.24 ST_Em (Emphasis Mark Type).
+     */
+    public STEm.Enum getEmphasisMark() {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTEm emphasis = pr.isSetEm() ? pr.getEm() : pr.addNewEm();
+        
+        STEm.Enum val = emphasis.getVal();
+        if (val == null) {
+            val = STEm.NONE;
+        }
+        return val;
+    }
+
+    /**
+     * Set the emphasis mark for the run. The emphasis mark goes above or below the run
+     * text.
+     *
+     * @param markType Emphasis mark type name, e.g., "dot" or "none". See 17.18.24 ST_Em (Emphasis Mark Type)
+     */
+    public void setEmphasisMark(String markType) {
+        CTRPr pr = run.isSetRPr() ? run.getRPr() : run.addNewRPr();
+        CTEm emphasisMark = pr.getEm();
+        STEm mark = emphasisMark.xgetVal();
+        if (mark == null) {
+            mark = STEm.Factory.newInstance();            
+        }
+        STEm.Enum val = STEm.Enum.forString(markType);
+        if (val != null) {
+            mark.setStringValue(val.toString());
+            emphasisMark.xsetVal(mark);
+        }
+
+        
+    }
+
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFSDT.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFSDT.java
@@ -25,7 +25,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSdtRun;
  * <p>
  * WARNING - APIs expected to change rapidly
  */
-public class XWPFSDT extends AbstractXWPFSDT
+public class XWPFSDT extends XWPFAbstractSDT
         implements IBodyElement, IRunBody, ISDTContents, IRunElement {
     private final ISDTContent content;
 

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFSDTCell.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFSDTCell.java
@@ -27,7 +27,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSdtCell;
  * <p>
  * WARNING - APIs expected to change rapidly
  */
-public class XWPFSDTCell extends AbstractXWPFSDT implements ICell {
+public class XWPFSDTCell extends XWPFAbstractSDT implements ICell {
     private final XWPFSDTContentCell cellContent;
 
     public XWPFSDTCell(CTSdtCell sdtCell, XWPFTableRow xwpfTableRow, IBody part) {

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFFootnotes.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFFootnotes.java
@@ -31,11 +31,11 @@ public class TestXWPFFootnotes extends TestCase {
     public void testCreateFootnotes() throws IOException{
         XWPFDocument docOut = new XWPFDocument();
 
-        AbstractXWPFFootnotesEndnotes footnotes = docOut.createFootnotes();
+        XWPFAbstractFootnotesEndnotes footnotes = docOut.createFootnotes();
         
         assertNotNull(footnotes);
         
-        AbstractXWPFFootnotesEndnotes secondFootnotes = docOut.createFootnotes();
+        XWPFAbstractFootnotesEndnotes secondFootnotes = docOut.createFootnotes();
         
         assertSame(footnotes, secondFootnotes);
         

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -45,6 +45,7 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.STBrClear;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STEm;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHighlightColor;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STOnOff;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.STThemeColor;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STUnderline;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STVerticalAlignRun;
 
@@ -729,6 +730,19 @@ public class TestXWPFRun {
         assertEquals(colorRgb.toUpperCase(), run.getUnderlineColor());
         run.setUnderlineColor("auto");
         assertEquals("auto", run.getUnderlineColor());
+        document.close();
+    }
+    
+    @Test
+    public void testSetGetUnderlineThemeColor() throws IOException {
+        XWPFDocument document = new XWPFDocument();
+        final XWPFRun run = document.createParagraph().createRun();
+        assertEquals(STThemeColor.NONE, run.getUnderlineThemeColor());
+        String colorName = "accent4";
+        run.setUnderlineThemeColor(colorName);
+        assertEquals(STThemeColor.Enum.forString(colorName), run.getUnderlineThemeColor());
+        run.setUnderlineThemeColor("none");
+        assertEquals(STThemeColor.NONE, run.getUnderlineThemeColor());
         document.close();
     }
     

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -719,6 +719,19 @@ public class TestXWPFRun {
         document.close();
     }
     
+    @Test
+    public void testSetGetUnderlineColor() throws IOException {
+        XWPFDocument document = new XWPFDocument();
+        final XWPFRun run = document.createParagraph().createRun();
+        assertEquals("auto", run.getUnderlineColor());
+        String colorRgb = "C0F1a2";
+        run.setUnderlineColor(colorRgb);
+        assertEquals(colorRgb.toUpperCase(), run.getUnderlineColor());
+        run.setUnderlineColor("auto");
+        assertEquals("auto", run.getUnderlineColor());
+        document.close();
+    }
+    
 
     @Test
     public void testSetStyleId() throws IOException {

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -214,7 +214,7 @@ public class TestXWPFRun {
         XWPFRun run = new XWPFRun(ctRun, irb);
         run.setColor("0F0F0F");
         String clr = run.getColor();
-        assertEquals("0F0F0F", clr);        
+        assertEquals("0F0F0F", clr);
     }
 
     @Test
@@ -729,8 +729,7 @@ public class TestXWPFRun {
         run.setStyle(styleId);
         String candStyleId = run.getCTR().getRPr().getRStyle().getVal();
         assertNotNull("Expected to find a run style ID", candStyleId);
-        assertEquals(styleId, candStyleId);
-        
+        assertEquals(styleId, candStyleId);        
     }
 
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
@@ -40,8 +40,8 @@ public final class TestXWPFSDT {
         XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug54849.docx");
         String tag = null;
         String title = null;
-        List<AbstractXWPFSDT> sdts = extractAllSDTs(doc);
-        for (AbstractXWPFSDT sdt : sdts) {
+        List<XWPFAbstractSDT> sdts = extractAllSDTs(doc);
+        for (XWPFAbstractSDT sdt : sdts) {
             if (sdt.getContent().toString().equals("Rich_text")) {
                 tag = "MyTag";
                 title = "MyTitle";
@@ -74,12 +74,12 @@ public final class TestXWPFSDT {
 
         };
         XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug54849.docx");
-        List<AbstractXWPFSDT> sdts = extractAllSDTs(doc);
+        List<XWPFAbstractSDT> sdts = extractAllSDTs(doc);
 
         assertEquals("number of sdts", contents.length, sdts.size());
 
         for (int i = 0; i < contents.length; i++) {
-            AbstractXWPFSDT sdt = sdts.get(i);
+            XWPFAbstractSDT sdt = sdts.get(i);
             assertEquals(i + ": " + contents[i], contents[i], sdt.getContent().toString());
         }
     }
@@ -92,7 +92,7 @@ public final class TestXWPFSDT {
         //Bug54771a.docx and Bug54771b.docx test slightly 
         //different recursion patterns. Keep both!
         XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug54771a.docx");
-        List<AbstractXWPFSDT> sdts = extractAllSDTs(doc);
+        List<XWPFAbstractSDT> sdts = extractAllSDTs(doc);
         String text = sdts.get(0).getContent().getText();
         assertEquals(2, sdts.size());
         assertContains(text, "Test");
@@ -118,7 +118,7 @@ public final class TestXWPFSDT {
     @Test
     public void testNewLinesBetweenRuns() throws Exception {
         XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug55142.docx");
-        List<AbstractXWPFSDT> sdts = extractAllSDTs(doc);
+        List<XWPFAbstractSDT> sdts = extractAllSDTs(doc);
         List<String> targs = new ArrayList<>();
         //these test newlines and tabs in paragraphs/body elements
         targs.add("Rich-text1 abcdefghi");
@@ -133,7 +133,7 @@ public final class TestXWPFSDT {
         targs.add("sdt_incell2 abcdefg");
 
         for (int i = 0; i < sdts.size(); i++) {
-            AbstractXWPFSDT sdt = sdts.get(i);
+            XWPFAbstractSDT sdt = sdts.get(i);
             assertEquals(targs.get(i), targs.get(i), sdt.getContent().getText());
         }
     }
@@ -142,15 +142,15 @@ public final class TestXWPFSDT {
     public void test60341() throws IOException {
         //handle sdtbody without an sdtpr
         XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug60341.docx");
-        List<AbstractXWPFSDT> sdts = extractAllSDTs(doc);
+        List<XWPFAbstractSDT> sdts = extractAllSDTs(doc);
         assertEquals(1, sdts.size());
         assertEquals("", sdts.get(0).getTag());
         assertEquals("", sdts.get(0).getTitle());
     }
 
-    private List<AbstractXWPFSDT> extractAllSDTs(XWPFDocument doc) {
+    private List<XWPFAbstractSDT> extractAllSDTs(XWPFDocument doc) {
 
-        List<AbstractXWPFSDT> sdts = new ArrayList<>();
+        List<XWPFAbstractSDT> sdts = new ArrayList<>();
 
         List<XWPFHeader> headers = doc.getHeaderList();
         for (XWPFHeader header : headers) {
@@ -172,8 +172,8 @@ public final class TestXWPFSDT {
         return sdts;
     }
 
-    private List<AbstractXWPFSDT> extractSDTsFromBodyElements(List<IBodyElement> elements) {
-        List<AbstractXWPFSDT> sdts = new ArrayList<>();
+    private List<XWPFAbstractSDT> extractSDTsFromBodyElements(List<IBodyElement> elements) {
+        List<XWPFAbstractSDT> sdts = new ArrayList<>();
         for (IBodyElement e : elements) {
             if (e instanceof XWPFSDT) {
                 XWPFSDT sdt = (XWPFSDT) e;
@@ -195,9 +195,9 @@ public final class TestXWPFSDT {
         return sdts;
     }
 
-    private List<AbstractXWPFSDT> extractSDTsFromTable(XWPFTable table) {
+    private List<XWPFAbstractSDT> extractSDTsFromTable(XWPFTable table) {
 
-        List<AbstractXWPFSDT> sdts = new ArrayList<>();
+        List<XWPFAbstractSDT> sdts = new ArrayList<>();
         for (XWPFTableRow r : table.getRows()) {
             for (ICell c : r.getTableICells()) {
                 if (c instanceof XWPFSDTCell) {


### PR DESCRIPTION
This adds getters and setters for additional Run formatting properties. My goal was to implement the properties likely to be used in generating DOCX from non-trivial HTML documents. The only property I couldn't figure out how to set was underline color, which I can come back to.

I also fixed a bug in isHighlight() that returned a false positive if highlight was not set at all (the test case was flawed and didn't catch this case).

I used the built-in OOXML enums so that I could set values using the same strings as specified in the OO XML spec rather than having to translate them to e.g., uppercase keywords as used with the custom enumerations (this is why I implemented setVerticalAlignment() as a replacement for setSubscript() [which was a bad method name anyway.]

I did not implement versions of the methods that involve enumerations to also allow direct specification of the enumeration values themselves--I can if there's a need for it, but for most uses it seems more likely that string values will be the input, e.g., from parsing of XML or HTML or whatever.