### PR TITLE
add an option for RangeCopier.copyRange() also clone styles

### DIFF
--- a/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
+++ b/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
@@ -50,10 +50,10 @@ public abstract class RangeCopier {
      * @param tileDestRange     destination range, which should be overridden
      */
     public void copyRange(CellRangeAddress tilePatternRange, CellRangeAddress tileDestRange) {
-        copyRange(tilePatternRange, tileDestRange, false);
+        copyRange(tilePatternRange, tileDestRange, false, false);
     }
 
-    public void copyRange(CellRangeAddress tilePatternRange, CellRangeAddress tileDestRange, boolean copyStyles) {
+    public void copyRange(CellRangeAddress tilePatternRange, CellRangeAddress tileDestRange, boolean copyStyles, boolean copyMergedRanges) {
         Sheet sourceCopy = sourceSheet.getWorkbook().cloneSheet(sourceSheet.getWorkbook().getSheetIndex(sourceSheet));
         Map<Integer, CellStyle> styleMap = copyStyles ? new HashMap<Integer, CellStyle>() {} : null;
         int sourceWidthMinus1 = tilePatternRange.getLastColumn() - tilePatternRange.getFirstColumn();
@@ -78,6 +78,10 @@ public abstract class RangeCopier {
             } while (nextCellIndexInRowToCopy <= tileDestRange.getLastColumn());
             nextRowIndexToCopy += heightToCopyMinus1 + 1;
         } while (nextRowIndexToCopy <= tileDestRange.getLastRow());
+
+        if (copyMergedRanges) {
+            sourceSheet.getMergedRegions().forEach((mergedRangeAddress) -> destSheet.addMergedRegion(mergedRangeAddress));
+        }
 
         int tempCopyIndex = sourceSheet.getWorkbook().getSheetIndex(sourceCopy);
         sourceSheet.getWorkbook().removeSheetAt(tempCopyIndex);

--- a/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
+++ b/src/java/org/apache/poi/ss/usermodel/RangeCopier.java
@@ -55,8 +55,7 @@ public abstract class RangeCopier {
 
     public void copyRange(CellRangeAddress tilePatternRange, CellRangeAddress tileDestRange, boolean copyStyles) {
         Sheet sourceCopy = sourceSheet.getWorkbook().cloneSheet(sourceSheet.getWorkbook().getSheetIndex(sourceSheet));
-        Map<Integer, CellStyle> styleMap = copyStyles ? new HashMap<Integer, CellStyle>() {
-        } : null;
+        Map<Integer, CellStyle> styleMap = copyStyles ? new HashMap<Integer, CellStyle>() {} : null;
         int sourceWidthMinus1 = tilePatternRange.getLastColumn() - tilePatternRange.getFirstColumn();
         int sourceHeightMinus1 = tilePatternRange.getLastRow() - tilePatternRange.getFirstRow();
         int rightLimitToCopy;

--- a/src/testcases/org/apache/poi/ss/usermodel/TestRangeCopier.java
+++ b/src/testcases/org/apache/poi/ss/usermodel/TestRangeCopier.java
@@ -19,13 +19,13 @@
 
 package org.apache.poi.ss.usermodel;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Ignore;
 import org.junit.Test;
 import org.apache.poi.ss.ITestDataProvider;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;
+
+import static org.junit.Assert.*;
 
 @Ignore
 public abstract class TestRangeCopier {
@@ -130,9 +130,29 @@ public abstract class TestRangeCopier {
         Sheet destSheet = sheet2;
         CellRangeAddress tileRange = CellRangeAddress.valueOf("D6:D6"); // on sheet1
         CellRangeAddress destRange = CellRangeAddress.valueOf("J6:J6"); // on sheet2
-        transSheetRangeCopier.copyRange(tileRange, destRange, true);
+        transSheetRangeCopier.copyRange(tileRange, destRange, true, false);
         assertEquals(cellContent, getCellContent(destSheet, "J6"));
         assertEquals(toTheRight, getCell(destSheet, "J6").getCellStyle().getAlignment());
+    }
+
+    @Test
+    public void testMergedRanges() {
+        String cellContent = "D6 merged to E7";
+
+//        create cell merged from D6 to E7
+        CellRangeAddress mergedRangeAddress = new CellRangeAddress(5,6,3,4);
+        Cell cell = sheet1.createRow(5).createCell(3);
+        cell.setCellValue(cellContent);
+        sheet1.addMergedRegion(mergedRangeAddress);
+
+        Sheet destSheet = sheet2;
+        CellRangeAddress tileRange = CellRangeAddress.valueOf("D6:E7"); // on sheet1
+        transSheetRangeCopier.copyRange(tileRange, tileRange, false, true);
+        assertEquals(cellContent, getCellContent(destSheet, "D6"));
+        assertFalse(destSheet.getMergedRegions().isEmpty());
+        destSheet.getMergedRegions().forEach((mergedRegion) -> {
+            assertTrue(mergedRegion.equals(mergedRangeAddress));
+        });
     }
 
    protected static String getCellContent(Sheet sheet, String coordinates) {

--- a/src/testcases/org/apache/poi/ss/usermodel/TestRangeCopier.java
+++ b/src/testcases/org/apache/poi/ss/usermodel/TestRangeCopier.java
@@ -116,13 +116,36 @@ public abstract class TestRangeCopier {
         assertEquals("1.2", getCellContent(sheet1, "G24"));
     }
 
-    protected static String getCellContent(Sheet sheet, String coordinates) {
+    @Test
+    public void testCopyStyles() {
+        String cellContent = "D6 aligned to the right";
+        HorizontalAlignment toTheRight = HorizontalAlignment.RIGHT;
+        // create cell with content aligned to the right
+        CellStyle style = workbook.createCellStyle();
+        style.setAlignment(toTheRight);
+        Cell cell = sheet1.createRow(5).createCell(3);
+        cell.setCellValue(cellContent);
+        cell.setCellStyle(style);
+
+        Sheet destSheet = sheet2;
+        CellRangeAddress tileRange = CellRangeAddress.valueOf("D6:D6"); // on sheet1
+        CellRangeAddress destRange = CellRangeAddress.valueOf("J6:J6"); // on sheet2
+        transSheetRangeCopier.copyRange(tileRange, destRange, true);
+        assertEquals(cellContent, getCellContent(destSheet, "J6"));
+        assertEquals(toTheRight, getCell(destSheet, "J6").getCellStyle().getAlignment());
+    }
+
+   protected static String getCellContent(Sheet sheet, String coordinates) {
+        Cell cell = getCell(sheet, coordinates);
+        return cell == null ? "" : cell.toString();
+   }
+   protected static Cell getCell(Sheet sheet, String coordinates) {
         try {
             CellReference p = new CellReference(coordinates);
-            return sheet.getRow(p.getRow()).getCell(p.getCol()).toString();
+            return sheet.getRow(p.getRow()).getCell(p.getCol());
         }
         catch (NullPointerException e) { // row or cell does not exist
-            return "";
+            return null;
         }
     }
 }


### PR DESCRIPTION
Found out that currently RangeCopier.copyRange() only copy values and formulas, however it always pass hardcoded null styleMap to RangeCopier.cloneCellContent(), therefore no styles were copied.  Not so sure why, so I added a boolean option for RangeCopier.copyRange() to copy styles.

The MR provides an additional argument on the current RangeCopier.copyRange(), while passing the boolean argument is optional. So it will be compatible with all existing codes using RangeCopier.copyRange().

```
myRangeCopier.copyRange(originalDataRange, destinationDataRange, true);
// the additional true enables style copying

myRangeCopier.copyRange(originalDataRange, destinationDataRange);
// works as before, copy range without copying styles
```

Tested in my company and the cell styles can be copied by copyRange(). Somehow we also need to include `compile("org.apache.commons:commons-math3:3.0")` for it to copy range with styles, probably due to local jar files including.