### PR TITLE
Better parallel build performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,12 +293,14 @@ subprojects {
 				'-Djunit.jupiter.execution.parallel.config.strategy=fixed',
 				'-Djunit.jupiter.execution.parallel.config.fixed.parallelism=2'
 			]
-			maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 2 
+			maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 		} else {
 			jvmArgs += [
 			    '-Djunit.jupiter.execution.parallel.enabled=true',
 			    '-Djunit.jupiter.execution.parallel.config.strategy=dynamic',
-				'-Djunit.jupiter.execution.parallel.mode.default=concurrent'
+
+                // this setting breaks the test builds, do not use it!
+				//'-Djunit.jupiter.execution.parallel.mode.default=concurrent'
 			]
 			
 			 // Explicitly defining the maxParallelForks was always slower than not setting it

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ buildscript {
 
 plugins {
     id 'base'
+    id "com.dorongold.task-tree" version "2.1.0"
     id('org.nosphere.apache.rat') version '0.7.0'
     id 'distribution'
 }
@@ -145,6 +146,7 @@ subprojects {
         options.encoding = 'UTF-8'
         options.compilerArgs << '-Xlint:unchecked'
         options.deprecation = true
+        //options.incremental = true
 
         onlyIf {
             (name != "compileJava9" && name != "compileTest9") || JavaVersion.current() != JavaVersion.VERSION_1_8
@@ -258,7 +260,12 @@ subprojects {
 
         // set heap size for the test JVM(s)
         minHeapSize = "128m"
-        maxHeapSize = "1512m"
+        maxHeapSize = "1G"
+        
+        // Setting the maxParallelForks was always slower than not setting item
+        //maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1 
+        //maxParallelForks = Math.max( Runtime.runtime.availableProcessors() - 1, 1 )
+
 
         // Specifying the local via system properties did not work, so we set them this way
         jvmArgs << [
@@ -271,8 +278,10 @@ subprojects {
             '-Djavax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl',
             "-Dversion.id=${project.version}",
             '-ea',
-            '-Djunit.jupiter.execution.parallel.config.strategy=fixed',
-            '-Djunit.jupiter.execution.parallel.config.fixed.parallelism=2'
+            '-Djunit.jupiter.execution.parallel.enabled=true',
+            '-Djunit.jupiter.execution.parallel..mode.default=concurrent'
+            // '-Djunit.jupiter.execution.parallel.config.strategy=fixed',
+            // '-Djunit.jupiter.execution.parallel.config.fixed.parallelism=2'
             // -Xjit:verbose={compileStart|compileEnd},vlog=build/jit.log${no.jit.sherlock}   ... if ${isIBMVM}
         ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ import javax.xml.xpath.XPath
 import javax.xml.xpath.XPathConstants
 import javax.xml.xpath.XPathFactory
 
+
 buildscript {
     repositories {
         maven { url 'https://plugins.gradle.org/m2/' }
@@ -51,6 +52,8 @@ if (project.hasProperty('enableSonar')) {
     println 'Enabling Sonar support'
     apply plugin: 'org.sonarqube'
 }
+
+boolean isCIBuild = false;
 
 // For help converting an Ant build to a Gradle build, see
 // https://docs.gradle.org/current/userguide/ant.html
@@ -142,11 +145,12 @@ subprojects {
         }
     }
 
+
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
         options.compilerArgs << '-Xlint:unchecked'
         options.deprecation = true
-        //options.incremental = true
+        options.incremental = true
 
         onlyIf {
             (name != "compileJava9" && name != "compileTest9") || JavaVersion.current() != JavaVersion.VERSION_1_8
@@ -261,11 +265,7 @@ subprojects {
         // set heap size for the test JVM(s)
         minHeapSize = "128m"
         maxHeapSize = "1G"
-        
-        // Setting the maxParallelForks was always slower than not setting item
-        //maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1 
-        //maxParallelForks = Math.max( Runtime.runtime.availableProcessors() - 1, 1 )
-
+       
 
         // Specifying the local via system properties did not work, so we set them this way
         jvmArgs << [
@@ -278,12 +278,35 @@ subprojects {
             '-Djavax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl',
             "-Dversion.id=${project.version}",
             '-ea',
-            '-Djunit.jupiter.execution.parallel.enabled=true',
-            '-Djunit.jupiter.execution.parallel..mode.default=concurrent'
-            // '-Djunit.jupiter.execution.parallel.config.strategy=fixed',
-            // '-Djunit.jupiter.execution.parallel.config.fixed.parallelism=2'
             // -Xjit:verbose={compileStart|compileEnd},vlog=build/jit.log${no.jit.sherlock}   ... if ${isIBMVM}
         ]
+        
+        // detect if running on Jenkins/CI
+        isCIBuild |= Boolean.valueOf(System.getenv("CI_BUILD"));
+        
+        if (isCIBuild) {
+        	jvmArgs += [
+        	    // Strictly serial
+        	    // '-Djunit.jupiter.execution.parallel.enabled=false',
+        	    
+        	    // OR parallel on 2 threads
+				'-Djunit.jupiter.execution.parallel.config.strategy=fixed',
+				'-Djunit.jupiter.execution.parallel.config.fixed.parallelism=2'
+			]
+			maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 2 
+		} else {
+			jvmArgs += [
+			    '-Djunit.jupiter.execution.parallel.enabled=true',
+			    '-Djunit.jupiter.execution.parallel.config.strategy=dynamic',
+				'-Djunit.jupiter.execution.parallel.mode.default=concurrent'
+			]
+			
+			 // Explicitly defining the maxParallelForks was always slower than not setting it
+			 // So we leave this to Gradle itself, which seems to be very smart
+			 // maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1 
+			 // maxParallelForks = Math.max( Runtime.runtime.availableProcessors() - 1, 1 )
+
+        }
 
         // show standard out and standard error of the test JVM(s) on the console
         //testLogging.showStandardStreams = true
@@ -508,7 +531,9 @@ task allJavaDoc(type: Javadoc) {
 }
 
 
-task jenkins(dependsOn: ['replaceVersion', subprojects.build, 'binDistZip','binDistTar','srcDistZip','srcDistTar']) {}
+task jenkins(dependsOn: ['replaceVersion', subprojects.build, 'binDistZip','binDistTar','srcDistZip','srcDistTar']) {
+	isCIBuild = true;
+}
 
 clean {
     delete "${rootDir}/build/dist"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,15 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m
+# Less than 2G definitely slows things down.
+org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# Activating will be much faster, but break the build of 'poi-ooxml-lite'
+# @todo: look into poi-ooxml-lite task generateModuleInfo and enforce running whatever is needed before
+org.gradle.caching=false
+
+# Modularise your project and enable parallel build
+org.gradle.parallel=true
+
+# Enable configure on demand.
+org.gradle.configureondemand=true
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Less than 2G definitely slows things down.
-org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# Less than 2G definitely slows things down. -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2G -XX:MaxPermSize=512m -Dfile.encoding=UTF-8
 
 # Activating will be much faster, but break the build of 'poi-ooxml-lite'
 # @todo: look into poi-ooxml-lite task generateModuleInfo and enforce running whatever is needed before

--- a/poi-integration/src/test/java/org/apache/poi/stress/TestAllFiles.java
+++ b/poi-integration/src/test/java/org/apache/poi/stress/TestAllFiles.java
@@ -36,6 +36,8 @@ import java.util.stream.Stream;
 import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.tools.ant.DirectoryScanner;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -66,7 +68,7 @@ import org.opentest4j.AssertionFailedError;
  *  that we do not remove expected sanity checks.
  */
 // also need to set JVM parameter: -Djunit.jupiter.execution.parallel.enabled=true
-//@Execution(ExecutionMode.CONCURRENT)
+@Execution(ExecutionMode.CONCURRENT)
 public class TestAllFiles {
     private static final String DEFAULT_TEST_DATA_PATH = "test-data";
     public static final File ROOT_DIR = new File(System.getProperty("POI.testdata.path", DEFAULT_TEST_DATA_PATH));

--- a/poi/build.gradle
+++ b/poi/build.gradle
@@ -183,6 +183,7 @@ javadocJar {
 }
 
 sourcesJar {
+    dependsOn generateVersionJava
     metaInf {
         from("$projectDir/../legal/LICENSE")
         from("$projectDir/../legal/NOTICE")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,4 @@
 rootProject.name = 'poi'
 
 include 'poi', 'poi-ooxml-full', 'poi-ooxml-lite-agent', 'poi-scratchpad',
-        'poi-ooxml', 'poi-excelant', 'poi-examples', 'poi-integration',
-        'poi-ooxml-lite'
+        'poi-ooxml', 'poi-excelant', 'poi-examples', 'poi-integration' , 'poi-ooxml-lite'


### PR DESCRIPTION
Following tweaks to Gradle reduces JAR build time by 27%:

1) `gradle clean jar` (after a first full warmup build), on a Ryzen7 5800U (8 physical cores, 16GB Ram)
2) the measurement is not scientific, I just used the Gradle Build time and Variable CPU frequencies and worked in parallel on the computer
3) the measurement has had around 15 seconds variance 
4) original build time was around 08:40 plus/minus 15 sec. new build time reduce to 06:20 plus/minus 15 seconds
5) build still worked on a memory starved laptop (2 Cores, 3 GByte)
6) build was stable, I ran more than 30 tests with various combinations of settings. The commit shows the best/optimal combination.
7) during the build, all CPUs have been used continuously and the machine was under serious load
8) build has been tested with JDK11
