### PR TITLE
64327 bugfix in SXSSFSheet isColumnTrackedForAutoSizing for untracked

### DIFF
--- a/src/ooxml/java/org/apache/poi/xssf/streaming/AutoSizeColumnTracker.java
+++ b/src/ooxml/java/org/apache/poi/xssf/streaming/AutoSizeColumnTracker.java
@@ -138,7 +138,8 @@ import org.apache.poi.util.Internal;
      * @since 3.14beta1
      */
     public boolean isColumnTracked(int column) {
-        return trackAllColumns || maxColumnWidths.containsKey(column);
+        return (trackAllColumns && !untrackedColumns.contains(column))
+                || maxColumnWidths.containsKey(column);
     }
     
     /**

--- a/src/ooxml/testcases/org/apache/poi/xssf/streaming/TestAutoSizeColumnTracker.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/streaming/TestAutoSizeColumnTracker.java
@@ -111,18 +111,7 @@ public class TestAutoSizeColumnTracker {
     
     @Test
     public void trackAndUntrackAllColumns() {
-        assumeTrue(tracker.getTrackedColumns().isEmpty());
-        tracker.trackAllColumns();
-        assertTrue(tracker.getTrackedColumns().isEmpty());
-        
-        Row row = sheet.createRow(0);
-        for (int column : columns) {
-            row.createCell(column);
-        }
-        // implicitly track the columns
-        tracker.updateColumnWidths(row);
-        assertEquals(columns, tracker.getTrackedColumns());
-        
+        createColumnsAndTrackThemAll();
         tracker.untrackAllColumns();
         assertTrue(tracker.getTrackedColumns().isEmpty());
     }
@@ -135,7 +124,19 @@ public class TestAutoSizeColumnTracker {
         tracker.untrackColumn(0);
         assertFalse(tracker.isColumnTracked(0));
     }
-    
+
+    @Test
+    public void isColumnTrackedAndTrackAllColumns() {
+        createColumnsAndTrackThemAll();
+        tracker.untrackColumn(0);
+        SortedSet<Integer> _newColumns = new TreeSet<>();
+        _newColumns.add(1);
+        _newColumns.add(3);
+        SortedSet<Integer> newColumns = Collections.unmodifiableSortedSet(_newColumns);
+        assertEquals(newColumns, tracker.getTrackedColumns());
+        assertFalse(tracker.isColumnTracked(0));
+    }
+
     @Test
     public void getTrackedColumns() {
         assumeTrue(tracker.getTrackedColumns().isEmpty());
@@ -213,5 +214,19 @@ public class TestAutoSizeColumnTracker {
         Font font = workbook.getFontAt(cell.getCellStyle().getFontIndexAsInt());
         Assume.assumeTrue("Cannot verify autoSizeColumn() because the necessary Fonts are not installed on this machine: " + font,
                           SheetUtil.canComputeColumnWidth(font));
+    }
+
+    private void createColumnsAndTrackThemAll() {
+        assumeTrue(tracker.getTrackedColumns().isEmpty());
+        tracker.trackAllColumns();
+        assertTrue(tracker.getTrackedColumns().isEmpty());
+
+        Row row = sheet.createRow(0);
+        for (int column : columns) {
+            row.createCell(column);
+        }
+        // implicitly track the columns
+        tracker.updateColumnWidths(row);
+        assertEquals(columns, tracker.getTrackedColumns());
     }
 }

--- a/src/ooxml/testcases/org/apache/poi/xssf/streaming/TestSXSSFSheetAutoSizeColumn.java
+++ b/src/ooxml/testcases/org/apache/poi/xssf/streaming/TestSXSSFSheetAutoSizeColumn.java
@@ -337,8 +337,9 @@ public class TestSXSSFSheetAutoSizeColumn {
         
         sheet.trackColumnsForAutoSizing(columns);
         sheet.trackAllColumnsForAutoSizing();
-        
-        sheet.untrackColumnForAutoSizing(0);
+
+        boolean untracked = sheet.untrackColumnForAutoSizing(0);
+        assertTrue(untracked);
         try {
             sheet.autoSizeColumn(0, useMergedCells);
             fail("Should not be able to auto-size an explicitly untracked column");


### PR DESCRIPTION
- fix boolean expression in AutoSizeColumnTracker. It looks into untrackedColumns now
- add test for bug reproducing
- extract duplicate code in test to a method
- add missing test for a boolean return from untrackColumnForAutoSizing