### PR TITLE
Bugzilla 59623: code inspired from Axel Richter on StackOverflow

### DIFF
--- a/src/examples/src/org/apache/poi/xssf/usermodel/examples/ExcelChartWithTargetLine.java
+++ b/src/examples/src/org/apache/poi/xssf/usermodel/examples/ExcelChartWithTargetLine.java
@@ -1,0 +1,230 @@
+/*
+ *  ====================================================================
+ *    Licensed to the Apache Software Foundation (ASF) under one or more
+ *    contributor license agreements.  See the NOTICE file distributed with
+ *    this work for additional information regarding copyright ownership.
+ *    The ASF licenses this file to You under the Apache License, Version 2.0
+ *    (the "License"); you may not use this file except in compliance with
+ *    the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * ====================================================================
+ */
+
+package org.apache.poi.xssf.usermodel.examples;
+
+import java.io.FileOutputStream;
+
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xddf.usermodel.PresetColor;
+import org.apache.poi.xddf.usermodel.XDDFColor;
+import org.apache.poi.xddf.usermodel.XDDFFillProperties;
+import org.apache.poi.xddf.usermodel.XDDFLineProperties;
+import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.XDDFSolidFillProperties;
+import org.apache.poi.xddf.usermodel.chart.AxisPosition;
+import org.apache.poi.xddf.usermodel.chart.AxisTickLabelPosition;
+import org.apache.poi.xddf.usermodel.chart.BarDirection;
+import org.apache.poi.xddf.usermodel.chart.ChartTypes;
+import org.apache.poi.xddf.usermodel.chart.LegendPosition;
+import org.apache.poi.xddf.usermodel.chart.XDDFBarChartData;
+import org.apache.poi.xddf.usermodel.chart.XDDFCategoryAxis;
+import org.apache.poi.xddf.usermodel.chart.XDDFCategoryDataSource;
+import org.apache.poi.xddf.usermodel.chart.XDDFChartLegend;
+import org.apache.poi.xddf.usermodel.chart.XDDFDataSourcesFactory;
+import org.apache.poi.xddf.usermodel.chart.XDDFLegendEntry;
+import org.apache.poi.xddf.usermodel.chart.XDDFNumericalDataSource;
+import org.apache.poi.xddf.usermodel.chart.XDDFScatterChartData;
+import org.apache.poi.xddf.usermodel.chart.XDDFValueAxis;
+import org.apache.poi.xddf.usermodel.text.XDDFRunProperties;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFChart;
+import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
+import org.apache.poi.xssf.usermodel.XSSFDrawing;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+/**
+ * This example is based on original contributions by Axel Richter on StackOverflow.
+ *
+ * <em>Note from original author</em>:
+ * This only works for Excel since OpenOffice or LibreOffice Calc is not able having series having literal numeric values set.
+ *
+ * @see <a href="https://stackoverflow.com/questions/50772989/">Create target marker in a bar chart with openxmlformats</a>
+ * @see <a href="https://stackoverflow.com/questions/50873700/">Change axis color and font of the chart in openxmlformats</a>
+ * @see <a href="https://stackoverflow.com/questions/51530552/">Change colors of line chart Apache POI</a>
+ */
+class ExcelChartWithTargetLine {
+
+    private static final int NUM_OF_ROWS = 6;
+
+    private static void createChart(XSSFChart chart, XSSFSheet sheet, int[] chartedCols, double target) {
+        // some colors
+        XDDFFillProperties[] fills = new XDDFFillProperties[] {
+            new XDDFSolidFillProperties(XDDFColor.from(PresetColor.TURQUOISE)),
+            new XDDFSolidFillProperties(XDDFColor.from(PresetColor.CHARTREUSE)),
+            new XDDFSolidFillProperties(XDDFColor.from(PresetColor.LAVENDER)),
+            new XDDFSolidFillProperties(XDDFColor.from(PresetColor.CHOCOLATE)),
+            new XDDFSolidFillProperties(XDDFColor.from(PresetColor.TOMATO)),
+            new XDDFSolidFillProperties(XDDFColor.from(PresetColor.PLUM))
+        };
+        XDDFLineProperties solidTurquoise = new XDDFLineProperties(fills[0]);
+        XDDFLineProperties solidTomato = new XDDFLineProperties(fills[4]);
+        XDDFLineProperties solidPlum = new XDDFLineProperties(fills[5]);
+        XDDFSolidFillProperties solidAlmond = new XDDFSolidFillProperties(XDDFColor.from(PresetColor.BLANCHED_ALMOND));
+        XDDFSolidFillProperties solidGray = new XDDFSolidFillProperties(XDDFColor.from(PresetColor.DARK_SLATE_GRAY));
+
+
+        // the bar chart
+
+        XDDFCategoryAxis barCategories = chart.createCategoryAxis(AxisPosition.BOTTOM);
+        XDDFValueAxis leftValues = chart.createValueAxis(AxisPosition.LEFT);
+        leftValues.crossAxis(barCategories);
+        barCategories.crossAxis(leftValues);
+
+        // from https://stackoverflow.com/questions/50873700/
+        // colored major grid lines
+        leftValues.getOrAddMajorGridProperties().setLineProperties(solidTomato);
+        //colored axis line
+        leftValues.getOrAddShapeProperties().setLineProperties(solidPlum);
+        // axis font
+        XDDFRunProperties props = leftValues.getOrAddTextProperties();
+        props.setFontSize(14.0);
+        props.setFillProperties(fills[5]);
+
+        XDDFBarChartData bar = (XDDFBarChartData) chart.createData(ChartTypes.BAR, barCategories, leftValues);
+        bar.setVaryColors(true);
+        bar.setBarDirection(chartedCols.length > 1 ? BarDirection.COL : BarDirection.BAR);
+
+        for (int c : chartedCols) {
+            // the data sources
+            XDDFCategoryDataSource xs = XDDFDataSourcesFactory.fromStringCellRange(sheet,
+                    new CellRangeAddress(1, NUM_OF_ROWS, 0, 0));
+            XDDFNumericalDataSource<Double> ys = XDDFDataSourcesFactory.fromNumericCellRange(sheet,
+                    new CellRangeAddress(1, NUM_OF_ROWS, c, c));
+            XDDFBarChartData.Series series = (XDDFBarChartData.Series) bar.addSeries(xs, ys);
+            series.setTitle(null, new CellReference(sheet.getSheetName(), 0, c, true, true));
+            series.setFillProperties(fills[c]);
+            series.setLineProperties(solidTurquoise); // bar border color different from fill
+        }
+        chart.plot(bar);
+
+
+        // target line
+        // line of a scatter chart from 0 (min) to 1 (max) having value of target
+
+        XDDFValueAxis scatterX = chart.createValueAxis(AxisPosition.TOP);
+        scatterX.setVisible(false);
+        scatterX.setTickLabelPosition(AxisTickLabelPosition.NONE);
+        XDDFValueAxis scatterY = chart.createValueAxis(AxisPosition.RIGHT);
+        scatterY.setVisible(false);
+        scatterY.setTickLabelPosition(AxisTickLabelPosition.NONE);
+        scatterX.crossAxis(scatterY);
+        scatterY.crossAxis(scatterX);
+        if (chartedCols.length > 1) {
+            scatterX.setMaximum(1.0);
+        } else {
+            scatterY.setMaximum(1.0);
+        }
+
+        XDDFScatterChartData scatter = (XDDFScatterChartData) chart.createData(ChartTypes.SCATTER, scatterX, scatterY);
+        scatter.setVaryColors(true);
+
+        //  This only works for Excel since OpenOffice or LibreOffice Calc does not support literal numeric data series.
+        XDDFNumericalDataSource<Double> targetDS = XDDFDataSourcesFactory.fromArray(new Double[] { target, target });
+        XDDFNumericalDataSource<Double> zeroOneDS = XDDFDataSourcesFactory.fromArray(new Double[] { 0.0, 1.0 });
+
+        if (chartedCols.length > 1) {
+            // BarDirection.COL then X axis is from 0 to 1 and Y axis is target axis
+            scatter.addSeries(zeroOneDS, targetDS).setLineProperties(solidTurquoise);
+        } else {
+            // BarDirection.BAR then X axis is target axis and Y axis is from 0 to 1
+            scatter.addSeries(targetDS, zeroOneDS).setLineProperties(solidTurquoise);
+        }
+
+        chart.plot(scatter);
+
+
+        // legend
+        if (chartedCols.length > 1) {
+            XDDFChartLegend legend = chart.getOrAddLegend();
+            legend.setPosition(LegendPosition.LEFT);
+            legend.setOverlay(false);
+
+            // delete additional target line series legend entry
+            XDDFLegendEntry entry = legend.addEntry();
+            entry.setIndex(0);
+            entry.setDelete(true);
+        }
+
+
+        // from https://stackoverflow.com/questions/51530552/
+        // customize the chart
+
+        // do not auto delete the title
+        chart.setAutoTitleDeleted(false);
+
+        // plot area background and border line
+        XDDFShapeProperties chartProps = chart.getOrAddShapeProperties();
+        chartProps.setFillProperties(solidAlmond);
+        chartProps.setLineProperties(new XDDFLineProperties(solidGray));
+
+        // line style of cat axis
+        XDDFLineProperties categoriesProps = new XDDFLineProperties(solidGray);
+        categoriesProps.setWidth(2.1);
+        barCategories.getOrAddShapeProperties().setLineProperties(categoriesProps);
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet("targetline");
+        final int NUM_OF_COLUMNS = 4;
+
+        // create some data
+        XSSFRow row;
+        XSSFCell cell;
+        String[] headings = new String[] { "Year", "Male", "Female", "Other" };
+        int rowIndex = 0;
+        row = sheet.createRow(rowIndex);
+        for (int colIndex = 0; colIndex < NUM_OF_COLUMNS; colIndex++) {
+            cell = row.createCell(colIndex);
+            cell.setCellValue(headings[colIndex]);
+        }
+        double[][] values = new double[][] { new double[] { 1980, 56.0, 44.1, 12.2 },
+                new double[] { 1985, 34.5, 41.0, 4 }, new double[] { 1990, 65.0, 68.5, 9.1 },
+                new double[] { 1995, 34.7, 47.6, 4.9 }, new double[] { 2000, 23.0, 64.5, 11.1 },
+                new double[] { 2005, 56.3, 69.8, 9.5 } };
+        for (; rowIndex < NUM_OF_ROWS; rowIndex++) {
+            row = sheet.createRow(rowIndex + 1);
+            for (int colIndex = 0; colIndex < NUM_OF_COLUMNS; colIndex++) {
+                cell = row.createCell(colIndex);
+                cell.setCellValue(values[rowIndex][colIndex]);
+            }
+        }
+
+        int[] chartedCols = new int[] {  1,  2  , 3  };
+
+        XSSFDrawing drawing = sheet.createDrawingPatriarch();
+        XSSFClientAnchor anchor = null;
+        if (chartedCols.length > 1) {
+            anchor = drawing.createAnchor(0, 0, 0, 0, 0, 8, 10, 23);
+        } else {
+            anchor = drawing.createAnchor(0, 0, 0, 0, 0, 8, 5, 23);
+        }
+        XSSFChart chart = drawing.createChart(anchor);
+        createChart(chart, sheet, chartedCols, 42.0);
+
+        workbook.write(new FileOutputStream("ExcelChartWithTargetLine.xlsx"));
+        workbook.close();
+
+    }
+}

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/Angles.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/Angles.java
@@ -1,0 +1,36 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.xddf.usermodel;
+
+public class Angles {
+    /**
+     * OOXML represents an angle in 60,000ths of a degree.
+     *
+     * Positive angles are clockwise (i.e., towards the positive y axis);
+     * negative angles are counter-clockwise (i.e., towards the negative y axis).
+     */
+    public static final int OOXML_DEGREE = 60_000;
+
+    public static final int degreesToAttribute(double angle) {
+        return (int) (OOXML_DEGREE * angle);
+    }
+
+    public static final double attributeToDegrees(int angle) {
+        return angle / ((double) OOXML_DEGREE);
+    }
+}

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/XDDFLineProperties.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/XDDFLineProperties.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
+import org.apache.poi.util.Units;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTLineProperties;
 
 @Beta
