### PR TITLE
Correct Maximum Width Calculation of unmerged Cells

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/AutoSizeColumnTracker.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/AutoSizeColumnTracker.java
@@ -102,7 +102,7 @@ import org.apache.poi.util.Internal;
          */
         public void setMaxColumnWidths(double unmergedWidth, double mergedWidth) {
             withUseMergedCells = Math.max(withUseMergedCells, mergedWidth);
-            withSkipMergedCells = Math.max(withUseMergedCells, unmergedWidth);
+            withSkipMergedCells = Math.max(withSkipMergedCells, unmergedWidth);
         }
     }
     


### PR DESCRIPTION
I strumbled upon this code line, it did't cause a problem for me. However it could  cause a problem if at some point merged cells are used, but the unmerge width is requested.