### PR TITLE
Specify more granular Batik dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,9 @@ project('ooxml') {
 
         // compile only, don't add it to our dist as it blows up the size
         compile "org.apache.xmlgraphics:batik-svggen:${batikVersion}"
-        compile "org.apache.xmlgraphics:batik-bridge:${batikVersion}"
+        compile("org.apache.xmlgraphics:batik-bridge:${batikVersion}") {
+            exclude group: 'org.apache.xmlgraphics', module: 'batik-script'
+        }
         compile "org.apache.xmlgraphics:batik-codec:${batikVersion}"
         compile 'xml-apis:xml-apis-ext:1.3.04'
         compile 'org.apache.xmlgraphics:xmlgraphics-commons:2.4'
@@ -420,6 +422,7 @@ project('integrationtest') {
 
     test {
         // exclude these from the normal test-run
+        exclude '**/TestAllFiles.class'
         exclude '**/*FileHandler.class'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ subprojects {
         mockitoVersion = '3.6.0'
         hamcrestVersion = '2.2'
         xmlbeansVersion = '5.0.0'
+        batikVersion = '1.14'
     }
 
     tasks.withType(JavaCompile) {
@@ -309,7 +310,9 @@ project('ooxml') {
         compile "org.apache.logging.log4j:log4j-api:${log4jVersion}"
 
         // compile only, don't add it to our dist as it blows up the size
-        compile 'org.apache.xmlgraphics:batik-all:1.14'
+        compile "org.apache.xmlgraphics:batik-svggen:${batikVersion}"
+        compile "org.apache.xmlgraphics:batik-bridge:${batikVersion}"
+        compile "org.apache.xmlgraphics:batik-codec:${batikVersion}"
         compile 'xml-apis:xml-apis-ext:1.3.04'
         compile 'org.apache.xmlgraphics:xmlgraphics-commons:2.4'
 

--- a/build.xml
+++ b/build.xml
@@ -314,7 +314,6 @@ under the License.
     <dependency prefix="svg.batik-gvt" artifact="org.apache.xmlgraphics:batik-gvt:1.14" usage="ooxml-batik"/>
     <dependency prefix="svg.batik-i18n" artifact="org.apache.xmlgraphics:batik-i18n:1.14" usage="ooxml-batik"/>
     <dependency prefix="svg.batik-parser" artifact="org.apache.xmlgraphics:batik-parser:1.14" usage="ooxml-batik"/>
-    <dependency prefix="svg.batik-script" artifact="org.apache.xmlgraphics:batik-script:1.14" usage="ooxml-batik"/>
     <dependency prefix="svg.batik-shared-resources" artifact="org.apache.xmlgraphics:batik-shared-resources:1.14" usage="ooxml-batik"/>
     <dependency prefix="svg.batik-svg-dom" artifact="org.apache.xmlgraphics:batik-svg-dom:1.14" usage="ooxml-batik"/>
     <dependency prefix="svg.batik-svggen" artifact="org.apache.xmlgraphics:batik-svggen:1.14" usage="ooxml-batik"/>
@@ -491,7 +490,6 @@ under the License.
         <pathelement location="${svg.batik-gvt.jar}"/>
         <pathelement location="${svg.batik-i18n.jar}"/>
         <pathelement location="${svg.batik-parser.jar}"/>
-        <pathelement location="${svg.batik-script.jar}"/>
         <pathelement location="${svg.batik-shared-resources.jar}"/>
         <pathelement location="${svg.batik-svg-dom.jar}"/>
         <pathelement location="${svg.batik-svggen.jar}"/>
@@ -805,7 +803,6 @@ under the License.
                     <available file="${svg.batik-gvt.jar}"/>
                     <available file="${svg.batik-i18n.jar}"/>
                     <available file="${svg.batik-parser.jar}"/>
-                    <available file="${svg.batik-script.jar}"/>
                     <available file="${svg.batik-shared-resources.jar}"/>
                     <available file="${svg.batik-svg-dom.jar}"/>
                     <available file="${svg.batik-svggen.jar}"/>
@@ -843,7 +840,6 @@ under the License.
         <downloadfile src="${svg.batik-gvt.url}" dest="${svg.batik-gvt.jar}"/>
         <downloadfile src="${svg.batik-i18n.url}" dest="${svg.batik-i18n.jar}"/>
         <downloadfile src="${svg.batik-parser.url}" dest="${svg.batik-parser.jar}"/>
-        <downloadfile src="${svg.batik-script.url}" dest="${svg.batik-script.jar}"/>
         <downloadfile src="${svg.batik-shared-resources.url}" dest="${svg.batik-shared-resources.jar}"/>
         <downloadfile src="${svg.batik-svg-dom.url}" dest="${svg.batik-svg-dom.jar}"/>
         <downloadfile src="${svg.batik-svggen.url}" dest="${svg.batik-svggen.jar}"/>
@@ -2679,7 +2675,6 @@ under the License.
             <auxClasspath path="${svg.batik-gvt.jar}"/>
             <auxClasspath path="${svg.batik-i18n.jar}"/>
             <auxClasspath path="${svg.batik-parser.jar}"/>
-            <auxClasspath path="${svg.batik-script.jar}"/>
             <auxClasspath path="${svg.batik-shared-resources.jar}"/>
             <auxClasspath path="${svg.batik-svg-dom.jar}"/>
             <auxClasspath path="${svg.batik-svggen.jar}"/>

--- a/maven/poi-ooxml.pom
+++ b/maven/poi-ooxml.pom
@@ -100,6 +100,12 @@
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-bridge</artifactId>
             <version>1.14</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.xmlgraphics</groupId>
+                    <artifactId>batik-script</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>

--- a/maven/poi-ooxml.pom
+++ b/maven/poi-ooxml.pom
@@ -93,14 +93,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-all</artifactId>
+            <artifactId>batik-svggen</artifactId>
             <version>1.14</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-bridge</artifactId>
+            <version>1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-codec</artifactId>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>de.rototor.pdfbox</groupId>

--- a/sonar/ooxml/pom.xml
+++ b/sonar/ooxml/pom.xml
@@ -153,7 +153,17 @@
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-all</artifactId>
+            <artifactId>batik-svggen</artifactId>
+            <version>1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-bridge</artifactId>
+            <version>1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-codec</artifactId>
             <version>1.14</version>
         </dependency>
         <dependency>

--- a/sonar/ooxml/pom.xml
+++ b/sonar/ooxml/pom.xml
@@ -160,6 +160,12 @@
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-bridge</artifactId>
             <version>1.14</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.xmlgraphics</groupId>
+                    <artifactId>batik-script</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
Batik-all is a strange artifact. It's POM declares dependencies on all the sub-JARs, but its JAR has all of the sub-jars repackaged. This results in two JARs with the package "org.apache.batik.transcoder" being added to consuming applications.

The Ant build does not use batik-all, so the Maven and Gradle builds should not either.