### PR TITLE
XWPFTableCell does not process bodyElements when handle paragraph

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
@@ -160,6 +160,7 @@ public class XWPFTableCell implements IBody, ICell {
      */
     public void addParagraph(XWPFParagraph p) {
         paragraphs.add(p);
+        bodyElements.add(p);
     }
 
     /**
@@ -168,8 +169,10 @@ public class XWPFTableCell implements IBody, ICell {
      * @param pos The position in the list of paragraphs, 0-based
      */
     public void removeParagraph(int pos) {
+        XWPFParagraph removedParagraph = paragraphs.get(pos);
         paragraphs.remove(pos);
         ctTc.removeP(pos);
+        bodyElements.remove(removedParagraph);
     }
 
     /**

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFTableCell.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFTableCell.java
@@ -149,4 +149,55 @@ public class TestXWPFTableCell {
         assertEquals(2500, cell.getWidth());
         doc.close();
     }
+
+    @Test
+    public void testAddParagraph() throws Exception {
+        XWPFDocument doc = new XWPFDocument();
+        XWPFTable table = doc.createTable();
+        XWPFTableRow tr = table.createRow();        
+        XWPFTableCell cell = tr.addNewTableCell();
+        
+        // cell have at least one paragraph by default
+        assertEquals(1, cell.getParagraphs().size());
+        assertEquals(1, cell.getBodyElements().size());
+        assertEquals(cell.getParagraphArray(0), cell.getBodyElements().get(0));
+        
+        XWPFParagraph p = cell.addParagraph();
+        assertEquals(2, cell.getParagraphs().size());
+        assertEquals(2, cell.getBodyElements().size());
+        assertEquals(p, cell.getParagraphArray(1));
+        assertEquals(cell.getParagraphArray(1), cell.getBodyElements().get(1));
+        doc.close();
+    }
+
+    @Test
+    public void testRemoveParagraph() throws Exception {
+        XWPFDocument doc = new XWPFDocument();
+        XWPFTable table = doc.createTable();
+        XWPFTableRow tr = table.createRow();        
+        XWPFTableCell cell = tr.addNewTableCell();
+
+        // cell have at least one paragraph by default
+        XWPFParagraph p0 = cell.getParagraphArray(0);
+        XWPFParagraph p1 = cell.addParagraph();
+        cell.addParagraph();
+
+        // remove 3rd
+        cell.removeParagraph(2);
+        assertEquals(2, cell.getParagraphs().size());
+        assertEquals(2, cell.getBodyElements().size());
+        assertEquals(p0, cell.getParagraphArray(0));
+        assertEquals(p1, cell.getParagraphArray(1));
+        assertEquals(p0, cell.getBodyElements().get(0));
+        assertEquals(p1, cell.getBodyElements().get(1));
+
+        // remove 2nd
+        cell.removeParagraph(1);
+        assertEquals(1, cell.getParagraphs().size());
+        assertEquals(1, cell.getBodyElements().size());
+        assertEquals(p0, cell.getParagraphArray(0));
+        assertEquals(p0, cell.getBodyElements().get(0));
+
+        doc.close();
+    }
 }


### PR DESCRIPTION
When I used XWPTFTableCell in depth, I found this bug.