### PR TITLE
add null checker to sourceRow so it can be skipped if it's null

### DIFF
--- a/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
+++ b/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
@@ -85,7 +85,9 @@ public abstract class RangeCopier {
         
         for(int rowNo = sourceRange.getFirstRow(); rowNo <= sourceRange.getLastRow(); rowNo++) {   
             Row sourceRow = sourceClone.getRow(rowNo); // copy from source copy, original source might be overridden in process!
-            if (sourceRow != null) {
+            if (sourceRow == null) {
+                continue;
+            } else {
                 for (int columnIndex = sourceRange.getFirstColumn(); columnIndex <= sourceRange.getLastColumn(); columnIndex++) {
                     Cell sourceCell = sourceRow.getCell(columnIndex);
                     if (sourceCell == null)

--- a/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
+++ b/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
@@ -85,22 +85,24 @@ public abstract class RangeCopier {
         
         for(int rowNo = sourceRange.getFirstRow(); rowNo <= sourceRange.getLastRow(); rowNo++) {   
             Row sourceRow = sourceClone.getRow(rowNo); // copy from source copy, original source might be overridden in process!
-            for (int columnIndex = sourceRange.getFirstColumn(); columnIndex <= sourceRange.getLastColumn(); columnIndex++) {  
-                Cell sourceCell = sourceRow.getCell(columnIndex);
-                if(sourceCell == null)
-                    continue;
-                Row destRow = destSheet.getRow(rowNo + deltaY);
-                if(destRow == null)
-                    destRow = destSheet.createRow(rowNo + deltaY);
-                
-                Cell newCell = destRow.getCell(columnIndex + deltaX);
-                if(newCell == null) {
-                    newCell = destRow.createCell(columnIndex + deltaX);
-                }
+            if (sourceRow != null) {
+                for (int columnIndex = sourceRange.getFirstColumn(); columnIndex <= sourceRange.getLastColumn(); columnIndex++) {
+                    Cell sourceCell = sourceRow.getCell(columnIndex);
+                    if (sourceCell == null)
+                        continue;
+                    Row destRow = destSheet.getRow(rowNo + deltaY);
+                    if (destRow == null)
+                        destRow = destSheet.createRow(rowNo + deltaY);
 
-                cloneCellContent(sourceCell, newCell, null);
-                if(newCell.getCellType() == CellType.FORMULA)
-                    adjustCellReferencesInsideFormula(newCell, destSheet, deltaX, deltaY);
+                    Cell newCell = destRow.getCell(columnIndex + deltaX);
+                    if (newCell == null) {
+                        newCell = destRow.createCell(columnIndex + deltaX);
+                    }
+
+                    cloneCellContent(sourceCell, newCell, null);
+                    if (newCell.getCellType() == CellType.FORMULA)
+                        adjustCellReferencesInsideFormula(newCell, destSheet, deltaX, deltaY);
+                }
             }
         }
     }

--- a/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
+++ b/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
@@ -85,26 +85,24 @@ public abstract class RangeCopier {
         
         for(int rowNo = sourceRange.getFirstRow(); rowNo <= sourceRange.getLastRow(); rowNo++) {   
             Row sourceRow = sourceClone.getRow(rowNo); // copy from source copy, original source might be overridden in process!
-            if (sourceRow == null) {
+            if(sourceRow == null)
                 continue;
-            } else {
-                for (int columnIndex = sourceRange.getFirstColumn(); columnIndex <= sourceRange.getLastColumn(); columnIndex++) {
-                    Cell sourceCell = sourceRow.getCell(columnIndex);
-                    if (sourceCell == null)
-                        continue;
-                    Row destRow = destSheet.getRow(rowNo + deltaY);
-                    if (destRow == null)
-                        destRow = destSheet.createRow(rowNo + deltaY);
+            for (int columnIndex = sourceRange.getFirstColumn(); columnIndex <= sourceRange.getLastColumn(); columnIndex++) {
+                Cell sourceCell = sourceRow.getCell(columnIndex);
+                if(sourceCell == null)
+                    continue;
+                Row destRow = destSheet.getRow(rowNo + deltaY);
+                if(destRow == null)
+                    destRow = destSheet.createRow(rowNo + deltaY);
 
-                    Cell newCell = destRow.getCell(columnIndex + deltaX);
-                    if (newCell == null) {
-                        newCell = destRow.createCell(columnIndex + deltaX);
-                    }
-
-                    cloneCellContent(sourceCell, newCell, null);
-                    if (newCell.getCellType() == CellType.FORMULA)
-                        adjustCellReferencesInsideFormula(newCell, destSheet, deltaX, deltaY);
+                Cell newCell = destRow.getCell(columnIndex + deltaX);
+                if(newCell == null) {
+                    newCell = destRow.createCell(columnIndex + deltaX);
                 }
+
+                cloneCellContent(sourceCell, newCell, null);
+                if(newCell.getCellType() == CellType.FORMULA)
+                    adjustCellReferencesInsideFormula(newCell, destSheet, deltaX, deltaY);
             }
         }
     }


### PR DESCRIPTION
When copying the sheet in the memory, if the row is null, currently it will cause NPE. So just a null checker to protect it, similar to how it skips null columns as of now.   @zmau 
```
2020-04-23 09:49:07.390 [,myservice,,] ERROR https-jsse-nio-9420-exec-2 [dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.NullPointerException] with root cause
java.lang.NullPointerException: null
        at org.apache.poi.ss.usermodel.RangeCopier.copyRange(RangeCopier.java:89)
        at org.apache.poi.ss.usermodel.RangeCopier.copyRange(RangeCopier.java:68)
```