### PR TITLE
fix gradle build after #64411 changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,8 +256,8 @@ project('ooxml') {
 
         compile project(':main')
         compile project(':scratchpad')		// TODO: get rid of this dependency!
-        compile files('../../ooxml-lib/ooxml-schemas-1.4.jar')
-        compile files('../../ooxml-lib/ooxml-security-1.1.jar')
+        compile files('../../lib/ooxml/ooxml-schemas-1.4.jar')
+        compile files('../../lib/ooxml/ooxml-security-1.1.jar')
 
         testCompile "junit:junit:${junitVersion}"
         testCompile "org.mockito:mockito-core:${mockitoVersion}"
@@ -290,7 +290,7 @@ project('examples') {
         compile project(':ooxml')
         compile project(':scratchpad')
         compile "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}"
-        compile files('../../ooxml-lib/ooxml-schemas-1.4.jar')
+        compile files('../../lib/ooxml/ooxml-schemas-1.4.jar')
         compile "org.apache.commons:commons-compress:${commonsCompressVersion}"
     }
 
@@ -335,7 +335,7 @@ project('integrationtest') {
 
         testCompile "junit:junit:${junitVersion}"
         testCompile  "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}"
-        testCompile files('../../ooxml-lib/ooxml-schemas-1.4.jar')
+        testCompile files('../../lib/ooxml/ooxml-schemas-1.4.jar')
     }
 
 	jar {


### PR DESCRIPTION
After rearranging some lib folders of ooxml in https://github.com/apache/poi/commit/114a4dbd41c56e4c544836e58fae02aae6793cdf , gradle build (and therefore IDE imports) was broken. This fixes the issue.