### PR TITLE
Implement specificWorkbookSheet method

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hssf/converter/ExcelToHtmlConverter.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hssf/converter/ExcelToHtmlConverter.java
@@ -136,7 +136,7 @@ public class ExcelToHtmlConverter extends AbstractExcelConverter {
     public static Document process(HSSFWorkbook workbook) throws IOException, ParserConfigurationException {
         ExcelToHtmlConverter excelToHtmlConverter = new ExcelToHtmlConverter(
             XMLHelper.newDocumentBuilder().newDocument());
-        excelToHtmlConverter.processWorkbook(workbook);
+        excelToHtmlConverter.processWorkbookSheet(workbook);
         return excelToHtmlConverter.getDocument();
     }
 
@@ -668,7 +668,7 @@ public class ExcelToHtmlConverter extends AbstractExcelConverter {
         htmlBody.appendChild(h2);
     }
 
-    public void processWorkbook(HSSFWorkbook workbook) {
+    public void processWorkbookSheet(HSSFWorkbook workbook) {
         final SummaryInformation summaryInformation = workbook
             .getSummaryInformation();
         if (summaryInformation != null) {
@@ -688,6 +688,24 @@ public class ExcelToHtmlConverter extends AbstractExcelConverter {
             HSSFSheet sheet = workbook.getSheetAt(s);
             processSheet(sheet);
         }
+
+        htmlDocumentFacade.updateStylesheet();
+    }
+
+    public void processWorkbookSheet(HSSFWorkbook workbook, int sheetNumber) {
+        SummaryInformation summaryInformation = workbook.getSummaryInformation();
+
+        if (summaryInformation != null) {
+            this.processDocumentInformation(summaryInformation);
+        }
+
+        if (workbook.getNumberOfSheets() < sheetNumber) {
+            throw new IllegalArgumentException("invalid sheet number: " + sheetNumber);
+        }
+
+        HSSFSheet sheet = workbook.getSheetAt(sheetNumber);
+
+        this.processSheet(sheet);
 
         htmlDocumentFacade.updateStylesheet();
     }

--- a/poi-scratchpad/src/test/java/org/apache/poi/hssf/converter/TestExcelConverterSuite.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hssf/converter/TestExcelConverterSuite.java
@@ -32,6 +32,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.poi.POIDataSamples;
+import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.util.XMLHelper;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -64,6 +65,7 @@ public class TestExcelConverterSuite
     void testFo(File child) throws Exception
     {
         HSSFWorkbook workbook;
+        int sheetNumber = 0;
         try {
             workbook = AbstractExcelUtils.loadXls( child );
         } catch ( Exception exc ) {
@@ -73,7 +75,8 @@ public class TestExcelConverterSuite
 
         ExcelToHtmlConverter excelToHtmlConverter = new ExcelToHtmlConverter(
                 XMLHelper.newDocumentBuilder().newDocument() );
-        excelToHtmlConverter.processWorkbook( workbook );
+        excelToHtmlConverter.processWorkbookSheet( workbook);
+        excelToHtmlConverter.processWorkbookSheet( workbook, sheetNumber);
 
         StringWriter stringWriter = new StringWriter();
 
@@ -90,6 +93,8 @@ public class TestExcelConverterSuite
     void testHtml(File child) throws Exception
     {
         HSSFWorkbook workbook;
+        int sheetNumber = 0; //
+
         try {
             workbook = AbstractExcelUtils.loadXls( child );
         } catch ( Exception exc ) {
@@ -99,7 +104,8 @@ public class TestExcelConverterSuite
 
         ExcelToHtmlConverter excelToHtmlConverter = new ExcelToHtmlConverter(
                 XMLHelper.newDocumentBuilder().newDocument() );
-        excelToHtmlConverter.processWorkbook( workbook );
+        excelToHtmlConverter.processWorkbookSheet( workbook);
+        excelToHtmlConverter.processWorkbookSheet( workbook, sheetNumber);
 
         StringWriter stringWriter = new StringWriter();
 


### PR DESCRIPTION
The specificWorkbookSheet() takes a workbook and sheetNumber as an argument, and creates an html of a specific sheet using the predefined method processSheet().

Initially it was not possible as processSheet() is protected and cannot be used.