### PR TITLE
Improve performance of OPCPackage#getPartsByRelationshipType

### DIFF
--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -659,9 +659,15 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
 		}
 		ArrayList<PackagePart> retArr = new ArrayList<>();
 		for (PackageRelationship rel : getRelationshipsByType(relationshipType)) {
-			PackagePart part = getPart(rel);
+			PackagePart part = null;
+			try {
+				part = getPart(PackagingURIHelper.createPartName(rel.getTargetURI()));
+			} catch (InvalidFormatException ignored) {
+				// The relationship already exists, so the part should have a valid URI.
+			}
+
 			if (part != null) {
-			    retArr.add(part);
+				retArr.add(part);
 			}
 		}
 		Collections.sort(retArr);


### PR DESCRIPTION
The previous version of this function would first retrieve a filtered set of all the relationships, and then for each of those, iterate through all of the relationships again before finding the part.

Since the relationships returned by getRelationshipsByType() are already trusted, we can retrieve the part directly by formulating the part name from the relationship.