### PR TITLE
Remove PackagePart#flush() API

### DIFF
--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -416,11 +416,6 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
 	 */
 	public void flush() {
 		throwExceptionIfReadOnly();
-
-		if (this.packageProperties != null) {
-			this.packageProperties.flush();
-		}
-
 		this.flushImpl();
 	}
 

--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/PackagePart.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/PackagePart.java
@@ -724,13 +724,6 @@ public abstract class PackagePart implements RelationshipSource, Comparable<Pack
     public abstract void close();
 
     /**
-     * Flush the content of this part. If the input stream and/or output stream
-     * as in a waiting state to read or write, the must to empty their
-     * respective buffer.
-     */
-    public abstract void flush();
-
-    /**
      * Allows sub-classes to clean up before new data is added.
      */
     public void clear() {

--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/ZipPackagePart.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/ZipPackagePart.java
@@ -140,9 +140,4 @@ public class ZipPackagePart extends PackagePart {
 		throw new InvalidOperationException("Method not implemented !");
 	}
 
-	@Override
-	@NotImplemented
-	public void flush() {
-		throw new InvalidOperationException("Method not implemented !");
-	}
 }

--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/internal/MemoryPackagePart.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/internal/MemoryPackagePart.java
@@ -134,8 +134,4 @@ public final class MemoryPackagePart extends PackagePart {
 		// Do nothing
 	}
 
-	@Override
-	public void flush() {
-		// Do nothing
-	}
 }

--- a/src/ooxml/java/org/apache/poi/openxml4j/opc/internal/PackagePropertiesPart.java
+++ b/src/ooxml/java/org/apache/poi/openxml4j/opc/internal/PackagePropertiesPart.java
@@ -752,8 +752,4 @@ public final class PackagePropertiesPart extends PackagePart implements PackageP
         // Do nothing
     }
 
-    @Override
-    public void flush() {
-        // Do nothing
-    }
 }


### PR DESCRIPTION
This method is never called by the POI code, and none of the built-in implementations have meaningful implementation of the method.

PackagePropertiesPart#flush() was called in one location, but as the implementation is empty, the call is unnecessary.

Fixes Bugzilla 64959