### PR TITLE
Improve perfomance of cell evaluation

### DIFF
--- a/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFRow.java
+++ b/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFRow.java
@@ -39,7 +39,6 @@ import org.apache.poi.util.NotImplemented;
 public class SXSSFRow implements Row, Comparable<SXSSFRow>
 {
     private static final Boolean UNDEFINED = null;
-
     private final SXSSFSheet _sheet; // parent sheet
     private final SortedMap<Integer, SXSSFCell> _cells = new TreeMap<>();
     private short _style = -1; // index of cell style in style table
@@ -49,6 +48,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     // use Boolean to have a tri-state for on/off/undefined
     private Boolean _hidden = UNDEFINED;
     private Boolean _collapsed = UNDEFINED;
+    private int number;
 
     public SXSSFRow(SXSSFSheet sheet)
     {
@@ -206,7 +206,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     @Override
     public int getRowNum()
     {
-        return _sheet.getRowNum(this);
+        return number;
     }
 
     /**
@@ -437,6 +437,10 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     {
         return _sheet;
     }
+
+	public void setNumber(int rownum) {
+        number = rownum;
+	}
 //end of interface implementation
 
 

--- a/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFRow.java
+++ b/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFRow.java
@@ -39,6 +39,7 @@ import org.apache.poi.util.NotImplemented;
 public class SXSSFRow implements Row, Comparable<SXSSFRow>
 {
     private static final Boolean UNDEFINED = null;
+
     private final SXSSFSheet _sheet; // parent sheet
     private final SortedMap<Integer, SXSSFCell> _cells = new TreeMap<>();
     private short _style = -1; // index of cell style in style table
@@ -48,7 +49,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     // use Boolean to have a tri-state for on/off/undefined
     private Boolean _hidden = UNDEFINED;
     private Boolean _collapsed = UNDEFINED;
-    private int number;
+    private int _rowNumber;
 
     public SXSSFRow(SXSSFSheet sheet)
     {
@@ -206,7 +207,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     @Override
     public int getRowNum()
     {
-        return number;
+        return _rowNumber;
     }
 
     /**
@@ -438,8 +439,8 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
         return _sheet;
     }
 
-	public void setNumber(int rownum) {
-        number = rownum;
+	public void setRowNumber(int rowNumber) {
+        _rowNumber = rowNumber;
 	}
 //end of interface implementation
 

--- a/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
+++ b/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
@@ -146,6 +146,7 @@ public class SXSSFSheet implements Sheet
         }
 
         SXSSFRow newRow = new SXSSFRow(this);
+        newRow.setNumber(rownum);
         _rows.put(rownum, newRow);
         allFlushed = false;
         if(_randomAccessWindowSize >= 0 && _rows.size() > _randomAccessWindowSize) {
@@ -1889,18 +1890,13 @@ public class SXSSFSheet implements Sheet
     {
 
         removeRow(row);
+        row.setNumber(newRowNum);
         _rows.put(newRowNum,row);
     }
 
     public int getRowNum(SXSSFRow row)
     {
-        for (Map.Entry<Integer, SXSSFRow> entry : _rows.entrySet()) {
-            if (entry.getValue() == row) {
-                return entry.getKey().intValue();
-            }
-        }
-
-        return -1;
+        return row.getRowNum();
     }
 
     /**

--- a/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
+++ b/src/ooxml/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
@@ -146,7 +146,7 @@ public class SXSSFSheet implements Sheet
         }
 
         SXSSFRow newRow = new SXSSFRow(this);
-        newRow.setNumber(rownum);
+        newRow.setRowNumber(rownum);
         _rows.put(rownum, newRow);
         allFlushed = false;
         if(_randomAccessWindowSize >= 0 && _rows.size() > _randomAccessWindowSize) {
@@ -1890,7 +1890,7 @@ public class SXSSFSheet implements Sheet
     {
 
         removeRow(row);
-        row.setNumber(newRowNum);
+        row.setRowNumber(newRowNum);
         _rows.put(newRowNum,row);
     }
 


### PR DESCRIPTION
The `SXSSFRow.getRowNum()` method is heavily used from various parts of the code (in particular, from the cell evaluation method). Current implementation of the method is using iterating over sheet rows to find the row number. This approach is ineffective for large sheets. The proposed patch stores the row number directly in the row object to improve method performance.