### PR TITLE
allow add and remove a HyperlinkRun or a FieldRun in XWPFParagraph

### DIFF
--- a/src/examples/src/org/apache/poi/xwpf/usermodel/examples/SimpleDocument.java
+++ b/src/examples/src/org/apache/poi/xwpf/usermodel/examples/SimpleDocument.java
@@ -27,6 +27,7 @@ import org.apache.poi.xwpf.usermodel.TextAlignment;
 import org.apache.poi.xwpf.usermodel.UnderlinePatterns;
 import org.apache.poi.xwpf.usermodel.VerticalAlign;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFHyperlinkRun;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
 
@@ -78,6 +79,11 @@ public class SimpleDocument {
             r3.setFontSize(20);
             r3.setSubscript(VerticalAlign.SUPERSCRIPT);
 
+            // hyperlink
+            XWPFHyperlinkRun hyperlink = p2.insertNewHyperlinkRun(0, "http://poi.apache.org/");
+            hyperlink.setUnderline(UnderlinePatterns.SINGLE);
+            hyperlink.setColor("0000ff");
+            hyperlink.setText("Apache POI");
 
             XWPFParagraph p3 = doc.createParagraph();
             p3.setWordWrapped(true);

--- a/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
+++ b/src/ooxml/testcases/org/apache/poi/xwpf/usermodel/TestXWPFParagraph.java
@@ -328,6 +328,138 @@ public final class TestXWPFParagraph {
     }
 
     @Test
+    public void testCreateNewRuns() throws IOException {
+        try (XWPFDocument doc = new XWPFDocument()) {
+
+            XWPFParagraph p = doc.createParagraph();
+            XWPFHyperlinkRun h = p.createHyperlinkRun("http://poi.apache.org");
+            XWPFFieldRun fieldRun = p.createFieldRun();
+            XWPFRun r = p.createRun();
+
+            assertEquals(3, p.getRuns().size());
+            assertEquals(0, p.getRuns().indexOf(h));
+            assertEquals(1, p.getRuns().indexOf(fieldRun));
+            assertEquals(2, p.getRuns().indexOf(r));
+
+            assertEquals(3, p.getIRuns().size());
+            assertEquals(0, p.getIRuns().indexOf(h));
+            assertEquals(1, p.getIRuns().indexOf(fieldRun));
+            assertEquals(2, p.getIRuns().indexOf(r));
+        }
+    }
+
+    @Test
+    public void testInsertNewRuns() throws IOException {
+        try (XWPFDocument doc = new XWPFDocument()) {
+
+            XWPFParagraph p = doc.createParagraph();
+            XWPFRun r = p.createRun();
+            assertEquals(1, p.getRuns().size());
+            assertEquals(0, p.getRuns().indexOf(r));
+
+            XWPFHyperlinkRun h = p.insertNewHyperlinkRun(0, "http://poi.apache.org");
+            assertEquals(2, p.getRuns().size());
+            assertEquals(0, p.getRuns().indexOf(h));
+            assertEquals(1, p.getRuns().indexOf(r));
+
+            XWPFFieldRun fieldRun2 = p.insertNewFieldRun(2);
+            assertEquals(3, p.getRuns().size());
+            assertEquals(2, p.getRuns().indexOf(fieldRun2));
+        }
+    }
+
+    @Test
+    public void testRemoveRuns() throws IOException {
+        try (XWPFDocument doc = new XWPFDocument()) {
+
+            XWPFParagraph p = doc.createParagraph();
+            XWPFRun r = p.createRun();
+            p.createRun();
+            XWPFHyperlinkRun hyperlinkRun = p
+                    .createHyperlinkRun("http://poi.apache.org");
+            XWPFFieldRun fieldRun = p.createFieldRun();
+
+            assertEquals(4, p.getRuns().size());
+            assertEquals(2, p.getRuns().indexOf(hyperlinkRun));
+            assertEquals(3, p.getRuns().indexOf(fieldRun));
+
+            p.removeRun(2);
+            assertEquals(3, p.getRuns().size());
+            assertEquals(-1, p.getRuns().indexOf(hyperlinkRun));
+            assertEquals(2, p.getRuns().indexOf(fieldRun));
+
+            p.removeRun(0);
+            assertEquals(2, p.getRuns().size());
+            assertEquals(-1, p.getRuns().indexOf(r));
+            assertEquals(1, p.getRuns().indexOf(fieldRun));
+
+            p.removeRun(1);
+            assertEquals(1, p.getRuns().size());
+            assertEquals(-1, p.getRuns().indexOf(fieldRun));
+        }
+    }
+
+    @Test
+    public void testRemoveAndInsertRunsWithOtherIRunElement()
+            throws IOException {
+        XWPFDocument doc = new XWPFDocument();
+
+        XWPFParagraph p = doc.createParagraph();
+        p.createRun();
+        // add other run element
+        p.getCTP().addNewSdt();
+        // add two CTR in hyperlink
+        XWPFHyperlinkRun hyperlinkRun = p
+                .createHyperlinkRun("http://poi.apache.org");
+        hyperlinkRun.getCTHyperlink().addNewR();
+        p.createFieldRun();
+
+        XWPFDocument doc2 = XWPFTestDataSamples.writeOutAndReadBack(doc);
+        XWPFParagraph paragraph = doc2.getParagraphArray(0);
+
+        assertEquals(4, paragraph.getRuns().size());
+        assertEquals(5, paragraph.getIRuns().size());
+
+        assertTrue(paragraph.getRuns().get(1) instanceof XWPFHyperlinkRun);
+        assertTrue(paragraph.getRuns().get(2) instanceof XWPFHyperlinkRun);
+        assertTrue(paragraph.getRuns().get(3) instanceof XWPFFieldRun);
+        
+        assertTrue(paragraph.getIRuns().get(1) instanceof XWPFSDT);
+        assertTrue(paragraph.getIRuns().get(2) instanceof XWPFHyperlinkRun);
+
+        paragraph.removeRun(1);
+        assertEquals(3, paragraph.getRuns().size());
+        assertTrue(paragraph.getRuns().get(1) instanceof XWPFHyperlinkRun);
+        assertTrue(paragraph.getRuns().get(2) instanceof XWPFFieldRun);
+        
+        assertTrue(paragraph.getIRuns().get(1) instanceof XWPFSDT);
+        assertTrue(paragraph.getIRuns().get(2) instanceof XWPFHyperlinkRun);
+
+        paragraph.removeRun(1);
+        assertEquals(2, paragraph.getRuns().size());
+        assertTrue(paragraph.getRuns().get(1) instanceof XWPFFieldRun);
+        
+        assertTrue(paragraph.getIRuns().get(1) instanceof XWPFSDT);
+        assertTrue(paragraph.getIRuns().get(2) instanceof XWPFFieldRun);
+
+        paragraph.removeRun(0);
+        assertEquals(1, paragraph.getRuns().size());
+        assertTrue(paragraph.getRuns().get(0) instanceof XWPFFieldRun);
+        
+        assertTrue(paragraph.getIRuns().get(0) instanceof XWPFSDT);
+        assertTrue(paragraph.getIRuns().get(1) instanceof XWPFFieldRun);
+
+        XWPFRun newRun = paragraph.insertNewRun(0);
+        assertEquals(2, paragraph.getRuns().size());
+        
+        assertEquals(3, paragraph.getIRuns().size());
+        assertEquals(0, paragraph.getRuns().indexOf(newRun));
+
+        doc.close();
+        doc2.close();
+    }
+
+    @Test
     public void testPictures() throws IOException {
         try (XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("VariousPictures.docx")) {
             assertEquals(7, doc.getParagraphs().size());


### PR DESCRIPTION
### What is the pr?
- add `createFieldRun`method
- add `insertNewHyperlinkRun` method
- add `insertNewFieldRun` method
- refactor `insertNewRun` method
- refactor `removeRun` method, Add support for removing HyperlinkRun and FieldRun
- add some testcases
- update examples/SimpleDocument, add hyperlink case

### How to work
`XWPFHyperlinkRun` and `XWPFFieldRun` both inherit `XWPFRun`, In the future, this code design should be re-discussed, but now I maintain the original data structure, and the code is also compatible with the previous use.

1. Since `w: p` can contain many child elements, I think the simple way should be to insert run through cursor instead of` CTP.insertNewR (int) `. If the currently inserted position is an `XWPFHyperlinkRun` or `XWPFFieldRun`, it will look up for the correct cursor position

2. When removing a run at a certain location, if it is an `XWPFHyperlinkRun` or `XWPFFieldRun` and they contain multiple Runs, the run will be removed directly. When there is only one run, the hyperlink or fieldrun will be removed
