### PR TITLE
Dourouc05 patch xwpfabstractfootnoteendnote

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
@@ -407,6 +407,17 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
     }
 
     /**
+     * Add a new {@link XWPFParagraph} to the end of the footnote.
+     *
+     * @return The new {@link XWPFParagraph}
+     */
+    public XWPFParagraph createParagraph() {
+        XWPFParagraph p = new XWPFParagraph(ctFtnEdn.addNewP(), this);
+        paragraphs.add(p);
+        return p;
+    }
+
+    /**
      * Get the {@link XWPFDocument} the footnote is part of.
      * @see org.apache.poi.xwpf.usermodel.IBody#getXWPFDocument()
      */

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -402,6 +402,24 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
         }
         return null;
     }
+    
+    /**
+     * Indicates whether this paragraph should be kept on the same page as the next one.
+     */
+    public boolean isKeepNext() {
+        if (getCTP() != null && getCTP().getPPr() != null) {
+            return getCTP().getPPr().setKeepNext(on);
+        }
+    }
+    
+    /**
+     * Sets this paragraph to be kept on the same page as the next one or not. 
+     */
+    public void setKeepNext(boolean keepNext) {
+        CTOnOff state = CTOnOff.Factory.newInstance();
+        state.setVal(keepNext ? STOnOff.ON : STOnOff.OFF);
+        getCTP().getPPr().setKeepNext(state);
+    }
 
     /**
      * Returns the text of the paragraph, but not of any objects in the

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -407,9 +407,10 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
      * Indicates whether this paragraph should be kept on the same page as the next one.
      */
     public boolean isKeepNext() {
-        if (getCTP() != null && getCTP().getPPr() != null) {
-            return getCTP().getPPr().setKeepNext(on);
+        if (getCTP() != null && getCTP().getPPr() != null && getCTP().getPPr().isSetKeepNext()) {
+            return getCTP().getPPr().getKeepNext().getVal() == STOnOff.ON;
         }
+        return false;
     }
     
     /**

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
@@ -467,6 +467,12 @@ public final class TestXWPFParagraph {
             p.setPageBreak(false);
             assertFalse(p.isPageBreak());
 
+            assertFalse(p.isKeepNext());
+            p.setKeepNext(true);
+            assertTrue(p.isKeepNext());
+            p.setKeepNext(false);
+            assertFalse(p.isKeepNext());
+
             assertEquals(-1, p.getSpacingAfter());
             p.setSpacingAfter(12);
             assertEquals(12, p.getSpacingAfter());


### PR DESCRIPTION
Add a helper method to directly create a paragraph within a footnote (rather than allowing the note to "eat" an existing CTP paragraph). 

Should this function handle the first paragraph as a special case, in order to create a FootnoteRef (in case this is a footnote) and to respect the documentation of https://poi.apache.org/apidocs/dev/org/apache/poi/xwpf/usermodel/XWPFFootnote.html#ensureFootnoteRef-org.apache.poi.xwpf.usermodel.XWPFParagraph-? 