@@ -31,6 +32,16 @@ public class XDDFLineProperties {
 
     public XDDFLineProperties() {
         this(CTLineProperties.Factory.newInstance());
+    }
+
+    /**
+     * @param fill
+     *      fill properties to set on the new line properties.
+     * @since POI 4.0.2
+     */
+    public XDDFLineProperties(XDDFFillProperties fill) {
+        this();
+        this.setFillProperties(fill);
     }
 
     @Internal
@@ -293,21 +304,29 @@ public class XDDFLineProperties {
         }
     }
 
-    public Integer getWidth() {
+    /**
+     * @return the width expressed in points.
+     */
+    public Double getWidth() {
         if (props.isSetW()) {
-            return props.getW();
+            return Units.toPoints(props.getW());
         } else {
             return null;
         }
     }
 
-    public void setWidth(Integer width) {
+    /**
+     * Internally converts the width to EMU units.
+     *
+     * @param width expressed in points.
+     */
+    public void setWidth(Double width) {
         if (width == null) {
             if (props.isSetW()) {
                 props.unsetW();
             }
         } else {
-            props.setW(width);
+            props.setW(Units.toEMU(width));
         }
     }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/XDDFLinearShadeProperties.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/XDDFLinearShadeProperties.java
@@ -34,21 +34,24 @@ public class XDDFLinearShadeProperties {
         return props;
     }
 
-    public Integer getAngle() {
+    public Double getAngle() {
         if (props.isSetAng()) {
-            return props.getAng();
+            return Angles.attributeToDegrees(props.getAng());
         } else {
             return null;
         }
     }
 
-    public void setAngle(Integer angle) {
+    public void setAngle(Double angle) {
         if (angle == null) {
             if (props.isSetAng()) {
                 props.unsetAng();
             }
         } else {
-            props.setAng(angle);
+            if (angle < 0.0 || 360.0 <= angle) {
+                throw new IllegalArgumentException("angle must be in the range [0, 360).");
+            }
+            props.setAng(Angles.degreesToAttribute(angle));
         }
     }
 

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/XDDFTransform2D.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/XDDFTransform2D.java
@@ -120,21 +120,21 @@ public class XDDFTransform2D {
         xformOff.setY(offset.getY());
     }
 
-    public Integer getRotation() {
+    public Double getRotation() {
         if (transform.isSetRot()) {
-            return transform.getRot();
+            return Angles.attributeToDegrees(transform.getRot());
         } else {
             return null;
         }
     }
 
-    public void setRotation(Integer rotation) {
+    public void setRotation(Double rotation) {
         if (rotation == null) {
             if (transform.isSetRot()) {
                 transform.unsetRot();
             }
         } else {
-            transform.setRot(rotation);
+            transform.setRot(Angles.degreesToAttribute(rotation));
         }
     }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFArea3DChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFArea3DChartData.java
@@ -32,8 +32,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFArea3DChartData extends XDDFChartData {
     private CTArea3DChart chart;
 
-    public XDDFArea3DChartData(CTArea3DChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFArea3DChartData(
+            XDDFChart parent,
+            CTArea3DChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTAreaSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -202,12 +207,12 @@ public class XDDFArea3DChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFAreaChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFAreaChartData.java
@@ -32,8 +32,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFAreaChartData extends XDDFChartData {
     private CTAreaChart chart;
 
-    public XDDFAreaChartData(CTAreaChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFAreaChartData(
+            XDDFChart parent,
+            CTAreaChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTAreaSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -180,12 +185,12 @@ public class XDDFAreaChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFBar3DChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFBar3DChartData.java
@@ -32,8 +32,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFBar3DChartData extends XDDFChartData {
     private CTBar3DChart chart;
 
-    public XDDFBar3DChartData(CTBar3DChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFBar3DChartData(
+            XDDFChart parent,
+            CTBar3DChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         if (chart.getBarDir() == null) {
             chart.addNewBarDir().setVal(BarDirection.BAR.underlying);
@@ -258,12 +263,12 @@ public class XDDFBar3DChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFBarChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFBarChartData.java
@@ -32,8 +32,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFBarChartData extends XDDFChartData {
     private CTBarChart chart;
 
-    public XDDFBarChartData(CTBarChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFBarChartData(
+            XDDFChart parent,
+            CTBarChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         if (chart.getBarDir() == null) {
             chart.addNewBarDir().setVal(BarDirection.BAR.underlying);
@@ -163,7 +168,7 @@ public class XDDFBarChartData extends XDDFChartData {
     @Override
     public XDDFChartData.Series addSeries(XDDFDataSource<?> category,
             XDDFNumericalDataSource<? extends Number> values) {
-        final int index = this.series.size();
+        final long index = this.parent.incrementSeriesCount();
         final CTBarSer ctSer = this.chart.addNewSer();
         ctSer.addNewTx();
         ctSer.addNewCat();

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFCategoryAxis.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFCategoryAxis.java
@@ -19,6 +19,7 @@ package org.apache.poi.xddf.usermodel.chart;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.text.XDDFRunProperties;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTAxPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTBoolean;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTCatAx;
@@ -27,10 +28,11 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTCrosses;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumFmt;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTPlotArea;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTScaling;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickMark;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTUnsignedInt;
-import org.openxmlformats.schemas.drawingml.x2006.chart.STTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTShapeProperties;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextBody;
 
 @Beta
 public class XDDFCategoryAxis extends XDDFChartAxis {
@@ -75,8 +77,21 @@ public class XDDFCategoryAxis extends XDDFChartAxis {
         } else {
             properties = ctCatAx.addNewSpPr();
         }
-
         return new XDDFShapeProperties(properties);
+    }
+
+    /**
+     * @since POI 4.0.2
+     */
+    @Override
+    public XDDFRunProperties getOrAddTextProperties() {
+        CTTextBody text;
+        if (ctCatAx.isSetTxPr()) {
+            text = ctCatAx.getTxPr();
+        } else {
+            text = ctCatAx.addNewTxPr();
+        }
+        return new XDDFRunProperties(getOrAddTextProperties(text));
     }
 
     /**
@@ -180,6 +195,11 @@ public class XDDFCategoryAxis extends XDDFChartAxis {
         return ctCatAx.getMinorTickMark();
     }
 
+    @Override
+    protected CTTickLblPos getCTTickLblPos() {
+        return ctCatAx.getTickLblPos();
+    }
+
     public AxisLabelAlignment getLabelAlignment() {
         return AxisLabelAlignment.valueOf(ctCatAx.getLblAlgn().getVal());
     }
@@ -196,7 +216,7 @@ public class XDDFCategoryAxis extends XDDFChartAxis {
         ctCatAx.addNewScaling();
         ctCatAx.addNewCrosses();
         ctCatAx.addNewCrossAx();
-        ctCatAx.addNewTickLblPos().setVal(STTickLblPos.NEXT_TO);
+        ctCatAx.addNewTickLblPos();
         ctCatAx.addNewDelete();
         ctCatAx.addNewMajorTickMark();
         ctCatAx.addNewMinorTickMark();
@@ -207,5 +227,6 @@ public class XDDFCategoryAxis extends XDDFChartAxis {
         setVisible(true);
         setMajorTickMark(AxisTickMark.CROSS);
         setMinorTickMark(AxisTickMark.NONE);
+        setTickLabelPosition(AxisTickLabelPosition.NEXT_TO);
     }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFCategoryDataSource.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFCategoryDataSource.java
@@ -29,6 +29,11 @@ public interface XDDFCategoryDataSource extends XDDFDataSource<String> {
     }
 
     @Override
+    default boolean isLiteral() {
+        return false;
+    }
+
+    @Override
     default boolean isNumeric() {
         return false;
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFChart.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFChart.java
@@ -383,11 +383,23 @@ public abstract class XDDFChart extends POIXMLDocumentPart implements TextContai
         return new XDDFManualLayout(chart.getPlotArea());
     }
 
+    private long seriesCount = 0;
+    protected long incrementSeriesCount() {
+        return seriesCount++;
+    }
+
     public void plot(XDDFChartData data) {
         XSSFSheet sheet = getSheet();
         for (XDDFChartData.Series series : data.getSeries()) {
             series.plot();
-            fillSheet(sheet, series.getCategoryData(), series.getValuesData());
+            XDDFDataSource<?> categoryDS = series.getCategoryData();
+            XDDFNumericalDataSource<? extends Number> valuesDS = series.getValuesData();
+            if (categoryDS.isReference() || valuesDS.isReference()
+                    || categoryDS.isLiteral() || valuesDS.isLiteral()) {
+                // let's assume the data is already in the sheet
+            } else {
+                fillSheet(sheet, categoryDS, valuesDS);
+            }
         }
     }
 
@@ -399,62 +411,62 @@ public abstract class XDDFChart extends POIXMLDocumentPart implements TextContai
 
         for (int i = 0; i < plotArea.sizeOfAreaChartArray(); i++) {
             CTAreaChart areaChart = plotArea.getAreaChartArray(i);
-            series.add(new XDDFAreaChartData(areaChart, categories, values));
+            series.add(new XDDFAreaChartData(this, areaChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfArea3DChartArray(); i++) {
             CTArea3DChart areaChart = plotArea.getArea3DChartArray(i);
-            series.add(new XDDFArea3DChartData(areaChart, categories, values));
+            series.add(new XDDFArea3DChartData(this, areaChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfBarChartArray(); i++) {
             CTBarChart barChart = plotArea.getBarChartArray(i);
-            series.add(new XDDFBarChartData(barChart, categories, values));
+            series.add(new XDDFBarChartData(this, barChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfBar3DChartArray(); i++) {
             CTBar3DChart barChart = plotArea.getBar3DChartArray(i);
-            series.add(new XDDFBar3DChartData(barChart, categories, values));
+            series.add(new XDDFBar3DChartData(this, barChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfLineChartArray(); i++) {
             CTLineChart lineChart = plotArea.getLineChartArray(i);
-            series.add(new XDDFLineChartData(lineChart, categories, values));
+            series.add(new XDDFLineChartData(this, lineChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfLine3DChartArray(); i++) {
             CTLine3DChart lineChart = plotArea.getLine3DChartArray(i);
-            series.add(new XDDFLine3DChartData(lineChart, categories, values));
+            series.add(new XDDFLine3DChartData(this, lineChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfPieChartArray(); i++) {
             CTPieChart pieChart = plotArea.getPieChartArray(i);
-            series.add(new XDDFPieChartData(pieChart));
+            series.add(new XDDFPieChartData(this, pieChart));
         }
 
         for (int i = 0; i < plotArea.sizeOfPie3DChartArray(); i++) {
             CTPie3DChart pieChart = plotArea.getPie3DChartArray(i);
-            series.add(new XDDFPie3DChartData(pieChart));
+            series.add(new XDDFPie3DChartData(this, pieChart));
         }
 
         for (int i = 0; i < plotArea.sizeOfRadarChartArray(); i++) {
             CTRadarChart radarChart = plotArea.getRadarChartArray(i);
-            series.add(new XDDFRadarChartData(radarChart, categories, values));
+            series.add(new XDDFRadarChartData(this, radarChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfScatterChartArray(); i++) {
             CTScatterChart scatterChart = plotArea.getScatterChartArray(i);
-            series.add(new XDDFScatterChartData(scatterChart, categories, values));
+            series.add(new XDDFScatterChartData(this, scatterChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfSurfaceChartArray(); i++) {
             CTSurfaceChart surfaceChart = plotArea.getSurfaceChartArray(i);
-            series.add(new XDDFSurfaceChartData(surfaceChart, categories, values));
+            series.add(new XDDFSurfaceChartData(this, surfaceChart, categories, values));
         }
 
         for (int i = 0; i < plotArea.sizeOfSurface3DChartArray(); i++) {
             CTSurface3DChart surfaceChart = plotArea.getSurface3DChartArray(i);
-            series.add(new XDDFSurface3DChartData(surfaceChart, categories, values));
+            series.add(new XDDFSurface3DChartData(this, surfaceChart, categories, values));
         }
 
         // TODO repeat above code for missing charts: Bubble, Doughnut, OfPie and Stock
@@ -553,29 +565,29 @@ public abstract class XDDFChart extends POIXMLDocumentPart implements TextContai
         final CTPlotArea plotArea = getCTPlotArea();
         switch (type) {
         case AREA:
-            return new XDDFAreaChartData(plotArea.addNewAreaChart(), categories, mapValues);
+            return new XDDFAreaChartData(this, plotArea.addNewAreaChart(), categories, mapValues);
         case AREA3D:
-            return new XDDFArea3DChartData(plotArea.addNewArea3DChart(), categories, mapValues);
+            return new XDDFArea3DChartData(this, plotArea.addNewArea3DChart(), categories, mapValues);
         case BAR:
-            return new XDDFBarChartData(plotArea.addNewBarChart(), categories, mapValues);
+            return new XDDFBarChartData(this, plotArea.addNewBarChart(), categories, mapValues);
         case BAR3D:
-            return new XDDFBar3DChartData(plotArea.addNewBar3DChart(), categories, mapValues);
+            return new XDDFBar3DChartData(this, plotArea.addNewBar3DChart(), categories, mapValues);
         case LINE:
-            return new XDDFLineChartData(plotArea.addNewLineChart(), categories, mapValues);
+            return new XDDFLineChartData(this, plotArea.addNewLineChart(), categories, mapValues);
         case LINE3D:
-            return new XDDFLine3DChartData(plotArea.addNewLine3DChart(), categories, mapValues);
+            return new XDDFLine3DChartData(this, plotArea.addNewLine3DChart(), categories, mapValues);
         case PIE:
-            return new XDDFPieChartData(plotArea.addNewPieChart());
+            return new XDDFPieChartData(this, plotArea.addNewPieChart());
         case PIE3D:
-            return new XDDFPie3DChartData(plotArea.addNewPie3DChart());
+            return new XDDFPie3DChartData(this, plotArea.addNewPie3DChart());
         case RADAR:
-            return new XDDFRadarChartData(plotArea.addNewRadarChart(), categories, mapValues);
+            return new XDDFRadarChartData(this, plotArea.addNewRadarChart(), categories, mapValues);
         case SCATTER:
-            return new XDDFScatterChartData(plotArea.addNewScatterChart(), categories, mapValues);
+            return new XDDFScatterChartData(this, plotArea.addNewScatterChart(), categories, mapValues);
         case SURFACE:
-            return new XDDFSurfaceChartData(plotArea.addNewSurfaceChart(), categories, mapValues);
+            return new XDDFSurfaceChartData(this, plotArea.addNewSurfaceChart(), categories, mapValues);
         case SURFACE3D:
-            return new XDDFSurface3DChartData(plotArea.addNewSurface3DChart(), categories, mapValues);
+            return new XDDFSurface3DChartData(this, plotArea.addNewSurface3DChart(), categories, mapValues);
         default:
             return null;
         }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFChartAxis.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFChartAxis.java
@@ -20,6 +20,7 @@ package org.apache.poi.xddf.usermodel.chart;
 import org.apache.poi.util.Beta;
 import org.apache.poi.xddf.usermodel.HasShapeProperties;
 import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.text.XDDFRunProperties;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTAxPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTBoolean;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTChartLines;
@@ -27,9 +28,14 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTCrosses;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumFmt;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTPlotArea;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTScaling;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickMark;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTUnsignedInt;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTShapeProperties;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextBody;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextCharacterProperties;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextParagraph;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextParagraphProperties;
 
 /**
  * Base class for all axis types.
@@ -52,9 +58,16 @@ public abstract class XDDFChartAxis implements HasShapeProperties {
 
     protected abstract CTTickMark getMinorCTTickMark();
 
+    protected abstract CTTickLblPos getCTTickLblPos();
+
     public abstract XDDFShapeProperties getOrAddMajorGridProperties();
 
     public abstract XDDFShapeProperties getOrAddMinorGridProperties();
+
+    /**
+     * @since POI 4.0.2
+     */
+    public abstract XDDFRunProperties getOrAddTextProperties();
 
     /**
      * @since 4.0.1
@@ -340,6 +353,48 @@ public abstract class XDDFChartAxis implements HasShapeProperties {
      */
     public void setMinorTickMark(AxisTickMark tickMark) {
         getMinorCTTickMark().setVal(tickMark.underlying);
+    }
+
+    /**
+     * @return tick label position.
+     * @since POI 4.0.2
+     */
+    public AxisTickLabelPosition getTickLabelPosition() {
+        return AxisTickLabelPosition.valueOf(getCTTickLblPos().getVal());
+    }
+
+    /**
+     * @param labelPosition
+     *            tick label position.
+     * @since POI 4.0.2
+     */
+    public void setTickLabelPosition(AxisTickLabelPosition labelPosition) {
+        getCTTickLblPos().setVal(labelPosition.underlying);
+    }
+
+    protected CTTextCharacterProperties getOrAddTextProperties(CTTextBody body) {
+        CTTextCharacterProperties properties;
+        if (body.getBodyPr() == null) {
+            body.addNewBodyPr();
+        }
+        CTTextParagraph paragraph;
+        if (body.sizeOfPArray() > 0) {
+            paragraph = body.getPArray(0);
+        } else {
+            paragraph = body.addNewP();
+        }
+        CTTextParagraphProperties paraprops;
+        if (paragraph.isSetPPr()) {
+            paraprops = paragraph.getPPr();
+        } else {
+            paraprops = paragraph.addNewPPr();
+        }
+        if (paraprops.isSetDefRPr()) {
+            properties = paraprops.getDefRPr();
+        } else {
+            properties = paraprops.addNewDefRPr();
+        }
+        return properties;
     }
 
     protected CTShapeProperties getOrAddLinesProperties(CTChartLines gridlines) {

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
@@ -27,6 +27,11 @@ public interface XDDFDataSource<T> {
 
     T getPointAt(int index);
 
+    /**
+     * @since POI 4.0.2
+     */
+    boolean isLiteral();
+
     boolean isReference();
 
     boolean isNumeric();

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSourcesFactory.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSourcesFactory.java
@@ -32,7 +32,8 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumDataSource;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTStrData;
 
 /**
- * Class {@code XDDFDataSourcesFactory} is a factory for {@link XDDFDataSource} instances.
+ * Class {@code XDDFDataSourcesFactory} is a factory for {@link XDDFDataSource}
+ * instances.
  */
 @Beta
 public class XDDFDataSourcesFactory {
@@ -137,6 +138,14 @@ public class XDDFDataSourcesFactory {
                 return 0;
             }
         };
+    }
+
+    public static <T extends Number> XDDFNumericalDataSource<T> fromArray(T[] elements) {
+        return new LiteralNumericalArrayDataSource<>(elements);
+    }
+
+    public static XDDFCategoryDataSource fromArray(String[] elements) {
+        return new LiteralStringArrayDataSource(elements);
     }
 
     public static <T extends Number> XDDFNumericalDataSource<T> fromArray(T[] elements, String dataRange) {
@@ -257,6 +266,28 @@ public class XDDFDataSourcesFactory {
         @Override
         public String getFormula() {
             return getDataRangeReference();
+        }
+    }
+
+    private static class LiteralNumericalArrayDataSource<T extends Number> extends NumericalArrayDataSource<T> {
+        public LiteralNumericalArrayDataSource(T[] elements) {
+            super(elements, null, 0);
+        }
+
+        @Override
+        public boolean isLiteral() {
+            return true;
+        }
+    }
+
+    private static class LiteralStringArrayDataSource extends StringArrayDataSource {
+        public LiteralStringArrayDataSource(String[] elements) {
+            super(elements, null, 0);
+        }
+
+        @Override
+        public boolean isLiteral() {
+            return true;
         }
     }
 

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFDateAxis.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFDateAxis.java
@@ -19,6 +19,7 @@ package org.apache.poi.xddf.usermodel.chart;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.text.XDDFRunProperties;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTAxPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTBoolean;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTChartLines;
@@ -27,10 +28,11 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTDateAx;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumFmt;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTPlotArea;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTScaling;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickMark;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTUnsignedInt;
-import org.openxmlformats.schemas.drawingml.x2006.chart.STTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTShapeProperties;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextBody;
 
 /**
  * Date axis type. Currently only implements the same values as
@@ -80,6 +82,20 @@ public class XDDFDateAxis extends XDDFChartAxis {
             properties = ctDateAx.addNewSpPr();
         }
         return new XDDFShapeProperties(properties);
+    }
+
+    /**
+     * @since POI 4.0.2
+     */
+    @Override
+    public XDDFRunProperties getOrAddTextProperties() {
+        CTTextBody text;
+        if (ctDateAx.isSetTxPr()) {
+            text = ctDateAx.getTxPr();
+        } else {
+            text = ctDateAx.addNewTxPr();
+        }
+        return new XDDFRunProperties(getOrAddTextProperties(text));
     }
 
     /**
@@ -211,6 +227,11 @@ public class XDDFDateAxis extends XDDFChartAxis {
         return ctDateAx.getMinorTickMark();
     }
 
+    @Override
+    protected CTTickLblPos getCTTickLblPos() {
+        return ctDateAx.getTickLblPos();
+    }
+
     private void initializeAxis(CTPlotArea plotArea, AxisPosition position) {
         final long id = getNextAxId(plotArea);
         ctDateAx = plotArea.addNewDateAx();
@@ -219,7 +240,7 @@ public class XDDFDateAxis extends XDDFChartAxis {
         ctDateAx.addNewScaling();
         ctDateAx.addNewCrosses();
         ctDateAx.addNewCrossAx();
-        ctDateAx.addNewTickLblPos().setVal(STTickLblPos.NEXT_TO);
+        ctDateAx.addNewTickLblPos();
         ctDateAx.addNewDelete();
         ctDateAx.addNewMajorTickMark();
         ctDateAx.addNewMinorTickMark();
@@ -230,5 +251,6 @@ public class XDDFDateAxis extends XDDFChartAxis {
         setVisible(true);
         setMajorTickMark(AxisTickMark.CROSS);
         setMinorTickMark(AxisTickMark.NONE);
+        setTickLabelPosition(AxisTickLabelPosition.NEXT_TO);
     }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFLegendEntry.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFLegendEntry.java
@@ -35,6 +35,9 @@ public class XDDFLegendEntry implements TextContainer {
     @Internal
     protected XDDFLegendEntry(CTLegendEntry entry) {
         this.entry = entry;
+        if (entry.getIdx() == null) {
+            entry.addNewIdx().setVal(0);
+        }
     }
 
     @Internal
@@ -108,12 +111,14 @@ public class XDDFLegendEntry implements TextContainer {
         }
     }
 
+    @Override
     public <R> Optional<R> findDefinedParagraphProperty(
             Function<CTTextParagraphProperties, Boolean> isSet,
             Function<CTTextParagraphProperties, R> getter) {
         return Optional.empty(); // legend entry has no (indirect) paragraph properties
     }
 
+    @Override
     public <R> Optional<R> findDefinedRunProperty(
             Function<CTTextCharacterProperties, Boolean> isSet,
             Function<CTTextCharacterProperties, R> getter) {

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFLine3DChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFLine3DChartData.java
@@ -33,8 +33,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFLine3DChartData extends XDDFChartData {
     private CTLine3DChart chart;
 
-    public XDDFLine3DChartData(CTLine3DChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFLine3DChartData(
+            XDDFChart parent,
+            CTLine3DChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTLineSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -254,12 +259,12 @@ public class XDDFLine3DChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFLineChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFLineChartData.java
@@ -33,8 +33,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFLineChartData extends XDDFChartData {
     private CTLineChart chart;
 
-    public XDDFLineChartData(CTLineChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFLineChartData(
+            XDDFChart parent,
+            CTLineChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTLineSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -90,7 +95,7 @@ public class XDDFLineChartData extends XDDFChartData {
     @Override
     public XDDFChartData.Series addSeries(XDDFDataSource<?> category,
             XDDFNumericalDataSource<? extends Number> values) {
-        final int index = this.series.size();
+        final long index = this.parent.incrementSeriesCount();
         final CTLineSer ctSer = this.chart.addNewSer();
         ctSer.addNewCat();
         ctSer.addNewVal();
@@ -234,12 +239,12 @@ public class XDDFLineChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFNumericalDataSource.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFNumericalDataSource.java
@@ -26,4 +26,9 @@ public interface XDDFNumericalDataSource<T extends Number> extends XDDFDataSourc
     String getFormatCode();
 
     void setFormatCode(String formatCode);
+
+    @Override
+    default boolean isLiteral() {
+        return false;
+    }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFPie3DChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFPie3DChartData.java
@@ -30,7 +30,9 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFPie3DChartData extends XDDFChartData {
     private CTPie3DChart chart;
 
-    public XDDFPie3DChartData(CTPie3DChart chart) {
+    @Internal
+    protected XDDFPie3DChartData(XDDFChart parent, CTPie3DChart chart) {
+        super(parent);
         this.chart = chart;
         for (CTPieSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -164,12 +166,12 @@ public class XDDFPie3DChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFPieChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFPieChartData.java
@@ -30,7 +30,9 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFPieChartData extends XDDFChartData {
     private CTPieChart chart;
 
-    public XDDFPieChartData(CTPieChart chart) {
+    @Internal
+    protected XDDFPieChartData(XDDFChart parent, CTPieChart chart) {
+        super(parent);
         this.chart = chart;
         for (CTPieSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -86,7 +88,7 @@ public class XDDFPieChartData extends XDDFChartData {
     @Override
     public XDDFChartData.Series addSeries(XDDFDataSource<?> category,
             XDDFNumericalDataSource<? extends Number> values) {
-        final int index = this.series.size();
+        final long index = this.parent.incrementSeriesCount();
         final CTPieSer ctSer = this.chart.addNewSer();
         ctSer.addNewCat();
         ctSer.addNewVal();
@@ -189,12 +191,12 @@ public class XDDFPieChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFRadarChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFRadarChartData.java
@@ -33,8 +33,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFRadarChartData extends XDDFChartData {
     private CTRadarChart chart;
 
-    public XDDFRadarChartData(CTRadarChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFRadarChartData(
+            XDDFChart parent,
+            CTRadarChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTRadarSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -90,7 +95,7 @@ public class XDDFRadarChartData extends XDDFChartData {
     @Override
     public XDDFChartData.Series addSeries(XDDFDataSource<?> category,
             XDDFNumericalDataSource<? extends Number> values) {
-        final int index = this.series.size();
+        final long index = this.parent.incrementSeriesCount();
         final CTRadarSer ctSer = this.chart.addNewSer();
         ctSer.addNewCat();
         ctSer.addNewVal();
@@ -171,12 +176,12 @@ public class XDDFRadarChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFScatterChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFScatterChartData.java
@@ -34,8 +34,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerTx;
 public class XDDFScatterChartData extends XDDFChartData {
     private CTScatterChart chart;
 
-    public XDDFScatterChartData(CTScatterChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFScatterChartData(
+            XDDFChart parent,
+            CTScatterChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTScatterSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getXVal(), series.getYVal()));
@@ -96,13 +101,14 @@ public class XDDFScatterChartData extends XDDFChartData {
     @Override
     public XDDFChartData.Series addSeries(XDDFDataSource<?> category,
             XDDFNumericalDataSource<? extends Number> values) {
-        final int index = this.series.size();
+        final long index = this.parent.incrementSeriesCount();
         final CTScatterSer ctSer = this.chart.addNewSer();
         ctSer.addNewXVal();
         ctSer.addNewYVal();
         ctSer.addNewIdx().setVal(index);
         ctSer.addNewOrder().setVal(index);
         final Series added = new Series(ctSer, category, values);
+        added.setMarkerStyle(MarkerStyle.NONE);
         this.series.add(added);
         return added;
     }
@@ -243,12 +249,12 @@ public class XDDFScatterChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFSeriesAxis.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFSeriesAxis.java
@@ -19,6 +19,7 @@ package org.apache.poi.xddf.usermodel.chart;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.text.XDDFRunProperties;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTAxPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTBoolean;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTChartLines;
@@ -27,10 +28,11 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumFmt;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTPlotArea;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTScaling;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTSerAx;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickMark;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTUnsignedInt;
-import org.openxmlformats.schemas.drawingml.x2006.chart.STTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTShapeProperties;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextBody;
 
 @Beta
 public class XDDFSeriesAxis extends XDDFChartAxis {
@@ -75,8 +77,21 @@ public class XDDFSeriesAxis extends XDDFChartAxis {
         } else {
             properties = ctSerAx.addNewSpPr();
         }
-
         return new XDDFShapeProperties(properties);
+    }
+
+    /**
+     * @since POI 4.0.2
+     */
+    @Override
+    public XDDFRunProperties getOrAddTextProperties() {
+        CTTextBody text;
+        if (ctSerAx.isSetTxPr()) {
+            text = ctSerAx.getTxPr();
+        } else {
+            text = ctSerAx.addNewTxPr();
+        }
+        return new XDDFRunProperties(getOrAddTextProperties(text));
     }
 
     /**
@@ -180,6 +195,11 @@ public class XDDFSeriesAxis extends XDDFChartAxis {
         return ctSerAx.getMinorTickMark();
     }
 
+    @Override
+    protected CTTickLblPos getCTTickLblPos() {
+        return ctSerAx.getTickLblPos();
+    }
+
     private void initializeAxis(CTPlotArea plotArea, AxisPosition position) {
         final long id = getNextAxId(plotArea);
         ctSerAx = plotArea.addNewSerAx();
@@ -188,7 +208,7 @@ public class XDDFSeriesAxis extends XDDFChartAxis {
         ctSerAx.addNewScaling();
         ctSerAx.addNewCrosses();
         ctSerAx.addNewCrossAx();
-        ctSerAx.addNewTickLblPos().setVal(STTickLblPos.NEXT_TO);
+        ctSerAx.addNewTickLblPos();
         ctSerAx.addNewDelete();
         ctSerAx.addNewMajorTickMark();
         ctSerAx.addNewMinorTickMark();
@@ -199,5 +219,6 @@ public class XDDFSeriesAxis extends XDDFChartAxis {
         setVisible(true);
         setMajorTickMark(AxisTickMark.CROSS);
         setMinorTickMark(AxisTickMark.NONE);
+        setTickLabelPosition(AxisTickLabelPosition.NEXT_TO);
     }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFSurface3DChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFSurface3DChartData.java
@@ -32,8 +32,13 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSurfaceSer;
 public class XDDFSurface3DChartData extends XDDFChartData {
     private CTSurface3DChart chart;
 
-    public XDDFSurface3DChartData(CTSurface3DChart chart, Map<Long, XDDFChartAxis> categories,
+    @Internal
+    protected XDDFSurface3DChartData(
+            XDDFChart parent,
+            CTSurface3DChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTSurfaceSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -173,12 +178,12 @@ public class XDDFSurface3DChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFSurfaceChartData.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFSurfaceChartData.java
@@ -31,8 +31,14 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTSurfaceSer;
 @Beta
 public class XDDFSurfaceChartData extends XDDFChartData {
     private CTSurfaceChart chart;
-    public XDDFSurfaceChartData(CTSurfaceChart chart, Map<Long, XDDFChartAxis> categories,
+
+    @Internal
+    protected XDDFSurfaceChartData(
+            XDDFChart parent,
+            CTSurfaceChart chart,
+            Map<Long, XDDFChartAxis> categories,
             Map<Long, XDDFValueAxis> values) {
+        super(parent);
         this.chart = chart;
         for (CTSurfaceSer series : chart.getSerList()) {
             this.series.add(new Series(series, series.getCat(), series.getVal()));
@@ -172,12 +178,12 @@ public class XDDFSurfaceChartData extends XDDFChartData {
         }
 
         @Override
-        public void setIndex(long val) {
+        protected void setIndex(long val) {
             series.getIdx().setVal(val);
         }
 
         @Override
-        public void setOrder(long val) {
+        protected void setOrder(long val) {
             series.getOrder().setVal(val);
         }
     }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFValueAxis.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFValueAxis.java
@@ -19,6 +19,7 @@ package org.apache.poi.xddf.usermodel.chart;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.xddf.usermodel.XDDFShapeProperties;
+import org.apache.poi.xddf.usermodel.text.XDDFRunProperties;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTAxPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTBoolean;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTChartLines;
@@ -26,11 +27,12 @@ import org.openxmlformats.schemas.drawingml.x2006.chart.CTCrosses;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumFmt;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTPlotArea;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTScaling;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTTickMark;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTUnsignedInt;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTValAx;
-import org.openxmlformats.schemas.drawingml.x2006.chart.STTickLblPos;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTShapeProperties;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextBody;
 
 @Beta
 public class XDDFValueAxis extends XDDFChartAxis {
@@ -76,6 +78,20 @@ public class XDDFValueAxis extends XDDFChartAxis {
             properties = ctValAx.addNewSpPr();
         }
         return new XDDFShapeProperties(properties);
+    }
+
+    /**
+     * @since POI 4.0.2
+     */
+    @Override
+    public XDDFRunProperties getOrAddTextProperties() {
+        CTTextBody text;
+        if (ctValAx.isSetTxPr()) {
+            text = ctValAx.getTxPr();
+        } else {
+            text = ctValAx.addNewTxPr();
+        }
+        return new XDDFRunProperties(getOrAddTextProperties(text));
     }
 
     /**
@@ -207,6 +223,11 @@ public class XDDFValueAxis extends XDDFChartAxis {
         return ctValAx.getMinorTickMark();
     }
 
+    @Override
+    protected CTTickLblPos getCTTickLblPos() {
+        return ctValAx.getTickLblPos();
+    }
+
     public AxisCrossBetween getCrossBetween() {
         return AxisCrossBetween.valueOf(ctValAx.getCrossBetween().getVal());
     }
@@ -224,7 +245,7 @@ public class XDDFValueAxis extends XDDFChartAxis {
         ctValAx.addNewCrossBetween();
         ctValAx.addNewCrosses();
         ctValAx.addNewCrossAx();
-        ctValAx.addNewTickLblPos().setVal(STTickLblPos.NEXT_TO);
+        ctValAx.addNewTickLblPos();
         ctValAx.addNewDelete();
         ctValAx.addNewMajorTickMark();
         ctValAx.addNewMinorTickMark();
@@ -236,5 +257,6 @@ public class XDDFValueAxis extends XDDFChartAxis {
         setVisible(true);
         setMajorTickMark(AxisTickMark.CROSS);
         setMinorTickMark(AxisTickMark.NONE);
+        setTickLabelPosition(AxisTickLabelPosition.NEXT_TO);
     }
 }

--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/text/XDDFRunProperties.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/text/XDDFRunProperties.java
@@ -45,7 +45,7 @@ public class XDDFRunProperties {
     }
 
     @Internal
-    protected XDDFRunProperties(CTTextCharacterProperties properties) {
+    public XDDFRunProperties(CTTextCharacterProperties properties) {
         this.props = properties;
     }
 


### PR DESCRIPTION
In order to give an example of code for [issue 59623](https://bz.apache.org/bugzilla/show_bug.cgi?id=59623), I reused three code examples from Axel Richter on StackOverflow:
  1.  [Create target marker in a bar chart with openxmlformats](https://stackoverflow.com/questions/50772989/)
  2. [Change axis color and font of the chart in openxmlformats](https://stackoverflow.com/questions/50873700/)
  3. [Change colors of line chart Apache POI](https://stackoverflow.com/questions/51530552/)

This led me to introduce and rewrite some internal code in the XDDF packages.