### PR TITLE
Fix RuntimeException on array formula referencing blank cell

### DIFF
--- a/src/java/org/apache/poi/ss/formula/WorkbookEvaluator.java
+++ b/src/java/org/apache/poi/ss/formula/WorkbookEvaluator.java
@@ -633,6 +633,12 @@ public final class WorkbookEvaluator {
         else {
             value = dereferenceResult(evaluationResult, ec.getRowIndex(), ec.getColumnIndex());
         }
+        if (value == BlankEval.instance) {
+            // Note Excel behaviour here. A blank final final value is converted to zero.
+            return NumberEval.ZERO;
+            // Formulas _never_ evaluate to blank.  If a formula appears to have evaluated to
+            // blank, the actual value is empty string. This can be verified with ISBLANK().
+        }
         
         return value;
     }

--- a/src/testcases/org/apache/poi/ss/formula/TestWorkbookEvaluator.java
+++ b/src/testcases/org/apache/poi/ss/formula/TestWorkbookEvaluator.java
@@ -46,6 +46,7 @@ import org.apache.poi.ss.usermodel.Name;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellRangeAddress;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -612,5 +613,43 @@ public class TestWorkbookEvaluator {
         assertEquals(expectedResult, D1.getNumericCellValue(), EPSILON);
         
         testIFEqualsFormulaEvaluation_teardown(wb);
+    }
+
+    @Test
+    public void testRefToBlankCellInArrayFormula() {
+        Workbook wb = new HSSFWorkbook();
+        Sheet sheet = wb.createSheet();
+        Row row = sheet.createRow(0);
+        Cell cellA1 = row.createCell(0);
+        Cell cellB1 = row.createCell(1);
+        Cell cellC1 = row.createCell(2);
+        Row row2 = sheet.createRow(1);
+        Cell cellA2 = row2.createCell(0);
+        Cell cellB2 = row2.createCell(1);
+        Cell cellC2 = row2.createCell(2);
+        Row row3 = sheet.createRow(2);
+        Cell cellA3 = row3.createCell(0);
+        Cell cellB3 = row3.createCell(1);
+        Cell cellC3 = row3.createCell(2);
+
+        cellA1.setCellValue("1");
+        // cell B1 intentionally left blank
+        cellC1.setCellValue("3");
+
+        cellA2.setCellFormula("A1");
+        cellB2.setCellFormula("B1");
+        cellC2.setCellFormula("C1");
+
+        sheet.setArrayFormula("A1:C1", CellRangeAddress.valueOf("A3:C3"));
+
+        wb.getCreationHelper().createFormulaEvaluator().evaluateAll();
+
+        assertEquals(cellA2.getStringCellValue(), "1");
+        assertEquals(cellB2.getNumericCellValue(),0, 0.00001);
+        assertEquals(cellC2.getStringCellValue(),"3");
+
+        assertEquals(cellA3.getStringCellValue(), "1");
+        assertEquals(cellB3.getNumericCellValue(),0, 0.00001);
+        assertEquals(cellC3.getStringCellValue(),"3");
     }
 }


### PR DESCRIPTION
I had an array formula that referenced range which contained blank cells - this caused exception, because method evaluateFormulaCellValue did not expect BlankEval. Interestingly enough, this does not happen in normal formulas (Blank cell evaluates to NumberEval[0]).

I traced this behavior to WorkbookEvaluator::defererenceResult(ValueEval, OperationEvaluationContext) which branches, depending whether this is AreaEval or not. Part for non-AreaEval (method dereferenceResult(ValueEval,int,int) ) swaps BlankEval for NumberEval.ZERO and part for AreaEval does not.

I checked in LibreOffice and expected behavior seems to be that ref to blank cell evalulates to zero (both in array and non-array formula), so I copied this logic to dereferenceResult(ValueEval, OperationEvaluationContext) - I wanted to move it completely, but method dereferenceResult(ValueEval,int,int) is public and used by other class, so removing this piece of code might influence its behavior.