### PR TITLE
Add, set the level to a numbering paragraph on XWPFParagraph

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -265,6 +265,24 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
     }
 
     /**
+     * setNumILvl of Paragraph
+     * 
+     * @param iLvl
+     */
+    public void setNumILvl(BigInteger iLvl) {
+        if (paragraph.getPPr() == null) {
+            paragraph.addNewPPr();
+        }
+        if (paragraph.getPPr().getNumPr() == null) {
+            paragraph.getPPr().addNewNumPr();
+        }
+        if (paragraph.getPPr().getNumPr().getIlvl() == null) {
+            paragraph.getPPr().getNumPr().addNewIlvl();
+        }
+        paragraph.getPPr().getNumPr().getIlvl().setVal(iLvl);
+    }
+
+    /**
      * Returns Ilvl of the numeric style for this paragraph.
      * Returns null if this paragraph does not have numeric style.
      *

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
@@ -300,6 +300,16 @@ public final class TestXWPFParagraph {
     }
 
     @Test
+    public void testGetSetILvl() throws IOException {
+        try (XWPFDocument doc = new XWPFDocument()) {
+            XWPFParagraph p = doc.createParagraph();
+
+            p.setNumILvl(new BigInteger("1"));
+            assertEquals("1", p.getNumIlvl().toString());
+        }
+    }
+
+    @Test
     public void testAddingRuns() throws IOException {
         try (XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("sample.docx")) {
 


### PR DESCRIPTION
To set the level of a paragraph in a multilevel numbering list by `setNumILvl`.