### PR TITLE
Customize Spliterator implementations for better parallelism

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackageRelationshipCollection.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackageRelationshipCollection.java
@@ -374,6 +374,16 @@ public final class PackageRelationshipCollection implements Iterable<PackageRela
     }
 
     /**
+     * Get this collection's spliterator.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<PackageRelationship> spliterator() {
+        return relationshipsByID.values().spliterator();
+    }
+
+    /**
      * Get an iterator of a collection with all relationship with the specified
      * type.
      *

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFTextParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFTextParagraph.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -118,6 +119,14 @@ public class XDDFTextParagraph implements Iterable<XDDFTextRun> {
     @Override
     public Iterator<XDDFTextRun> iterator() {
         return _runs.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XDDFTextRun> spliterator() {
+        return _runs.spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFTextParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFTextParagraph.java
@@ -48,7 +48,7 @@ import org.openxmlformats.schemas.drawingml.x2006.main.CTTextSpacing;
  * is the highest level text separation mechanism.
  */
 @Beta
-public class XDDFTextParagraph {
+public class XDDFTextParagraph implements Iterable<XDDFTextRun> {
     private XDDFTextBody _parent;
     private XDDFParagraphProperties _properties;
     private final CTTextParagraph _p;
@@ -115,6 +115,7 @@ public class XDDFTextParagraph {
         return _runs;
     }
 
+    @Override
     public Iterator<XDDFTextRun> iterator() {
         return _runs.iterator();
     }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -85,6 +86,14 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
     @Override
     public Iterator<XSLFTextParagraph> iterator() {
         return getTextParagraphs().iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XSLFTextParagraph> spliterator() {
+        return getTextParagraphs().spliterator();
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFDrawing.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFDrawing.java
@@ -18,6 +18,7 @@
 package org.apache.poi.xssf.streaming;
 
 import java.util.Iterator;
+import java.util.Spliterator;
 
 import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.Comment;
@@ -66,6 +67,14 @@ public class SXSSFDrawing implements Drawing<XSSFShape> {
     public Iterator<XSSFShape> iterator() {
         return _drawing.getShapes().iterator();
     }
-    
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XSSFShape> spliterator() {
+        return _drawing.getShapes().spliterator();
+    }
+
 }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
@@ -101,15 +101,6 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     }
 //begin of interface implementation
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Iterator<Cell> iterator()
-    {
-        return new FilledCellIterator();
-    }
-
-    /**
      * Use this to create new cells within the row and return it.
      * <p>
      * The cell that is returned is a {@link CellType#BLANK}. The type can be changed
@@ -427,7 +418,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     @Override
     public Iterator<Cell> cellIterator()
     {
-        return iterator();
+        return new FilledCellIterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.SortedMap;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.TreeMap;
 
 import org.apache.poi.ss.SpreadsheetVersion;
@@ -59,6 +61,11 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     public Iterator<Cell> allCellsIterator()
     {
         return new CellIterator();
+    }
+
+    public Spliterator<Cell> allCellsSpliterator()
+    {
+        return Spliterators.spliterator(allCellsIterator(), getLastCellNum(), 0);
     }
 
     public boolean hasCustomHeight()
@@ -419,6 +426,22 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
     public Iterator<Cell> cellIterator()
     {
         return new FilledCellIterator();
+    }
+
+    /**
+     * Create a spliterator over the cells from [0, getLastCellNum()).
+     * Includes blank cells, excludes empty cells
+     *
+     * Returns a spliterator over all filled cells (created via Row.createCell())
+     * Throws ConcurrentModificationException if cells are added, moved, or
+     * removed after the spliterator is created.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<Cell> spliterator() {
+        return (Spliterator<Cell>)(Spliterator<? extends Cell>) _cells.values().spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.TreeMap;
 
 import org.apache.poi.ss.SpreadsheetVersion;
@@ -501,6 +502,20 @@ public class SXSSFSheet implements Sheet, OoxmlSheetExtensions {
         @SuppressWarnings("unchecked")
         Iterator<Row> result = (Iterator<Row>)(Iterator<? extends Row>)_rows.values().iterator();
         return result;
+    }
+
+    /**
+     *  Returns a spliterator of the physical rows
+     *
+     * @return a spliterator of the PHYSICAL rows.  Meaning the 3rd element may not
+     * be the third row if say for instance the second row is undefined.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<Row> spliterator() {
+        return (Spliterator<Row>)(Spliterator<? extends Row>) _rows.values().spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
@@ -100,11 +100,6 @@ public class SXSSFSheet implements Sheet, OoxmlSheetExtensions {
     }
 
     //start of interface implementation
-    @Override
-    public Iterator<Row> iterator() {
-        return rowIterator();
-    }
-
     /**
      * Create a new row within the sheet and return the high level representation
      *

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
 
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.Zip64Mode;
@@ -756,6 +757,19 @@ public class SXSSFWorkbook implements Workbook {
     @Override
     public Iterator<Sheet> sheetIterator() {
         return new SheetIterator<>();
+    }
+
+    /**
+     *  Returns a spliterator of the sheets in the workbook
+     *  in sheet order. Includes hidden and very hidden sheets.
+     *
+     * @return a spliterator of the sheets.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<Sheet> spliterator() {
+        return _wb.spliterator();
     }
 
     protected final class SheetIterator<T extends Sheet> implements Iterator<T> {

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
@@ -787,15 +787,6 @@ public class SXSSFWorkbook implements Workbook {
     }
 
     /**
-     * Alias for {@link #sheetIterator()} to allow
-     * foreach loops
-     */
-    @Override
-    public Iterator<Sheet> iterator() {
-        return sheetIterator();
-    }
-
-    /**
      * Get the Sheet object at the given index.
      *
      * @param index of the sheet number (0-based physical and logical)

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFDrawing.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFDrawing.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import javax.xml.namespace.QName;
 
@@ -722,6 +723,14 @@ public final class XSSFDrawing extends POIXMLDocumentPart implements Drawing<XSS
     @Override
     public Iterator<XSSFShape> iterator() {
         return getShapes().iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XSSFShape> spliterator() {
+        return getShapes().spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
@@ -120,21 +120,6 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
     }
 
     /**
-     * Alias for {@link #cellIterator()} to allow  foreach loops:
-     * <blockquote><pre>
-     * for(Cell cell : row){
-     *     ...
-     * }
-     * </pre></blockquote>
-     *
-     * @return an iterator over cells in this row.
-     */
-    @Override
-    public Iterator<Cell> iterator() {
-        return cellIterator();
-    }
-
-    /**
      * Compares two {@code XSSFRow} objects.  Two rows are equal if they belong to the same worksheet and
      * their row indexes are equal.
      *

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
@@ -22,6 +22,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.TreeMap;
 
 import org.apache.poi.ss.SpreadsheetVersion;
@@ -117,6 +118,19 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
     @SuppressWarnings("unchecked")
     public Iterator<Cell> cellIterator() {
         return (Iterator<Cell>)(Iterator<? extends Cell>)_cells.values().iterator();
+    }
+
+    /**
+     * Cell spliterator over the physically defined cells
+     *
+     * @return a spliterator over cells in this row.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<Cell> spliterator() {
+        return (Spliterator<Cell>)(Spliterator<? extends Cell>)_cells.values().spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFShapeGroup.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFShapeGroup.java
@@ -18,6 +18,7 @@
 package org.apache.poi.xssf.usermodel;
 
 import java.util.Iterator;
+import java.util.Spliterator;
 
 import org.apache.poi.openxml4j.opc.PackageRelationship;
 import org.apache.poi.ss.usermodel.ShapeContainer;
@@ -228,6 +229,14 @@ public final class XSSFShapeGroup extends XSSFShape implements ShapeContainer<XS
     @Override
     public Iterator<XSSFShape> iterator() {
         return getDrawing().getShapes(this).iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XSSFShape> spliterator() {
+        return getDrawing().getShapes(this).spliterator();
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
@@ -2058,6 +2058,19 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet, OoxmlSheetEx
     }
 
     /**
+     * @return a spliterator of the PHYSICAL rows.  Meaning the 3rd element may not
+     * be the third row if say for instance the second row is undefined.
+     * Call getRowNum() on each row if you care which one it is.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<Row> spliterator() {
+        return (Spliterator<Row>)(Spliterator<? extends Row>) _rows.values().spliterator();
+    }
+
+    /**
      * Flag indicating whether the sheet displays Automatic Page Breaks.
      *
      * @return {@code true} if the sheet displays Automatic Page Breaks.

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
@@ -2058,15 +2058,6 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet, OoxmlSheetEx
     }
 
     /**
-     * Alias for {@link #rowIterator()} to
-     *  allow foreach loops
-     */
-    @Override
-    public Iterator<Row> iterator() {
-        return rowIterator();
-    }
-
-    /**
      * Flag indicating whether the sheet displays Automatic Page Breaks.
      *
      * @return {@code true} if the sheet displays Automatic Page Breaks.

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSimpleShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSimpleShape.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -165,6 +166,14 @@ public class XSSFSimpleShape extends XSSFShape implements Iterable<XSSFTextParag
     @Override
     public Iterator<XSSFTextParagraph> iterator() {
         return _paragraphs.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XSSFTextParagraph> spliterator() {
+        return _paragraphs.spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
 import java.util.regex.Pattern;
 
 import javax.xml.namespace.QName;
@@ -1267,6 +1268,20 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
     @Override
     public Iterator<Sheet> iterator() {
         return sheetIterator();
+    }
+
+    /**
+     * Returns a spliterator of the sheets in the workbook
+     * in sheet order. Includes hidden and very hidden sheets.
+     *
+     * @return a spliterator of the sheets.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<Sheet> spliterator() {
+        return (Spliterator<Sheet>)(Spliterator<? extends Sheet>) sheets.spliterator();
     }
 
     private final class SheetIterator<T extends Sheet> implements Iterator<T> {

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
@@ -20,6 +20,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.util.Internal;
@@ -110,6 +111,17 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
     @Override
     public Iterator<XWPFParagraph> iterator() {
         return paragraphs.iterator();
+    }
+
+    /**
+     * Get a spliterator over the {@link XWPFParagraph}s in the footnote.
+     * @return Spliterator over the paragraph list.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<XWPFParagraph> spliterator() {
+        return paragraphs.spliterator();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
 
 import javax.xml.namespace.QName;
 
@@ -346,6 +347,15 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
 
     public Iterator<IBodyElement> getBodyElementsIterator() {
         return bodyElements.iterator();
+    }
+
+    /**
+     * returns a Spliterator with paragraphs and tables
+     *
+     * @since POI 5.2.0
+     */
+    public Spliterator<IBodyElement> getBodyElementsSpliterator() {
+        return bodyElements.spliterator();
     }
 
     @Override
@@ -1582,8 +1592,22 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
         return tables.iterator();
     }
 
+    /**
+     * @since POI 5.2.0
+     */
+    public Spliterator<XWPFTable> getTablesSpliterator() {
+        return tables.spliterator();
+    }
+
     public Iterator<XWPFParagraph> getParagraphsIterator() {
         return paragraphs.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    public Spliterator<XWPFParagraph> getParagraphsSpliterator() {
+        return paragraphs.spliterator();
     }
 
     /**

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestSXSSFSheet.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestSXSSFSheet.java
@@ -179,7 +179,9 @@ public final class TestSXSSFSheet extends BaseTestXSheet {
         assertEquals(2, row0.getRowNum(), "Row 2 knows its row number");
         assertEquals(1, sheet.getRowNum(row1), "Sheet knows Row 1's row number");
         assertEquals(2, sheet.getRowNum(row0), "Sheet knows Row 2's row number");
-        assertEquals(row1, sheet.iterator().next(), "Sheet row iteratation order should be ascending");
+        assertEquals(row1, sheet.iterator().next(), "Sheet row iteration order should be ascending");
+        sheet.spliterator().tryAdvance(row ->
+                assertEquals(row1, row, "Sheet row iteration order should be ascending"));
 
         wb.close();
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/PPDrawing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/PPDrawing.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Spliterator;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -83,6 +84,14 @@ public final class PPDrawing extends RecordAtom implements Iterable<EscherRecord
     @Override
     public Iterator<EscherRecord> iterator() {
         return getEscherRecords().iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<EscherRecord> spliterator() {
+        return getEscherRecords().spliterator();
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFGroupShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFGroupShape.java
@@ -21,6 +21,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -259,6 +260,14 @@ implements HSLFShapeContainer, GroupShape<HSLFShape,HSLFTextParagraph> {
     @Override
     public Iterator<HSLFShape> iterator() {
         return getShapes().iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<HSLFShape> spliterator() {
+        return getShapes().spliterator();
     }
 
     @Override

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSheet.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSheet.java
@@ -22,6 +22,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import org.apache.poi.ddf.EscherContainerRecord;
 import org.apache.poi.ddf.EscherDgRecord;
@@ -360,6 +361,13 @@ public abstract class HSLFSheet implements HSLFShapeContainer, Sheet<HSLFShape,H
         return getShapes().iterator();
     }
 
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<HSLFShape> spliterator() {
+        return getShapes().spliterator();
+    }
 
     /**
      * @return whether shapes on the master sheet should be shown. By default master graphics is turned off.

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextParagraph.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextParagraph.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -339,6 +340,14 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
     @Override
     public Iterator<HSLFTextRun> iterator() {
         return _runs.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<HSLFTextRun> spliterator() {
+        return _runs.spliterator();
     }
 
     @Override

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextShape.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -702,6 +703,14 @@ implements TextShape<HSLFShape,HSLFTextParagraph> {
     @Override
     public Iterator<HSLFTextParagraph> iterator() {
         return _paragraphs.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<HSLFTextParagraph> spliterator() {
+        return _paragraphs.spliterator();
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/ddf/EscherArrayProperty.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherArrayProperty.java
@@ -20,6 +20,8 @@ package org.apache.poi.ddf;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -261,6 +263,14 @@ public final class EscherArrayProperty extends EscherComplexProperty implements 
                 throw new UnsupportedOperationException("not yet implemented");
             }
         };
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<byte[]> spliterator() {
+        return Spliterators.spliterator(iterator(), getNumberOfElementsInArray(), 0);
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/ddf/EscherContainerRecord.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherContainerRecord.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.function.Supplier;
 
 import org.apache.logging.log4j.LogManager;
@@ -170,6 +171,15 @@ public final class EscherContainerRecord extends EscherRecord implements Iterabl
         return Collections.unmodifiableList(_childRecords).iterator();
     }
 
+    /**
+     * @return a spliterator over the child records
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<EscherRecord> spliterator() {
+        return _childRecords.spliterator();
+    }
 
     /**
      * replaces the internal child list with the contents of the supplied {@code childRecords}

--- a/poi/src/main/java/org/apache/poi/hssf/record/PageBreakRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/PageBreakRecord.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.function.Supplier;
 
 import org.apache.poi.common.usermodel.GenericRecord;
@@ -144,6 +145,13 @@ public abstract class PageBreakRecord extends StandardRecord {
 
     public final Iterator<Break> getBreaksIterator() {
         return _breaks.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    public final Spliterator<Break> getBreaksSpliterator() {
+        return _breaks.spliterator();
     }
 
    /**

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/RowRecordsAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/RowRecordsAggregate.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.TreeMap;
 
 import org.apache.poi.hssf.model.RecordStream;
@@ -307,6 +308,13 @@ public final class RowRecordsAggregate extends RecordAggregate {
         return _rowRecords.values().iterator();
     }
 
+    /**
+     * @since POI 5.2.0
+     */
+    public Spliterator<RowRecord> getSpliterator() {
+        return _rowRecords.values().spliterator();
+    }
+
     public int findStartOfRowOutlineGroup(int row) {
         // Find the start of the group.
         RowRecord rowRecord = this.getRow( row );
@@ -459,6 +467,15 @@ public final class RowRecordsAggregate extends RecordAggregate {
      */
     public Iterator<CellValueRecordInterface> getCellValueIterator() {
         return _valuesAgg.iterator();
+    }
+
+    /**
+     * Returns a spliterator for the cell values
+     *
+     * @since POI 5.2.0
+     */
+    public Spliterator<CellValueRecordInterface> getCellValueSpliterator() {
+        return _valuesAgg.spliterator();
     }
 
     public IndexRecord createIndexRecord(int indexRecordOffset, int sizeOfInitialSheetRecords) {

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/ValueRecordsAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/ValueRecordsAggregate.java
@@ -19,6 +19,8 @@ package org.apache.poi.hssf.record.aggregates;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 import org.apache.poi.hssf.model.RecordStream;
 import org.apache.poi.hssf.record.BlankRecord;
@@ -353,5 +355,15 @@ public final class ValueRecordsAggregate implements Iterable<CellValueRecordInte
     /** value iterator */
     public Iterator<CellValueRecordInterface> iterator() {
         return new ValueIterator();
+    }
+
+    /**
+     * value spliterator
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<CellValueRecordInterface> spliterator() {
+        return Spliterators.spliterator(iterator(), getPhysicalNumberOfCells(), 0);
     }
 }

--- a/poi/src/main/java/org/apache/poi/hssf/record/common/UnicodeString.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/common/UnicodeString.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Spliterator;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -322,6 +323,16 @@ public class UnicodeString implements Comparable<UnicodeString>, Duplicatable, G
         return field_4_format_runs.iterator();
       }
       return null;
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    public Spliterator<FormatRun> formatSpliterator() {
+        if (field_4_format_runs != null) {
+            return field_4_format_runs.spliterator();
+        }
+        return null;
     }
 
     public void removeFormatRun(FormatRun r) {

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPatriarch.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPatriarch.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
 
 import org.apache.poi.ddf.EscherComplexProperty;
 import org.apache.poi.ddf.EscherContainerRecord;
@@ -552,6 +553,14 @@ public final class HSSFPatriarch implements HSSFShapeContainer, Drawing<HSSFShap
     @Override
     public Iterator<HSSFShape> iterator() {
         return _shapes.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<HSSFShape> spliterator() {
+        return _shapes.spliterator();
     }
 
     protected HSSFSheet getSheet() {

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRow.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRow.java
@@ -630,14 +630,6 @@ public final class HSSFRow implements Row, Comparable<HSSFRow> {
     {
       return new CellIterator();
     }
-    /**
-     * Alias for {@link #cellIterator} to allow
-     *  foreach loops
-     */
-    @Override
-    public Iterator<Cell> iterator() {
-       return cellIterator();
-    }
 
     /**
      * An iterator over the (physical) cells in the row.

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFShapeGroup.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFShapeGroup.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import org.apache.poi.ddf.DefaultEscherRecordFactory;
 import org.apache.poi.ddf.EscherBoolProperty;
@@ -409,5 +410,13 @@ public class HSSFShapeGroup extends HSSFShape implements HSSFShapeContainer {
     @Override
     public Iterator<HSSFShape> iterator() {
         return shapes.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<HSSFShape> spliterator() {
+        return shapes.spliterator();
     }
 }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
@@ -963,16 +963,6 @@ public final class HSSFSheet implements Sheet {
     }
 
     /**
-     * Alias for {@link #rowIterator()} to allow
-     * foreach loops
-     */
-    @Override
-    public Iterator<Row> iterator() {
-        return rowIterator();
-    }
-
-
-    /**
      * used internally in the API to get the low level Sheet record represented by this
      * Object.
      *

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -960,6 +961,19 @@ public final class HSSFSheet implements Sheet {
         @SuppressWarnings("unchecked") // can this clumsy generic syntax be improved?
                 Iterator<Row> result = (Iterator<Row>) (Iterator<? extends Row>) _rows.values().iterator();
         return result;
+    }
+
+    /**
+     * @return a spliterator of the PHYSICAL rows.  Meaning the 3rd element may not
+     *         be the third row if say for instance the second row is undefined.
+     *         Call getRowNum() on each row if you care which one it is.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked") // can this clumsy generic syntax be improved?
+    public Spliterator<Row> spliterator() {
+        return (Spliterator<Row>)(Spliterator<? extends Row>) _rows.values().spliterator();
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.regex.Pattern;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -985,6 +986,20 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
     @Override
     public Iterator<Sheet> sheetIterator() {
         return new SheetIterator<>();
+    }
+
+    /**
+     * Returns a spliterator of the sheets in the workbook
+     * in sheet order. Includes hidden and very hidden sheets.
+     *
+     * @return a spliterator of the sheets.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Spliterator<Sheet> spliterator() {
+        return (Spliterator<Sheet>)(Spliterator<? extends Sheet>) _sheets.spliterator();
     }
 
     private final class SheetIterator<T extends Sheet> implements Iterator<T> {

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -987,15 +987,6 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
         return new SheetIterator<>();
     }
 
-    /**
-     * Alias for {@link #sheetIterator()} to allow
-     * foreach loops
-     */
-    @Override
-    public Iterator<Sheet> iterator() {
-        return sheetIterator();
-    }
-
     private final class SheetIterator<T extends Sheet> implements Iterator<T> {
         final private Iterator<T> it;
 

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/DirectoryNode.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/DirectoryNode.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
 
 import org.apache.poi.hpsf.ClassID;
 import org.apache.poi.poifs.dev.POIFSViewable;
@@ -551,6 +552,16 @@ public class DirectoryNode
     @Override
     public Iterator<Entry> iterator() {
         return getEntries();
+    }
+
+    /**
+     * Returns a Spliterator over all the entries
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<Entry> spliterator() {
+        return _entries.spliterator();
     }
 
     /* **********  END  begin implementation of POIFSViewable ********** */

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/FilteringDirectoryNode.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/FilteringDirectoryNode.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 import org.apache.poi.hpsf.ClassID;
 
@@ -113,6 +115,14 @@ public class FilteringDirectoryNode implements DirectoryEntry
    @Override
    public Iterator<Entry> iterator() {
       return getEntries();
+   }
+
+   /**
+    * @since POI 5.2.0
+    */
+   @Override
+   public Spliterator<Entry> spliterator() {
+      return Spliterators.spliterator(iterator(), getEntryCount(), 0);
    }
 
    @Override

--- a/poi/src/main/java/org/apache/poi/poifs/property/DirectoryProperty.java
+++ b/poi/src/main/java/org/apache/poi/poifs/property/DirectoryProperty.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.Spliterator;
 
 /**
  * Directory property
@@ -242,6 +243,18 @@ public class DirectoryProperty extends Property implements Parent, Iterable<Prop
      */
     public Iterator<Property> iterator() {
         return getChildren();
+    }
+    /**
+     * Get a spliterator over the children of this Parent; all elements
+     * are instances of Property.
+     *
+     * @return Spliterator of children; may refer to an empty collection
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<Property> spliterator() {
+        return _children.spliterator();
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/CustomGeometry.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/CustomGeometry.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Spliterator;
 
 /**
  * Definition of a custom geometric shape
@@ -108,6 +109,14 @@ public final class CustomGeometry implements Iterable<PathIf>{
     @Override
     public Iterator<PathIf> iterator() {
         return paths.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<PathIf> spliterator() {
+        return paths.spliterator();
     }
 
     public Path getTextBounds(){

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/LookupUtils.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/LookupUtils.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -123,6 +125,12 @@ public final class LookupUtils {
                 }
             };
         }
+        /**
+         * @since POI 5.2.0
+         */
+        default Spliterator<Integer> indexSpliterator() {
+            return Spliterators.spliterator(indexIterator(), getSize(), 0);
+        }
         default Iterator<Integer> reverseIndexIterator() {
             return new Iterator<Integer>() {
                 int pos = getSize() - 1;
@@ -137,6 +145,12 @@ public final class LookupUtils {
                     return pos--;
                 }
             };
+        }
+        /**
+         * @since POI 5.2.0
+         */
+        default Spliterator<Integer> reverseIndexSpliterator() {
+            return Spliterators.spliterator(reverseIndexIterator(), getSize(), 0);
         }
     }
 

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Row.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Row.java
@@ -18,6 +18,8 @@
 package org.apache.poi.ss.usermodel;
 
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 /**
  * High level representation of a row of a spreadsheet.
@@ -224,6 +226,17 @@ public interface Row extends Iterable<Cell> {
     @Override
     default Iterator<Cell> iterator() {
         return cellIterator();
+    }
+
+    /**
+     * @return Cell spliterator of the physically defined cells.  Note element 4 may
+     * actually be row cell depending on how many are defined!
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    default Spliterator<Cell> spliterator() {
+        return Spliterators.spliterator(cellIterator(), getPhysicalNumberOfCells(), 0);
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Row.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Row.java
@@ -212,6 +212,21 @@ public interface Row extends Iterable<Cell> {
     Iterator<Cell> cellIterator();
 
     /**
+     * Alias for {@link #cellIterator()} to allow  foreach loops:
+     * <blockquote><pre>
+     * for(Cell cell : row){
+     *     ...
+     * }
+     * </pre></blockquote>
+     *
+     * @return an iterator over cells in this row.
+     */
+    @Override
+    default Iterator<Cell> iterator() {
+        return cellIterator();
+    }
+
+    /**
      * Returns the Sheet this row belongs to
      *
      * @return the Sheet that owns this row

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Sheet.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Sheet.java
@@ -376,6 +376,14 @@ public interface Sheet extends Iterable<Row> {
     Iterator<Row> rowIterator();
 
     /**
+     * Alias for {@link #rowIterator()} to allow foreach loops
+     */
+    @Override
+    default Iterator<Row> iterator() {
+        return rowIterator();
+    }
+
+    /**
      * Control if Excel should be asked to recalculate all formulas on this sheet
      * when the workbook is opened.
      *

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Sheet.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Sheet.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
@@ -381,6 +383,19 @@ public interface Sheet extends Iterable<Row> {
     @Override
     default Iterator<Row> iterator() {
         return rowIterator();
+    }
+
+    /**
+     *  Returns a spliterator of the physical rows
+     *
+     * @return a spliterator of the PHYSICAL rows.  Meaning the 3rd element may not
+     * be the third row if say for instance the second row is undefined.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    default Spliterator<Row> spliterator() {
+        return Spliterators.spliterator(rowIterator(), getPhysicalNumberOfRows(), 0);
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Workbook.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Workbook.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
 
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.formula.EvaluationWorkbook;
@@ -226,6 +228,19 @@ public interface Workbook extends Closeable, Iterable<Sheet> {
     @Override
     default Iterator<Sheet> iterator() {
         return sheetIterator();
+    }
+
+    /**
+     *  Returns a spliterator of the sheets in the workbook
+     *  in sheet order. Includes hidden and very hidden sheets.
+     *
+     * @return a spliterator of the sheets.
+     *
+     * @since POI 5.2.0
+     */
+    @Override
+    default Spliterator<Sheet> spliterator() {
+        return Spliterators.spliterator(sheetIterator(), getNumberOfSheets(), 0);
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Workbook.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Workbook.java
@@ -221,6 +221,14 @@ public interface Workbook extends Closeable, Iterable<Sheet> {
     Iterator<Sheet> sheetIterator();
 
     /**
+     * Alias for {@link #sheetIterator()} to allow foreach loops
+     */
+    @Override
+    default Iterator<Sheet> iterator() {
+        return sheetIterator();
+    }
+
+    /**
      * Get the number of spreadsheets in the workbook
      *
      * @return the number of sheets

--- a/poi/src/main/java/org/apache/poi/ss/util/CellRangeAddressBase.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellRangeAddressBase.java
@@ -22,6 +22,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Supplier;
 
 import org.apache.poi.common.Duplicatable;
@@ -287,6 +289,15 @@ public abstract class CellRangeAddressBase implements Iterable<CellAddress>, Dup
     @Override
     public Iterator<CellAddress> iterator() {
         return new RowMajorCellAddressIterator(this);
+    }
+
+    /**
+     * Returns a spliterator over the CellAddresses in this cell range in row-major order.
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<CellAddress> spliterator() {
+        return Spliterators.spliterator(iterator(), getNumberOfCells(), 0);
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/ss/util/SSCellRange.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/SSCellRange.java
@@ -20,6 +20,7 @@ package org.apache.poi.ss.util;
 import java.lang.reflect.Array;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.stream.Stream;
 
 import org.apache.poi.ss.usermodel.Cell;
@@ -118,5 +119,13 @@ public final class SSCellRange<K extends Cell> implements CellRange<K> {
     @Override
     public Iterator<K> iterator() {
         return Stream.of(_flattenedArray).iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    @Override
+    public Spliterator<K> spliterator() {
+        return Stream.of(_flattenedArray).spliterator();
     }
 }

--- a/poi/src/main/java/org/apache/poi/util/IntMapper.java
+++ b/poi/src/main/java/org/apache/poi/util/IntMapper.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Spliterator;
 
 import org.apache.poi.common.Duplicatable;
 
@@ -88,6 +89,13 @@ public class IntMapper<T> implements Duplicatable, Iterable<T> {
 
     public Iterator<T> iterator() {
         return elements.iterator();
+    }
+
+    /**
+     * @since POI 5.2.0
+     */
+    public Spliterator<T> spliterator() {
+        return elements.spliterator();
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/util/IntMapper.java
+++ b/poi/src/main/java/org/apache/poi/util/IntMapper.java
@@ -37,7 +37,7 @@ import org.apache.poi.common.Duplicatable;
  * update
  */
 
-public class IntMapper<T> implements Duplicatable {
+public class IntMapper<T> implements Duplicatable, Iterable<T> {
     private final List<T> elements;
     private final Map<T, Integer> valueKeyMap;
 

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestDrawingShapes.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestDrawingShapes.java
@@ -25,10 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
 
 import org.apache.poi.ddf.EscherBoolProperty;
 import org.apache.poi.ddf.EscherContainerRecord;
@@ -700,6 +702,11 @@ class TestDrawingShapes {
             assertEquals(s1, iter.next());
             assertEquals(s2, iter.next());
             assertFalse(iter.hasNext());
+
+            Spliterator<HSSFShape> spliter = patriarch.spliterator();
+            spliter.tryAdvance(s -> assertEquals(s1, s));
+            spliter.tryAdvance(s -> assertEquals(s2, s));
+            assertFalse(spliter.tryAdvance(s -> fail()));
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestDirectoryNode.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestDirectoryNode.java
@@ -63,6 +63,9 @@ final class TestDirectoryNode {
             }
             assertEquals(0, count);
 
+            // verify that spliterator behaves correctly
+            assertEquals(0, node.spliterator().getExactSizeIfKnown());
+
             // verify behavior of isEmpty
             assertTrue(node.isEmpty());
 
@@ -110,6 +113,9 @@ final class TestDirectoryNode {
                 iter.next();
             }
             assertEquals(2, count);
+
+            // verify that spliterator behaves correctly
+            assertEquals(2, node.spliterator().getExactSizeIfKnown());
 
             // verify behavior of isEmpty
             assertFalse(node.isEmpty());

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestFilteringDirectoryNode.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestFilteringDirectoryNode.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -30,6 +31,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,6 +79,12 @@ final class TestFilteringDirectoryNode {
         assertEquals(dirB, i.next());
         assertEquals(eRoot, i.next());
         assertThrows(NoSuchElementException.class, i::next, "Should throw NoSuchElementException when depleted");
+
+        Spliterator<Entry> s = d.spliterator();
+        s.tryAdvance(entry -> assertEquals(dirA, entry));
+        s.tryAdvance(entry -> assertEquals(dirB, entry));
+        s.tryAdvance(entry -> assertEquals(eRoot, entry));
+        assertFalse(s.tryAdvance(entry -> fail("Should be depleted")), "Should return false when depleted");
     }
 
     @Test
@@ -98,6 +106,11 @@ final class TestFilteringDirectoryNode {
         assertEquals(dirB, i.next());
         assertThrows(NoSuchElementException.class, i::next, "Should throw NoSuchElementException when depleted");
 
+        Spliterator<Entry> s1 = d1.spliterator();
+        s1.tryAdvance(entry -> assertEquals(dirA, entry));
+        s1.tryAdvance(entry -> assertEquals(dirB, entry));
+        assertFalse(s1.tryAdvance(entry -> fail("Should be depleted")), "Should return false when depleted");
+
 
         // Filter more
         excl = Arrays.asList("NotThere", "AlsoNotThere", eRoot.getName(), dirA.getName());
@@ -115,6 +128,10 @@ final class TestFilteringDirectoryNode {
         assertEquals(dirB, i.next());
         assertThrows(NoSuchElementException.class, i::next, "Should throw NoSuchElementException when depleted");
 
+        Spliterator<Entry> s2 = d2.spliterator();
+        s2.tryAdvance(entry -> assertEquals(dirB, entry));
+        assertFalse(s2.tryAdvance(entry -> fail("Should be depleted")), "Should return false when depleted");
+
         // Filter everything
         excl = Arrays.asList("NotThere", eRoot.getName(), dirA.getName(), dirB.getName());
         FilteringDirectoryNode d3 = new FilteringDirectoryNode(fs.getRoot(), excl);
@@ -129,6 +146,9 @@ final class TestFilteringDirectoryNode {
 
         i = d3.getEntries();
         assertThrows(NoSuchElementException.class, i::next, "Should throw NoSuchElementException when depleted");
+
+        Spliterator<Entry> s3 = d3.spliterator();
+        assertFalse(s3.tryAdvance(entry -> fail("Should be depleted")), "Should return false when depleted");
     }
 
     @Test

--- a/poi/src/test/java/org/apache/poi/poifs/property/TestDirectoryProperty.java
+++ b/poi/src/test/java/org/apache/poi/poifs/property/TestDirectoryProperty.java
@@ -110,6 +110,7 @@ final class TestDirectoryProperty {
             children.add(iter.next());
         }
         assertEquals(count, children.size());
+        assertEquals(count, _property.spliterator().getExactSizeIfKnown());
         if (count != 0)
         {
             boolean[] found = new boolean[ count ];

--- a/poi/src/test/java/org/apache/poi/sl/draw/geom/TestPresetGeometries.java
+++ b/poi/src/test/java/org/apache/poi/sl/draw/geom/TestPresetGeometries.java
@@ -24,7 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
+import java.util.stream.StreamSupport;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TestPresetGeometries {
@@ -41,6 +43,9 @@ class TestPresetGeometries {
                 Path2D path = p.getPath(ctx);
                 assertNotNull(path);
             }
+            StreamSupport.stream(geom.spliterator(), true)
+                    .map(p -> p.getPath(ctx))
+                    .forEach(Assertions::assertNotNull);
         }
 
         // we get the same instance on further calls

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestSheet.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestSheet.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Spliterator;
 
 import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
@@ -83,6 +84,9 @@ public abstract class BaseTestSheet {
             assertSame(row1, it.next());
             assertTrue(it.hasNext());
             assertSame(row2, it.next());
+            Spliterator<Row> split = sheet.spliterator();
+            assertTrue(split.tryAdvance(row -> assertSame(row1, row)));
+            assertTrue(split.tryAdvance(row -> assertSame(row2, row)));
             assertEquals(1, sheet.getLastRowNum());
 
             // Test row creation with non consecutive index
@@ -102,6 +106,12 @@ public abstract class BaseTestSheet {
             Row row2_ovrewritten_ref = it2.next();
             assertSame(row2_ovrewritten, row2_ovrewritten_ref);
             assertEquals(100.0, row2_ovrewritten_ref.getCell(0).getNumericCellValue(), 0.0);
+            Spliterator<Row> split2 = sheet.spliterator();
+            assertTrue(split2.tryAdvance(row -> assertSame(row1, row)));
+            assertTrue(split2.tryAdvance(row -> {
+                assertSame(row2_ovrewritten, row);
+                assertEquals(100.0, row.getCell(0).getNumericCellValue(), 0.0);
+            }));
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestWorkbook.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestWorkbook.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
+import java.util.Spliterator;
 
 import org.apache.poi.hssf.HSSFTestDataSamples;
 import org.apache.poi.ss.ITestDataProvider;
@@ -74,11 +75,15 @@ public abstract class BaseTestWorkbook {
             wb.createSheet("Sheet2");
 
             Iterator<Sheet> it = wb.sheetIterator();
+            Spliterator<Sheet> split = wb.spliterator();
             it.next();
+            split.tryAdvance(sheet -> {});
             wb.setSheetOrder("Sheet2", 1);
 
             // Iterator order should be fixed when iterator is created
             assertThrows(ConcurrentModificationException.class, it::next);
+            // Spliterator order should be fixed when spliterator is created
+            assertThrows(ConcurrentModificationException.class, () -> split.tryAdvance(sheet -> {}));
         }
     }
 
@@ -95,10 +100,15 @@ public abstract class BaseTestWorkbook {
             wb.createSheet("Sheet2");
 
             Iterator<Sheet> it = wb.sheetIterator();
+            Spliterator<Sheet> split = wb.spliterator();
+            it.next();
+            split.tryAdvance(sheet -> {});
             wb.removeSheetAt(1);
 
             // Iterator order should be fixed when iterator is created
             assertThrows(ConcurrentModificationException.class, it::next);
+            // Spliterator order should be fixed when spliterator is created
+            assertThrows(ConcurrentModificationException.class, () -> split.tryAdvance(sheet -> {}));
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/util/TestCellRangeAddress.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/TestCellRangeAddress.java
@@ -28,10 +28,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.hssf.record.TestcaseRecordInputStream;
 import org.apache.poi.util.LittleEndianOutputStream;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class TestCellRangeAddress {
@@ -272,6 +275,29 @@ final class TestCellRangeAddress {
             assertNotNull(addr);
             count++;
         }
+        assertEquals(4, count);
+    }
+
+    @Test
+    void spliterator() {
+        final CellRangeAddress A1_B2 = new CellRangeAddress(0, 1, 0, 1);
+
+        // the cell address iterator iterates in row major order
+        final Spliterator<CellAddress> spliter = A1_B2.spliterator();
+        spliter.tryAdvance(addr ->
+                assertEquals(new CellAddress(0, 0), addr, "A1"));
+        spliter.tryAdvance(addr ->
+                assertEquals(new CellAddress(0, 1), addr, "B1"));
+        spliter.tryAdvance(addr ->
+                assertEquals(new CellAddress(1, 0), addr, "A2"));
+        spliter.tryAdvance(addr ->
+                assertEquals(new CellAddress(1, 1), addr, "B2"));
+        assertFalse(spliter.tryAdvance(addr -> fail()));
+
+        // stream
+        long count = StreamSupport.stream(A1_B2.spliterator(), false)
+                .peek(Assertions::assertNotNull)
+                .count();
         assertEquals(4, count);
     }
 


### PR DESCRIPTION
# Why

There are many classes in Apache POI that implements [Iterable](https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html), but only implements [Iterable#iterator()](https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html#iterator--) without overriding [Iterable#spliterator()](https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html#spliterator--).

The default implementation of [Iterable#spliterator()](https://github.com/openjdk/jdk/blob/9a9add8825a040565051a09010b29b099c2e7d49/jdk/src/share/classes/java/lang/Iterable.java#L100-L102) is:
```java
default Spliterator<T> spliterator() {
    return Spliterators.spliteratorUnknownSize(iterator(), 0);
}
```
[Spliterator#spliteratorUnknownSize(Iterator, int)](https://docs.oracle.com/javase/8/docs/api/java/util/Spliterators.html#spliteratorUnknownSize-java.util.Iterator-int-) returns a `Spliterator` with no initial size estimate, which has poor splitting capabilities. The default implementation has to do this because not all `Iterable`s have a fixed size.

This is important when trying to convert the `Iterable` to a parallel `Stream`. For example, when trying to process [Row](https://poi.apache.org/apidocs/5.0/org/apache/poi/ss/usermodel/Row.html)s in a [XSSFSheet](https://poi.apache.org/apidocs/5.0/org/apache/poi/xssf/usermodel/XSSFSheet.html) (`XSSFSheet` implements `Iterable<Row>`) in parallel, the performance is terrible:
```java
StreamSupport.stream(sheet.spliterator(), true)
    .forEach(row -> {
        // ...
    });
```

The `XSSFSheet`'s `Iterator` is backed by a [TreeMap#values()](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html#values--):
https://github.com/apache/poi/blob/cf1354dc6c6128d8fd024ee1f57359761cd5fd1f/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java#L95
https://github.com/apache/poi/blob/cf1354dc6c6128d8fd024ee1f57359761cd5fd1f/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java#L2049-L2067

`TreeMap#values()` returns a [Collection](https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html), and thus has a fixed size. Its `Spliterator` is hence sized and has good splitting capabilities, allowing it to be properly parallelized. Therefore an easy way to customize `XSSFSheet#spliterator()` is to simply delegate to the underlying `TreeMap#values()`, eg.
```java
@Override
@SuppressWarnings("unchecked")
public Spliterator<Row> spliterator() {
    return (Spliterator<Row>)(Spliterator<? extends Row>) _rows.values().spliterator();
}
```

# How

- For classes that expose an `Iterator` factory method with a backing `Collection`/`Iterable`, I simply delegated the `Spliterator` factory method to the underlying `Collection`/`Iterable`.
- For classes that expose an `Iterator` factory method but do not have a backing `Collection`/`Iterable`, but have a fixed size, I customized the `Spliterator` factory method to return a sized `Spliterator` using [Spliterators#spliterator(Iterator, long, int)](https://docs.oracle.com/javase/8/docs/api/java/util/Spliterators.html#spliterator-java.util.Iterator-long-int-).
- Classes that expose an `Iterator` factory method but do not have a fixed size remain unchanged.

I also took the liberty to perform the following refactors:
- Move `iterator()` implementation in child classes to `Workbook`/`Sheet`/`Row` interface using `default` methods (the `iterator()` method is an alias of `sheetIterator()`/`rowIterator()`/`cellIterator()`, and is currently being duplicated in all child classes)
- Add `Iterable` interface to `IntMapper` and `XDDFTextParagraph` (so that they can be iterated using an enhanced `for` loop)

None of the changes break source/binary compatibility.

---

For anyone interested, the current workaround is create a sized `Spliterator` using [Sheet#getPhysicalNumberOfRows()](https://poi.apache.org/apidocs/5.0/org/apache/poi/ss/usermodel/Sheet.html#getPhysicalNumberOfRows--), eg.
```java
Spliterator<Row> spliterator = Spliterators.spliterator(sheet.iterator(), sheet.getPhysicalNumberOfRows(), 0);
StreamSupport.stream(spliterator, true)
    .forEach(row -> {
        // ...
    });
```
This however, is still less optimal than using the backing `Collection`'s `Spliterator`.