### PR TITLE
Change regex to account for decimals with no leading digit

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/format/CellFormatPart.java
+++ b/poi/src/main/java/org/apache/poi/ss/format/CellFormatPart.java
@@ -105,7 +105,7 @@ public class CellFormatPart {
     static {
         // A condition specification
         String condition = "([<>=]=?|!=|<>)    # The operator\n" +
-                "  \\s*(-?[0-9]+(?:\\.[0-9]*)?)\\s*  # The constant to test against\n";
+                "  \\s*(-?([0-9]+(?:\\.[0-9]*)?)|(\\.[0-9]*))\\s*  # The constant to test against\n";
 
         // A currency symbol / string, in a specific locale
         String currency = "(\\[\\$.{0,3}-[0-9a-f]{3}\\])";

--- a/poi/src/test/java/org/apache/poi/ss/format/TestCellFormat.java
+++ b/poi/src/test/java/org/apache/poi/ss/format/TestCellFormat.java
@@ -1026,4 +1026,21 @@ class TestCellFormat {
                 .map(CellFormatPart.NAMED_COLORS::get)
                 .forEach(Assertions::assertNotNull);
     }
+
+    @Test
+    void testDecimalFormat(){
+        // Create a workbook, row and cell to test with
+        Workbook wb = new HSSFWorkbook();
+        Sheet sheet = wb.createSheet();
+        Row row = sheet.createRow(0);
+        Cell cell = row.createCell(0);
+
+        CellFormat cf = CellFormat.getInstance("[<=.01]0.00%;#,##0");
+
+        cell.setCellValue(1);
+        assertEquals("1", cf.apply(cell).text);
+
+        cell.setCellValue(.001);
+        assertEquals("0.10%", cf.apply(cell).text);
+    }
 }


### PR DESCRIPTION
This PR changes the condition regex to account for the case where the comparison value is a decimal with no preceding digits (i.e [<=.01])