### PR TITLE
Fix DOUGHNUT chart creation

### DIFF
--- a/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFChart.java
+++ b/src/ooxml/java/org/apache/poi/xddf/usermodel/chart/XDDFChart.java
@@ -650,7 +650,7 @@ public abstract class XDDFChart extends POIXMLDocumentPart implements TextContai
         Map<Long, XDDFChartAxis> categories = null;
         Map<Long, XDDFValueAxis> mapValues = null;
 
-        if (ChartTypes.PIE != type && ChartTypes.PIE3D != type) {
+        if (ChartTypes.PIE != type && ChartTypes.PIE3D != type && ChartTypes.DOUGHNUT != type) {
             categories = Collections.singletonMap(category.getId(), category);
             mapValues = Collections.singletonMap(values.getId(), values);
         }


### PR DESCRIPTION
Currently the DOUGHNUT chart requires `XDDFChartAxis` and `XDDFValueAxis` objects in its creation which is not correct. As with the PIE and PIE3D charts, the DOUGHNUT chart does not need these axis objects as it can be seen in its constructor. These incurs in null pointer exception when the not needed axis objects are not provided and in errors when reading the Excel file.