### PR TITLE
MAPIType.isFixedLength: not true in case of length > 8

### DIFF
--- a/src/scratchpad/src/org/apache/poi/hsmf/datatypes/Types.java
+++ b/src/scratchpad/src/org/apache/poi/hsmf/datatypes/Types.java
@@ -119,7 +119,7 @@ public final class Types {
          * Is this type a fixed-length type, or a variable-length one?
          */
         public boolean isFixedLength() {
-            return (length != -1);
+            return (length != -1) && (length <= 8);
         }
 
         public int getId() {


### PR DESCRIPTION
`MAPIType.isFixedLength`: not true in case of length > 8 as fixed length properties are always stored as 8 bytes (zero-padded if length < 8) and cannot exceed 8 bytes.

Writing e.g. `MAPIType` `CLS_ID` which has length 16 would fail otherwise.
(Defined here: https://github.com/apache/poi/blob/f509d1deae86866ed531f10f2eba7db17e098473/src/scratchpad/src/org/apache/poi/hsmf/datatypes/Types.java#L69)