### PR TITLE
XWPFPicture: easy access to width and depth

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
@@ -77,6 +77,20 @@ public class XWPFPicture {
         }
         return null;
     }
+   
+    /**
+     * Returns the width of the picture (in EMU). 
+     */
+    public long getWidth() {
+        return ctPic.getSpPr().getXfrm().getExt().getCx();
+    }
+   
+    /**
+     * Returns the width of the picture (in EMU). 
+     */
+    public long getDepth() {
+        return ctPic.getSpPr().getXfrm().getExt().getCy();
+    }
 
     public String getDescription() {
         return description;

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
@@ -79,17 +79,17 @@ public class XWPFPicture {
     }
    
     /**
-     * Returns the width of the picture (in EMU). 
+     * Returns the width of the picture (in points). 
      */
     public long getWidth() {
-        return ctPic.getSpPr().getXfrm().getExt().getCx();
+        return Units.toPoints(ctPic.getSpPr().getXfrm().getExt().getCx());
     }
    
     /**
-     * Returns the width of the picture (in EMU). 
+     * Returns the depth of the picture (in points). 
      */
     public long getDepth() {
-        return ctPic.getSpPr().getXfrm().getExt().getCy();
+        return Units.toPoints(ctPic.getSpPr().getXfrm().getExt().getCy());
     }
 
     public String getDescription() {

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
@@ -18,6 +18,7 @@ package org.apache.poi.xwpf.usermodel;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackageRelationship;
+import org.apache.poi.util.Units;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTBlipFillProperties;
 import org.openxmlformats.schemas.drawingml.x2006.picture.CTPicture;
 
@@ -81,14 +82,14 @@ public class XWPFPicture {
     /**
      * Returns the width of the picture (in points). 
      */
-    public long getWidth() {
+    public double getWidth() {
         return Units.toPoints(ctPic.getSpPr().getXfrm().getExt().getCx());
     }
    
     /**
      * Returns the depth of the picture (in points). 
      */
-    public long getDepth() {
+    public double getDepth() {
         return Units.toPoints(ctPic.getSpPr().getXfrm().getExt().getCy());
     }
 

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -520,7 +520,7 @@ public class TestXWPFRun {
         XWPFPicture pic = r.getEmbeddedPictures().get(0);
         CTPicture ctPic = pic.getCTPicture();
         CTBlipFillProperties ctBlipFill = ctPic.getBlipFill();
-        
+
         assertNotNull(ctBlipFill);
         
         CTBlip ctBlip = ctBlipFill.getBlip();
@@ -784,6 +784,27 @@ public class TestXWPFRun {
         assertEquals(styleId, candStyleId);
 
         document.close();
+    }
+
+    @Test
+    public void testGetDepthWidth() throws IOException, InvalidFormatException {
+        XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("TestDocument.docx");
+        XWPFHeader hdr = doc.createHeader(HeaderFooterType.DEFAULT);
+        XWPFParagraph p = hdr.createParagraph();
+        XWPFRun r = p.createRun();
+
+        assertEquals(0, hdr.getAllPictures().size());
+        assertEquals(0, r.getEmbeddedPictures().size());
+
+        r.addPicture(new ByteArrayInputStream(new byte[0]), Document.PICTURE_TYPE_JPEG, "test.jpg", 21, 32);
+
+        assertEquals(1, hdr.getAllPictures().size());
+        assertEquals(1, r.getEmbeddedPictures().size());
+
+        XWPFPicture pic = r.getEmbeddedPictures().get(0);
+
+        assertEquals(pic.getWidth(), 21);
+        assertEquals(pic.getDepth(), 32);
     }
 
 }

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -803,8 +803,8 @@ public class TestXWPFRun {
 
         XWPFPicture pic = r.getEmbeddedPictures().get(0);
 
-        assertEquals(pic.getWidth(), 21);
-        assertEquals(pic.getDepth(), 32);
+        assertEquals(pic.getWidth(), Units.toPoints(21), 0.0);
+        assertEquals(pic.getDepth(), Units.toPoints(32), 0.0);
     }
 
 }


### PR DESCRIPTION
I suppose adding a test case wouldn't hurt (something like calling XWPFRun.addPicture then calling these two new methods).

(BTW, would a pull request to add an overload to XWPFRun.addPicture be accepted? It would be to compute the width and depth from the input file, using javax.ImageIO -- an acceptable dependency or not?)