### PR TITLE
Change TRUNC implementation to use MathX

### DIFF
--- a/src/java/org/apache/poi/ss/formula/functions/NumericFunction.java
+++ b/src/java/org/apache/poi/ss/formula/functions/NumericFunction.java
@@ -330,9 +330,7 @@ public abstract class NumericFunction implements Function {
 			try {
 				double d0 = singleOperandEvaluate(arg0, srcRowIndex, srcColumnIndex);
 				double d1 = singleOperandEvaluate(arg1, srcRowIndex, srcColumnIndex);
-				double multi = Math.pow(10d,d1);
-				if(d0 < 0) result = -Math.floor(-d0 * multi) / multi;
-                else result = Math.floor(d0 * multi) / multi;
+				result = MathX.roundDown(d0, (int)d1);
 				checkValue(result);
 			}catch (EvaluationException e) {
 				return e.getErrorEval();

--- a/src/testcases/org/apache/poi/ss/formula/functions/TestTrunc.java
+++ b/src/testcases/org/apache/poi/ss/formula/functions/TestTrunc.java
@@ -58,6 +58,21 @@ public final class TestTrunc extends BaseTestNumeric {
 	}
 
 	@Test
+	public void testTruncWithProblematicDecimalNumber() {
+		ValueEval[] args = { new NumberEval(0.29), new NumberEval(2) };
+		ValueEval result = NumericFunction.TRUNC.evaluate(args, -1, (short)-1);
+		assertEquals("TRUNC", (new NumberEval(0.29d)).getNumberValue(), ((NumberEval)result).getNumberValue());
+	}
+
+	@Test
+	public void testTruncWithProblematicCalculationResult() {
+
+		ValueEval[] args = { new NumberEval(21.624d / 24d + .009d), new NumberEval(2) };
+		ValueEval result = NumericFunction.TRUNC.evaluate(args, -1, (short)-1);
+		assertEquals("TRUNC", (new NumberEval(0.91d)).getNumberValue(), ((NumberEval)result).getNumberValue());
+	}
+
+	@Test
 	public void testTruncWithDecimalNumberOneArg() {
 		ValueEval[] args = { new NumberEval(2.612777) };
 		ValueEval result = NumericFunction.TRUNC.evaluate(args, -1, (short)-1);


### PR DESCRIPTION
The TRUNC implementation is still broken.  (BUG:  https://bz.apache.org/bugzilla/show_bug.cgi?id=62506 )
1. Bug 62506 reports that TRUNC(0.29, 2) = 0.28
2. The solution proposed in that bugfix still fails for some calculations (see test case)

The main argument against the proposed fix in 62506 was the performance hit of using BigDecimal for every round() operation.  Since the round() methods now use MathX methods which construct a BigDecimal from the Excel string, the TRUNC function can be fixed by using the MathX.roundDown() method.