### PR TITLE
Fix root property size calculation.

### DIFF
--- a/src/java/org/apache/poi/poifs/filesystem/POIFSMiniStore.java
+++ b/src/java/org/apache/poi/poifs/filesystem/POIFSMiniStore.java
@@ -252,7 +252,7 @@ public class POIFSMiniStore extends BlockStore
           if (!sbat.hasFreeSectors()) {
               blocksUsed += _filesystem.getBigBlockSizeDetails().getBATEntriesPerBlock();
           } else {
-              blocksUsed += sbat.getUsedSectors(false);
+              blocksUsed += sbat.getOccupiedSize();
           }
        }
        // Set the size on the root in terms of the number of SBAT blocks

--- a/src/java/org/apache/poi/poifs/storage/BATBlock.java
+++ b/src/java/org/apache/poi/poifs/storage/BATBlock.java
@@ -192,6 +192,25 @@ public final class BATBlock implements BlockWritable {
         return usedSectors;
     }
 
+    /**
+     * How much of this block is occupied?.
+     * This counts the number of sectors up and including the last used sector.
+     * Note that this is different from {@link #getUsedSectors(boolean)} which
+     * could be smaller as it does not count unused sectors where there are
+     * used ones after it (i.e. fragmentation).
+     */
+    public int getOccupiedSize() {
+        int usedSectors = _values.length;
+        for (int k = _values.length - 1; k >= 0; k--) {
+            if(_values[k] == POIFSConstants.UNUSED_BLOCK) {
+                usedSectors--;
+            } else {
+                break;
+            }
+        }
+        return usedSectors;
+    }
+
     public int getValueAt(int relativeOffset) {
        if(relativeOffset >= _values.length) {
           throw new ArrayIndexOutOfBoundsException(

--- a/src/testcases/org/apache/poi/poifs/storage/TestBATBlock.java
+++ b/src/testcases/org/apache/poi/poifs/storage/TestBATBlock.java
@@ -175,6 +175,68 @@ public final class TestBATBlock {
         assertEquals(1024, block4096.getUsedSectors(false));
         assertEquals(1023, block4096.getUsedSectors(true));
     }
+    
+        @Test
+    public void testOccupiedSize() {
+        POIFSBigBlockSize b512 = POIFSConstants.SMALLER_BIG_BLOCK_SIZE_DETAILS;
+        POIFSBigBlockSize b4096 = POIFSConstants.LARGER_BIG_BLOCK_SIZE_DETAILS;
+        
+        // Try first with 512 block sizes, which can hold 128 entries
+        BATBlock block512 = BATBlock.createEmptyBATBlock(b512, false);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(0, block512.getUsedSectors(false));
+
+        // Allocate a few
+        block512.setValueAt(0, 42);
+        block512.setValueAt(10, 42);
+        block512.setValueAt(20, 42);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(21, block512.getOccupiedSize());
+        
+        // Release one in the middle should not lower size
+        block512.setValueAt(10, POIFSConstants.UNUSED_BLOCK);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(21, block512.getOccupiedSize());
+        
+        // Release the last one should lower the size
+        block512.setValueAt(20, POIFSConstants.UNUSED_BLOCK);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(1, block512.getOccupiedSize());
+        
+        // Release first one should lower the size
+        block512.setValueAt(0, POIFSConstants.UNUSED_BLOCK);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(0, block512.getOccupiedSize());
+        
+        // Set the last one
+        block512.setValueAt(127, 42);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(128, block512.getOccupiedSize());
+        
+        block512.setValueAt(126, 42);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(128, block512.getOccupiedSize());
+        
+        block512.setValueAt(127, POIFSConstants.UNUSED_BLOCK);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(127, block512.getOccupiedSize());
+        
+        // Allocate all
+        for (int i=0; i<b512.getBATEntriesPerBlock(); i++) {
+            block512.setValueAt(i, 82);
+        }
+        // Check
+        assertFalse(block512.hasFreeSectors());
+        assertEquals(128, block512.getOccupiedSize());
+        
+        // Release some in the beginning should not lower size
+        block512.setValueAt(0, POIFSConstants.UNUSED_BLOCK);
+        block512.setValueAt(1, POIFSConstants.UNUSED_BLOCK);
+        block512.setValueAt(13, POIFSConstants.UNUSED_BLOCK);
+        assertTrue(block512.hasFreeSectors());
+        assertEquals(128, block512.getOccupiedSize());
+        
+    }
 
     @Test
     public void testGetBATBlockAndIndex() {


### PR DESCRIPTION
Before this patch the POIFSMiniStore.syncWithDataStore() method sets the root property size to be based on the number of sectors in each block that is used. 

However it can happen is some files that a block is not only filled in the beginning. Instead there could be gaps with unused sectors within it and currently POI does not count those. However the MS tool (in this case signtool) calculates the occupied size (i.e. the size from beginning of block up to and including the last used sector). Specifically for Windows Installer (MSI) files, if the root size is not calculated this way the digital signature will not show up as correct.

This pull request changes the calculation of the root property so that Windows will not complain also for files with blocks that has unused sectors in the middle.
