### PR TITLE
Improve Performance of OperandResolver#parseDouble

### DIFF
--- a/src/java/org/apache/poi/ss/formula/eval/OperandResolver.java
+++ b/src/java/org/apache/poi/ss/formula/eval/OperandResolver.java
@@ -41,9 +41,10 @@ public final class OperandResolver {
                  "[+-]?(" +
                    "("+Digits+"(\\.)?("+Digits+"?)("+Exp+")?)|"+
                  "(\\."+Digits+"("+Exp+")?))"+
-                 "[\\x00-\\x20]*"); 
-            
-    
+                 "[\\x00-\\x20]*");
+    private static final Pattern fpPattern = Pattern.compile(fpRegex);
+
+
     private OperandResolver() {
         // no instances of this class
     }
@@ -292,7 +293,7 @@ public final class OperandResolver {
      */
     public static Double parseDouble(String pText) {
         
-        if (Pattern.matches(fpRegex, pText))
+        if (fpPattern.matcher(pText).matches())
             try {
                 return Double.parseDouble(pText);
             } catch (NumberFormatException e) {


### PR DESCRIPTION
improves parseDouble performance by about 85%-90%
100000 invocations 
before ~230ms 
after ~28ms (using a precompiled regex)

I am not sure how to add a meaningful performance unit test for this in this project.

Here my local test printing comparing the two different method implementations:

```
import org.junit.Test;

import java.util.regex.Pattern;

public class TestParseDoublePerformance {

	private static final String fpRegex = "[\\x00-\\x20]*[+-]?(((((\\p{Digit}+)(\\.)?((\\p{Digit}+)?)([eE][+-]?(\\p{Digit}+))?)|(\\.((\\p{Digit}+))([eE][+-]?(\\p{Digit}+))?))))[\\x00-\\x20]*";
	private static final Pattern fpPattern = Pattern.compile(fpRegex);

	@Test
	public void testPerformance() {
		long start;
		for (int j = 0; j < 10; j++) {
			start = System.nanoTime();
			for(int i = 0; i < 100000; i++) {
				parseDouble(1000 + ".1234" + i);
			}
			System.out.println("100000 x Pattern.matches(fpRegex, pText)   : " + ((System.nanoTime() - start) / 1000000.0) + "ms");

			start = System.nanoTime();
			for(int i = 0; i < 100000; i++) {
				parseDouble2(1000 + ".1234" + i);
			}
			System.out.println("100000 x fpPattern.matcher(pText).matches(): " + ((System.nanoTime() - start) / 1000000.0) + "ms");
		}
	}

	public static Double parseDouble(String pText) {
		if (Pattern.matches(fpRegex, pText)) {
			try {
				return Double.parseDouble(pText);
			} catch (NumberFormatException var2) {
				return null;
			}
		} else {
			return null;
		}
	}

	public static Double parseDouble2(String pText) {
		if (fpPattern.matcher(pText).matches()) {
			try {
				return Double.parseDouble(pText);
			} catch (NumberFormatException var2) {
				return null;
			}
		} else {
			return null;
		}
	}
}
```

Output (using jdk 11)
```
100000 x Pattern.matches(fpRegex, pText)   : 528.583911ms
100000 x fpPattern.matcher(pText).matches(): 36.131033ms
100000 x Pattern.matches(fpRegex, pText)   : 247.689554ms
100000 x fpPattern.matcher(pText).matches(): 28.203332ms
100000 x Pattern.matches(fpRegex, pText)   : 230.243142ms
100000 x fpPattern.matcher(pText).matches(): 28.258646ms
100000 x Pattern.matches(fpRegex, pText)   : 246.361356ms
100000 x fpPattern.matcher(pText).matches(): 28.530509ms
100000 x Pattern.matches(fpRegex, pText)   : 232.466833ms
100000 x fpPattern.matcher(pText).matches(): 29.992254ms
100000 x Pattern.matches(fpRegex, pText)   : 232.972345ms
100000 x fpPattern.matcher(pText).matches(): 27.680976ms
100000 x Pattern.matches(fpRegex, pText)   : 227.946587ms
100000 x fpPattern.matcher(pText).matches(): 28.363269ms
100000 x Pattern.matches(fpRegex, pText)   : 235.331679ms
100000 x fpPattern.matcher(pText).matches(): 27.830178ms
100000 x Pattern.matches(fpRegex, pText)   : 233.785736ms
100000 x fpPattern.matcher(pText).matches(): 29.759473ms
100000 x Pattern.matches(fpRegex, pText)   : 231.619982ms
100000 x fpPattern.matcher(pText).matches(): 28.545904ms
```
