### PR TITLE
XWPFNumbering.addAbstractNum will definitely throw an exception

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractNum.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractNum.java
@@ -57,4 +57,8 @@ public class XWPFAbstractNum {
         return ctAbstractNum;
     }
 
+    public void setCtAbstractNum(CTAbstractNum ctAbstractNum) {
+        this.ctAbstractNum = ctAbstractNum;
+    }
+
 }

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFNumbering.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFNumbering.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.xml.namespace.QName;
@@ -237,7 +238,7 @@ public class XWPFNumbering extends POIXMLDocumentPart {
         if (abstractNum.getAbstractNum() != null) { // Use the current CTAbstractNum if it exists
             ctNumbering.addNewAbstractNum().set(abstractNum.getAbstractNum());
         } else {
-            ctNumbering.addNewAbstractNum();
+            abstractNum.setCtAbstractNum(ctNumbering.addNewAbstractNum());
             abstractNum.getAbstractNum().setAbstractNumId(BigInteger.valueOf(pos));
             ctNumbering.setAbstractNumArray(pos, abstractNum.getAbstractNum());
         }
@@ -283,5 +284,20 @@ public class XWPFNumbering extends POIXMLDocumentPart {
             return null;
         return num.getCTNum().getAbstractNumId().getVal();
     }
+
+    /**
+     * @return all abstractNums
+     */
+    public List<XWPFAbstractNum> getAbstractNums() {
+        return Collections.unmodifiableList(abstractNums);
+    }
+
+    /**
+     * @return all nums
+     */
+    public List<XWPFNum> getNums() {
+        return Collections.unmodifiableList(nums);
+    }
+
 }
 

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFNumbering.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFNumbering.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 
 import org.apache.poi.xwpf.XWPFTestDataSamples;
 import org.junit.Test;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTAbstractNum;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTNum;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTNumLvl;
 
@@ -58,6 +59,45 @@ public class TestXWPFNumbering {
 
         numbering = docIn.getNumbering();
         assertTrue(numbering.numExist(numId));
+        XWPFNum num = numbering.getNum(numId);
+
+        BigInteger compareAbstractNum = num.getCTNum().getAbstractNumId().getVal();
+        assertEquals(abstractNumId, compareAbstractNum);
+    }
+    
+    @Test
+    public void testAddAbstractNumIfAbstractNumNotEqualNull() throws IOException {
+        BigInteger abstractNumId = BigInteger.valueOf(1);
+        XWPFDocument docOut = new XWPFDocument();
+        XWPFNumbering numbering = docOut.createNumbering();
+
+        CTAbstractNum cTAbstractNum = CTAbstractNum.Factory.newInstance();
+        // must set the AbstractNumId, Otherwise fail
+        cTAbstractNum.setAbstractNumId(abstractNumId);
+        XWPFAbstractNum abstractNum = new XWPFAbstractNum(cTAbstractNum);
+        abstractNumId = numbering.addAbstractNum(abstractNum);
+        BigInteger numId = numbering.addNum(abstractNumId);
+
+        XWPFDocument docIn = XWPFTestDataSamples.writeOutAndReadBack(docOut);
+
+        numbering = docIn.getNumbering();
+        XWPFNum num = numbering.getNum(numId);
+        BigInteger compareAbstractNum = num.getCTNum().getAbstractNumId().getVal();
+        assertEquals(abstractNumId, compareAbstractNum);
+    }
+
+    @Test
+    public void testAddAbstractNumIfAbstractNumEqualNull() throws IOException {
+        XWPFDocument docOut = new XWPFDocument();
+        XWPFNumbering numbering = docOut.createNumbering();
+
+        XWPFAbstractNum abstractNum = new XWPFAbstractNum();
+        BigInteger abstractNumId = numbering.addAbstractNum(abstractNum);
+        BigInteger numId = numbering.addNum(abstractNumId);
+
+        XWPFDocument docIn = XWPFTestDataSamples.writeOutAndReadBack(docOut);
+
+        numbering = docIn.getNumbering();
         XWPFNum num = numbering.getNum(numId);
 
         BigInteger compareAbstractNum = num.getCTNum().getAbstractNumId().getVal();


### PR DESCRIPTION
XWPFNumbering.addAbstractNum code is an if branch. There are two points to note:
1. When `abstractNum.getAbstractNum ()` is not null, you must ensure that AbstractNumId has a value, so in order for users to find the correct AbstractNumId value, two getter methods are exposed, of course, the list cannot be modified.

2. When `abstractNum.getAbstractNum ()` is null, an exception will be thrown when cascading the method of `abstractNum.getAbstractNum ()`, so you need to set the attribute CtAbstractNum of the abstractNum.

PS: For the first point, we can also assert in the `XWPFNumbering.addAbstractNum` that AbstractNumId is not null, fail fast.