### PR TITLE
Rework getParagraph functions for XWPF

### DIFF
--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/IBody.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/IBody.java
@@ -71,13 +71,11 @@ public interface IBody {
     public List<XWPFTable> getTables();
 
     /**
-     * if there is a corresponding {@link XWPFParagraph} of the parameter ctTable in the paragraphList of this header or footer
-     * the method will return this paragraph
-     * if there is no corresponding {@link XWPFParagraph} the method will return null
+     * Returns the paragraph corresponding to the provided {@link CTP}.
      *
      * @param p is instance of CTP and is searching for an XWPFParagraph
-     * @return null if there is no XWPFParagraph with an corresponding CTPparagraph in the paragraphList of this header or footer
-     * XWPFParagraph with the correspondig CTP p
+     * @return The paragraph corresponding to the {@link CTP}, or {@code null} if there is no corresponding paragraph in
+     * this body.
      */
     public XWPFParagraph getParagraph(CTP p);
 

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
@@ -204,15 +204,7 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
         return null;
     }
 
-    /**
-     * if there is a corresponding {@link XWPFParagraph} of the parameter p in the paragraphList of this header or footer
-     * the method will return that paragraph, otherwise the method will return null.
-     *
-     * @param p The CTP paragraph to find the corresponding {@link XWPFParagraph} for.
-     * @return The {@link XWPFParagraph} that corresponds to the CTP paragraph in the paragraph
-     * list of this footnote or null if no paragraph is found.
-     * @see org.apache.poi.xwpf.usermodel.IBody#getParagraph(CTP p)
-     */
+    @Override
     public XWPFParagraph getParagraph(CTP p) {
         for (XWPFParagraph paragraph : paragraphs) {
             if (paragraph.getCTP().equals(p))

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -1548,9 +1548,9 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
 
     @Override
     public XWPFParagraph getParagraph(CTP p) {
-        for (int i = 0; i < getParagraphs().size(); i++) {
-            if (getParagraphs().get(i).getCTP() == p) {
-                return getParagraphs().get(i);
+        for (XWPFParagraph paragraph : paragraphs) {
+            if (paragraph.getCTP() == p) {
+                return paragraph;
             }
         }
         return null;

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -1546,12 +1546,6 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
         return styles;
     }
 
-    /**
-     * get the paragraph with the CTP class p
-     *
-     * @param p
-     * @return the paragraph with the CTP class p
-     */
     @Override
     public XWPFParagraph getParagraph(CTP p) {
         for (int i = 0; i < getParagraphs().size(); i++) {

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFHeaderFooter.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFHeaderFooter.java
@@ -180,15 +180,7 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
         return null;
     }
 
-    /**
-     * if there is a corresponding {@link XWPFParagraph} of the parameter ctTable in the paragraphList of this header or footer
-     * the method will return this paragraph
-     * if there is no corresponding {@link XWPFParagraph} the method will return null
-     *
-     * @param p is instance of CTP and is searching for an XWPFParagraph
-     * @return null if there is no XWPFParagraph with an corresponding CTPparagraph in the paragraphList of this header or footer
-     * XWPFParagraph with the correspondig CTP p
-     */
+    @Override
     public XWPFParagraph getParagraph(CTP p) {
         for (XWPFParagraph paragraph : paragraphs) {
             if (paragraph.getCTP().equals(p))

--- a/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
+++ b/src/ooxml/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
@@ -175,15 +175,7 @@ public class XWPFTableCell implements IBody, ICell {
         bodyElements.remove(removedParagraph);
     }
 
-    /**
-     * if there is a corresponding {@link XWPFParagraph} of the parameter ctTable in the paragraphList of this table
-     * the method will return this paragraph
-     * if there is no corresponding {@link XWPFParagraph} the method will return null
-     *
-     * @param p is instance of CTP and is searching for an XWPFParagraph
-     * @return null if there is no XWPFParagraph with an corresponding CTPparagraph in the paragraphList of this table
-     * XWPFParagraph with the correspondig CTP p
-     */
+    @Override
     public XWPFParagraph getParagraph(CTP p) {
         for (XWPFParagraph paragraph : paragraphs) {
             if (p.equals(paragraph.getCTP())) {


### PR DESCRIPTION
The implementations all share an interface, so they don't need their own Javadoc, as the Javadoc is automatically inherited.

Also revise the implementation of `XWPFDocument#getParagraph(CTP)` to be more performant.