### PR TITLE
fix: PackagingURIHelper.encode(性) get wrong value

### DIFF
--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/PackagingURIHelper.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/PackagingURIHelper.java
@@ -759,7 +759,7 @@ public final class PackagingURIHelper {
     };
 
     private static boolean isUnsafe(int ch) {
-        return ch > 0x80 || Character.isWhitespace(ch);
+        return ch >= 0x80 || Character.isWhitespace(ch);
     }
 
 }

--- a/src/ooxml/testcases/org/apache/poi/openxml4j/opc/TestPackagingURIHelper.java
+++ b/src/ooxml/testcases/org/apache/poi/openxml4j/opc/TestPackagingURIHelper.java
@@ -119,6 +119,7 @@ public class TestPackagingURIHelper extends TestCase {
                 "file:///D:\\seva\\1981\\r810102ns.mp3",
                 "..\\cygwin\\home\\yegor\\dinom\\%5baccess%5d.2010-10-26.log",
                 "#'Instructions (Text)'!B21",
+				"#'性'!B21",
                 "javascript://"
         };
         for(String s : href){


### PR DESCRIPTION
`PackagingURIHelper.encode(性) ` return `%E6%A7`, but it should be `%E6%80%A7`