### PR TITLE
Allow sections to have distinct headers and footers

### DIFF
--- a/poi-examples/src/main/java/org/apache/poi/examples/xwpf/usermodel/MultiHeaderDocument.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xwpf/usermodel/MultiHeaderDocument.java
@@ -1,0 +1,105 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.examples.xwpf.usermodel;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.poi.xwpf.model.XWPFHeaderFooterPolicy;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFRun;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPPr;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSectPr;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
+
+public class MultiHeaderDocument {
+	public static void main(String[] args) throws IOException {
+		try (XWPFDocument doc = new XWPFDocument()) {
+			// First Body Paragraph
+			XWPFParagraph p1 = doc.createParagraph();
+
+			XWPFRun run1 = p1.createRun();
+			run1.setText("This is the text of the first paragraph/page/section");
+
+			CTP ctp1 = p1.getCTP();
+			CTPPr ppr1 = null;
+			if (!ctp1.isSetPPr()) {
+				ctp1.addNewPPr();
+			}
+			ppr1 = ctp1.getPPr();
+
+			CTSectPr sec1 = null;
+			if (!ppr1.isSetSectPr()) {
+				ppr1.addNewSectPr();
+			}
+
+			sec1 = ppr1.getSectPr();
+
+			// Paragraph for Section 1 header.
+			CTP parCTP = CTP.Factory.newInstance();
+			parCTP.addNewR().addNewT().setStringValue("Header For Section 1");
+			XWPFParagraph headerPar1 = new XWPFParagraph(parCTP, doc);
+
+			XWPFParagraph[] headerPars1 = { headerPar1 };
+
+			XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
+			pol1.createHeader(STHdrFtr.DEFAULT, headerPars1);
+
+			// Create second body paragraph with a different header
+
+			XWPFParagraph p2 = doc.createParagraph();
+
+			XWPFRun run2 = p2.createRun();
+			run2.setText("This is the text of the second paragraph/page/section");
+
+			CTP ctp2 = p2.getCTP();
+			CTPPr ppr2 = null;
+			if (!ctp2.isSetPPr()) {
+				ctp2.addNewPPr();
+			}
+			ppr2 = ctp2.getPPr();
+
+			CTSectPr sec2 = null;
+			if (!ppr2.isSetSectPr()) {
+				ppr2.addNewSectPr();
+			}
+
+			sec2 = ppr2.getSectPr();
+
+			// Paragraph for Section 2 header.
+			CTP parCTP2 = CTP.Factory.newInstance();
+			parCTP2.addNewR().addNewT().setStringValue("Header For Section 2");
+			XWPFParagraph headerPar2 = new XWPFParagraph(parCTP2, doc);
+
+			XWPFParagraph[] headerPars2 = { headerPar2 };
+
+			XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
+			pol2.createHeader(STHdrFtr.DEFAULT, headerPars2);
+
+			try (OutputStream os = new FileOutputStream(new File("multiheader.docx"))) {
+
+				doc.write(os);
+
+			}
+		}
+	}
+}

--- a/poi-examples/src/main/java/org/apache/poi/examples/xwpf/usermodel/MultiHeaderDocument.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xwpf/usermodel/MultiHeaderDocument.java
@@ -32,74 +32,74 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSectPr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
 
 public class MultiHeaderDocument {
-	public static void main(String[] args) throws IOException {
-		try (XWPFDocument doc = new XWPFDocument()) {
-			// First Body Paragraph
-			XWPFParagraph p1 = doc.createParagraph();
+    public static void main(String[] args) throws IOException {
+        try (XWPFDocument doc = new XWPFDocument()) {
+            // First Body Paragraph
+            XWPFParagraph p1 = doc.createParagraph();
 
-			XWPFRun run1 = p1.createRun();
-			run1.setText("This is the text of the first paragraph/page/section");
+            XWPFRun run1 = p1.createRun();
+            run1.setText("This is the text of the first paragraph/page/section");
 
-			CTP ctp1 = p1.getCTP();
-			CTPPr ppr1 = null;
-			if (!ctp1.isSetPPr()) {
-				ctp1.addNewPPr();
-			}
-			ppr1 = ctp1.getPPr();
+            CTP ctp1 = p1.getCTP();
+            CTPPr ppr1 = null;
+            if (!ctp1.isSetPPr()) {
+                ctp1.addNewPPr();
+            }
+            ppr1 = ctp1.getPPr();
 
-			CTSectPr sec1 = null;
-			if (!ppr1.isSetSectPr()) {
-				ppr1.addNewSectPr();
-			}
+            CTSectPr sec1 = null;
+            if (!ppr1.isSetSectPr()) {
+                ppr1.addNewSectPr();
+            }
 
-			sec1 = ppr1.getSectPr();
+            sec1 = ppr1.getSectPr();
 
-			// Paragraph for Section 1 header.
-			CTP parCTP = CTP.Factory.newInstance();
-			parCTP.addNewR().addNewT().setStringValue("Header For Section 1");
-			XWPFParagraph headerPar1 = new XWPFParagraph(parCTP, doc);
+            // Paragraph for Section 1 header.
+            CTP parCTP = CTP.Factory.newInstance();
+            parCTP.addNewR().addNewT().setStringValue("Header For Section 1");
+            XWPFParagraph headerPar1 = new XWPFParagraph(parCTP, doc);
 
-			XWPFParagraph[] headerPars1 = { headerPar1 };
+            XWPFParagraph[] headerPars1 = { headerPar1 };
 
-			XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
-			pol1.createHeader(STHdrFtr.DEFAULT, headerPars1);
+            XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
+            pol1.createHeader(STHdrFtr.DEFAULT, headerPars1);
 
-			// Create second body paragraph with a different header
+            // Create second body paragraph with a different header
 
-			XWPFParagraph p2 = doc.createParagraph();
+            XWPFParagraph p2 = doc.createParagraph();
 
-			XWPFRun run2 = p2.createRun();
-			run2.setText("This is the text of the second paragraph/page/section");
+            XWPFRun run2 = p2.createRun();
+            run2.setText("This is the text of the second paragraph/page/section");
 
-			CTP ctp2 = p2.getCTP();
-			CTPPr ppr2 = null;
-			if (!ctp2.isSetPPr()) {
-				ctp2.addNewPPr();
-			}
-			ppr2 = ctp2.getPPr();
+            CTP ctp2 = p2.getCTP();
+            CTPPr ppr2 = null;
+            if (!ctp2.isSetPPr()) {
+                ctp2.addNewPPr();
+            }
+            ppr2 = ctp2.getPPr();
 
-			CTSectPr sec2 = null;
-			if (!ppr2.isSetSectPr()) {
-				ppr2.addNewSectPr();
-			}
+            CTSectPr sec2 = null;
+            if (!ppr2.isSetSectPr()) {
+                ppr2.addNewSectPr();
+            }
 
-			sec2 = ppr2.getSectPr();
+            sec2 = ppr2.getSectPr();
 
-			// Paragraph for Section 2 header.
-			CTP parCTP2 = CTP.Factory.newInstance();
-			parCTP2.addNewR().addNewT().setStringValue("Header For Section 2");
-			XWPFParagraph headerPar2 = new XWPFParagraph(parCTP2, doc);
+            // Paragraph for Section 2 header.
+            CTP parCTP2 = CTP.Factory.newInstance();
+            parCTP2.addNewR().addNewT().setStringValue("Header For Section 2");
+            XWPFParagraph headerPar2 = new XWPFParagraph(parCTP2, doc);
 
-			XWPFParagraph[] headerPars2 = { headerPar2 };
+            XWPFParagraph[] headerPars2 = { headerPar2 };
 
-			XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
-			pol2.createHeader(STHdrFtr.DEFAULT, headerPars2);
+            XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
+            pol2.createHeader(STHdrFtr.DEFAULT, headerPars2);
 
-			try (OutputStream os = new FileOutputStream(new File("multiheader.docx"))) {
+            try (OutputStream os = new FileOutputStream(new File("multiheader.docx"))) {
 
-				doc.write(os);
+                doc.write(os);
 
-			}
-		}
-	}
+            }
+        }
+    }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/model/XWPFHeaderFooterPolicy.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/model/XWPFHeaderFooterPolicy.java
@@ -16,6 +16,17 @@
 ==================================================================== */
 package org.apache.poi.xwpf.model;
 
+import com.microsoft.schemas.office.office.CTLock;
+import com.microsoft.schemas.office.office.STConnectType;
+import com.microsoft.schemas.vml.CTFormulas;
+import com.microsoft.schemas.vml.CTGroup;
+import com.microsoft.schemas.vml.CTH;
+import com.microsoft.schemas.vml.CTHandles;
+import com.microsoft.schemas.vml.CTPath;
+import com.microsoft.schemas.vml.CTShape;
+import com.microsoft.schemas.vml.CTShapetype;
+import com.microsoft.schemas.vml.CTTextPath;
+import com.microsoft.schemas.vml.STExt;
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLDocumentPart.RelationPart;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
@@ -41,236 +52,231 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.HdrDocument;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr.Enum;
 
-import com.microsoft.schemas.office.office.CTLock;
-import com.microsoft.schemas.office.office.STConnectType;
-import com.microsoft.schemas.vml.CTFormulas;
-import com.microsoft.schemas.vml.CTGroup;
-import com.microsoft.schemas.vml.CTH;
-import com.microsoft.schemas.vml.CTHandles;
-import com.microsoft.schemas.vml.CTPath;
-import com.microsoft.schemas.vml.CTShape;
-import com.microsoft.schemas.vml.CTShapetype;
-import com.microsoft.schemas.vml.CTTextPath;
-import com.microsoft.schemas.vml.STExt;
-
 /**
- * A .docx file can have no headers/footers, the same header/footer on each
- * page, odd/even page footers, and optionally also a different header/footer on
- * the first page. This class handles sorting out what there is, and giving you
+ * A .docx file can have no headers/footers, the same header/footer
+ * on each page, odd/even page footers, and optionally also
+ * a different header/footer on the first page.
+ * This class handles sorting out what there is, and giving you
  * the right headers and footers for the document.
  */
 public class XWPFHeaderFooterPolicy {
-	public static final Enum DEFAULT = STHdrFtr.DEFAULT;
-	public static final Enum EVEN = STHdrFtr.EVEN;
-	public static final Enum FIRST = STHdrFtr.FIRST;
+    public static final Enum DEFAULT = STHdrFtr.DEFAULT;
+    public static final Enum EVEN = STHdrFtr.EVEN;
+    public static final Enum FIRST = STHdrFtr.FIRST;
 
-	private XWPFDocument doc;
+    private XWPFDocument doc;
 
-	private XWPFHeader firstPageHeader;
-	private XWPFFooter firstPageFooter;
+    private XWPFHeader firstPageHeader;
+    private XWPFFooter firstPageFooter;
 
-	private XWPFHeader evenPageHeader;
-	private XWPFFooter evenPageFooter;
+    private XWPFHeader evenPageHeader;
+    private XWPFFooter evenPageFooter;
 
-	private XWPFHeader defaultHeader;
-	private XWPFFooter defaultFooter;
-	// This variable stores a reference to the section, it allows the sections to
-	// have different headers and footers
-	private CTSectPr sectPr;
+    private XWPFHeader defaultHeader;
+    private XWPFFooter defaultFooter;
+    //This variable allows to have a reference for each section, and having different headers in each of them.
+    private CTSectPr sectPr;
 
-	/**
-	 * Figures out the policy for the given document, and creates any header and
-	 * footer objects as required.
-	 */
-	public XWPFHeaderFooterPolicy(XWPFDocument doc) {
-		this(doc, null);
-	}
+    /**
+     * Figures out the policy for the given document,
+     * and creates any header and footer objects
+     * as required.
+     */
+    public XWPFHeaderFooterPolicy(XWPFDocument doc) {
+        this(doc, null);
+    }
 
-	/**
-	 * Figures out the policy for the given document, and creates any header and
-	 * footer objects as required.
-	 */
-	public XWPFHeaderFooterPolicy(XWPFDocument doc, CTSectPr sectPr) {
-		// Grab what headers and footers have been defined
-		// For now, we don't care about different ranges, as it
-		// doesn't seem that .docx properly supports that
-		// feature of the file format yet
-		if (sectPr == null) {
-			CTBody ctBody = doc.getDocument().getBody();
-			sectPr = ctBody.isSetSectPr() ? ctBody.getSectPr() : ctBody.addNewSectPr();
-		}
-		this.doc = doc;
-		this.sectPr = sectPr;
-		for (int i = 0; i < sectPr.sizeOfHeaderReferenceArray(); i++) {
-			// Get the header
-			CTHdrFtrRef ref = sectPr.getHeaderReferenceArray(i);
-			POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
-			XWPFHeader hdr = null;
-			if (relatedPart != null && relatedPart instanceof XWPFHeader) {
-				hdr = (XWPFHeader) relatedPart;
-			}
-			// Assign it; treat invalid options as "default" POI-60293
-			Enum type;
-			try {
-				type = ref.getType();
-			} catch (XmlValueOutOfRangeException e) {
-				type = STHdrFtr.DEFAULT;
-			}
+    /**
+     * Figures out the policy for the given document,
+     * and creates any header and footer objects
+     * as required.
+     */
+    public XWPFHeaderFooterPolicy(XWPFDocument doc, CTSectPr sectPr) {
+        // Grab what headers and footers have been defined
+        // For now, we don't care about different ranges, as it
+        //  doesn't seem that .docx properly supports that
+        //  feature of the file format yet
+        if (sectPr == null) {
+            CTBody ctBody = doc.getDocument().getBody();
+            sectPr = ctBody.isSetSectPr()
+                    ? ctBody.getSectPr()
+                    : ctBody.addNewSectPr();
+        }
+        this.doc = doc;
+        this.sectPr = sectPr;
 
-			assignHeader(hdr, type);
-		}
-		for (int i = 0; i < sectPr.sizeOfFooterReferenceArray(); i++) {
-			// Get the footer
-			CTHdrFtrRef ref = sectPr.getFooterReferenceArray(i);
-			POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
-			XWPFFooter ftr = null;
-			if (relatedPart != null && relatedPart instanceof XWPFFooter) {
-				ftr = (XWPFFooter) relatedPart;
-			}
-			// Assign it; treat invalid options as "default" POI-60293
-			Enum type;
-			try {
-				type = ref.getType();
-			} catch (XmlValueOutOfRangeException e) {
-				type = STHdrFtr.DEFAULT;
-			}
-			assignFooter(ftr, type);
-		}
-	}
+        for (int i = 0; i < sectPr.sizeOfHeaderReferenceArray(); i++) {
+            // Get the header
+            CTHdrFtrRef ref = sectPr.getHeaderReferenceArray(i);
+            POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
+            XWPFHeader hdr = null;
+            if (relatedPart != null && relatedPart instanceof XWPFHeader) {
+                hdr = (XWPFHeader) relatedPart;
+            }
+            // Assign it; treat invalid options as "default" POI-60293
+            Enum type;
+            try {
+                type = ref.getType();
+            } catch (XmlValueOutOfRangeException e) {
+                type = STHdrFtr.DEFAULT;
+            }
 
-	private void assignFooter(XWPFFooter ftr, Enum type) {
-		if (type == STHdrFtr.FIRST) {
-			firstPageFooter = ftr;
-		} else if (type == STHdrFtr.EVEN) {
-			evenPageFooter = ftr;
-		} else {
-			defaultFooter = ftr;
-		}
-	}
+            assignHeader(hdr, type);
+        }
+        for (int i = 0; i < sectPr.sizeOfFooterReferenceArray(); i++) {
+            // Get the footer
+            CTHdrFtrRef ref = sectPr.getFooterReferenceArray(i);
+            POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
+            XWPFFooter ftr = null;
+            if (relatedPart != null && relatedPart instanceof XWPFFooter) {
+                ftr = (XWPFFooter) relatedPart;
+            }
+            // Assign it; treat invalid options as "default" POI-60293
+            Enum type;
+            try {
+                type = ref.getType();
+            } catch (XmlValueOutOfRangeException e) {
+                type = STHdrFtr.DEFAULT;
+            }
+            assignFooter(ftr, type);
+        }
+    }
 
-	private void assignHeader(XWPFHeader hdr, Enum type) {
-		if (type == STHdrFtr.FIRST) {
-			firstPageHeader = hdr;
-		} else if (type == STHdrFtr.EVEN) {
-			evenPageHeader = hdr;
-		} else {
-			defaultHeader = hdr;
-		}
-	}
+    private void assignFooter(XWPFFooter ftr, Enum type) {
+        if (type == STHdrFtr.FIRST) {
+            firstPageFooter = ftr;
+        } else if (type == STHdrFtr.EVEN) {
+            evenPageFooter = ftr;
+        } else {
+            defaultFooter = ftr;
+        }
+    }
 
-	/**
-	 * Creates an empty header of the specified type, containing a single empty
-	 * paragraph, to which you can then set text, add more paragraphs etc.
-	 */
-	public XWPFHeader createHeader(Enum type) {
-		return createHeader(type, null);
-	}
+    private void assignHeader(XWPFHeader hdr, Enum type) {
+        if (type == STHdrFtr.FIRST) {
+            firstPageHeader = hdr;
+        } else if (type == STHdrFtr.EVEN) {
+            evenPageHeader = hdr;
+        } else {
+            defaultHeader = hdr;
+        }
+    }
 
-	/**
-	 * Creates a new header of the specified type, to which the supplied (and
-	 * previously unattached!) paragraphs are added to.
-	 */
-	public XWPFHeader createHeader(Enum type, XWPFParagraph[] pars) {
-		XWPFHeader header = getHeader(type);
+    /**
+     * Creates an empty header of the specified type, containing a single
+     * empty paragraph, to which you can then set text, add more paragraphs etc.
+     */
+    public XWPFHeader createHeader(Enum type) {
+        return createHeader(type, null);
+    }
 
-		if (header == null) {
-			HdrDocument hdrDoc = HdrDocument.Factory.newInstance();
+    /**
+     * Creates a new header of the specified type, to which the
+     * supplied (and previously unattached!) paragraphs are
+     * added to.
+     */
+    public XWPFHeader createHeader(Enum type, XWPFParagraph[] pars) {
+        XWPFHeader header = getHeader(type);
 
-			XWPFRelation relation = XWPFRelation.HEADER;
-			int i = getRelationIndex(relation);
+        if (header == null) {
+            HdrDocument hdrDoc = HdrDocument.Factory.newInstance();
 
-			XWPFHeader wrapper = (XWPFHeader) doc.createRelationship(relation, XWPFFactory.getInstance(), i);
-			wrapper.setXWPFDocument(doc);
+            XWPFRelation relation = XWPFRelation.HEADER;
+            int i = getRelationIndex(relation);
 
-			CTHdrFtr hdr = buildHdr(type, wrapper, pars);
-			wrapper.setHeaderFooter(hdr);
-			hdrDoc.setHdr(hdr);
-			assignHeader(wrapper, type);
-			header = wrapper;
-		}
+            XWPFHeader wrapper = (XWPFHeader) doc.createRelationship(relation,
+                    XWPFFactory.getInstance(), i);
+            wrapper.setXWPFDocument(doc);
 
-		return header;
-	}
+            CTHdrFtr hdr = buildHdr(type, wrapper, pars);
+            wrapper.setHeaderFooter(hdr);
+            hdrDoc.setHdr(hdr);
+            assignHeader(wrapper, type);
+            header = wrapper;
+        }
 
-	/**
-	 * Creates an empty footer of the specified type, containing a single empty
-	 * paragraph, to which you can then set text, add more paragraphs etc.
-	 */
-	public XWPFFooter createFooter(Enum type) {
-		return createFooter(type, null);
-	}
+        return header;
+    }
 
-	/**
-	 * Creates a new footer of the specified type, to which the supplied (and
-	 * previously unattached!) paragraphs are added to.
-	 */
-	public XWPFFooter createFooter(Enum type, XWPFParagraph[] pars) {
-		XWPFFooter footer = getFooter(type);
+    /**
+     * Creates an empty footer of the specified type, containing a single
+     * empty paragraph, to which you can then set text, add more paragraphs etc.
+     */
+    public XWPFFooter createFooter(Enum type) {
+        return createFooter(type, null);
+    }
 
-		if (footer == null) {
-			FtrDocument ftrDoc = FtrDocument.Factory.newInstance();
+    /**
+     * Creates a new footer of the specified type, to which the
+     * supplied (and previously unattached!) paragraphs are
+     * added to.
+     */
+    public XWPFFooter createFooter(Enum type, XWPFParagraph[] pars) {
+        XWPFFooter footer = getFooter(type);
 
-			XWPFRelation relation = XWPFRelation.FOOTER;
-			int i = getRelationIndex(relation);
+        if (footer == null) {
+            FtrDocument ftrDoc = FtrDocument.Factory.newInstance();
 
-			XWPFFooter wrapper = (XWPFFooter) doc.createRelationship(relation, XWPFFactory.getInstance(), i);
-			wrapper.setXWPFDocument(doc);
+            XWPFRelation relation = XWPFRelation.FOOTER;
+            int i = getRelationIndex(relation);
 
-			CTHdrFtr ftr = buildFtr(type, wrapper, pars);
-			wrapper.setHeaderFooter(ftr);
-			ftrDoc.setFtr(ftr);
-			assignFooter(wrapper, type);
-			footer = wrapper;
-		}
+            XWPFFooter wrapper = (XWPFFooter) doc.createRelationship(relation,
+                    XWPFFactory.getInstance(), i);
+            wrapper.setXWPFDocument(doc);
 
-		return footer;
-	}
+            CTHdrFtr ftr = buildFtr(type, wrapper, pars);
+            wrapper.setHeaderFooter(ftr);
+            ftrDoc.setFtr(ftr);
+            assignFooter(wrapper, type);
+            footer = wrapper;
+        }
 
-	private int getRelationIndex(XWPFRelation relation) {
-		int i = 1;
-		for (RelationPart rp : doc.getRelationParts()) {
-			if (rp.getRelationship().getRelationshipType().equals(relation.getRelation())) {
-				i++;
-			}
-		}
-		return i;
-	}
+        return footer;
+    }
 
-	private CTHdrFtr buildFtr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
-		// CTHdrFtr ftr = buildHdrFtr(pStyle, pars); // MB 24 May 2010
-		CTHdrFtr ftr = buildHdrFtr(pars, wrapper); // MB 24 May 2010
-		setFooterReference(type, wrapper);
-		return ftr;
-	}
+    private int getRelationIndex(XWPFRelation relation) {
+        int i = 1;
+        for (RelationPart rp : doc.getRelationParts()) {
+            if (rp.getRelationship().getRelationshipType().equals(relation.getRelation())) {
+                i++;
+            }
+        }
+        return i;
+    }
 
-	private CTHdrFtr buildHdr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
-		// CTHdrFtr hdr = buildHdrFtr(pStyle, pars); // MB 24 May 2010
-		CTHdrFtr hdr = buildHdrFtr(pars, wrapper); // MB 24 May 2010
-		setHeaderReference(type, wrapper);
-		return hdr;
-	}
+    private CTHdrFtr buildFtr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
+        //CTHdrFtr ftr = buildHdrFtr(pStyle, pars);             // MB 24 May 2010
+        CTHdrFtr ftr = buildHdrFtr(pars, wrapper);        // MB 24 May 2010
+        setFooterReference(type, wrapper);
+        return ftr;
+    }
 
-	/**
-	 * MB 24 May 2010. Created this overloaded buildHdrFtr() method because testing
-	 * demonstrated that the XWPFFooter or XWPFHeader object returned by calls to
-	 * the createHeader(int, XWPFParagraph[]) and createFooter(int, XWPFParagraph[])
-	 * methods or the getXXXXXHeader/Footer methods where headers or footers had
-	 * been added to a document since it had been created/opened, returned an object
-	 * that contained no XWPFParagraph objects even if the header/footer itself did
-	 * contain text. The reason was that this line of code; CTHdrFtr ftr =
-	 * CTHdrFtr.Factory.newInstance(); created a brand new instance of the CTHDRFtr
-	 * class which was then populated with data when it should have recovered the
-	 * CTHdrFtr object encapsulated within the XWPFHeaderFooter object that had
-	 * previoulsy been instantiated in the createHeader(int, XWPFParagraph[]) or
-	 * createFooter(int, XWPFParagraph[]) methods.
-	 */
-	private CTHdrFtr buildHdrFtr(XWPFParagraph[] paragraphs, XWPFHeaderFooter wrapper) {
-		CTHdrFtr ftr = wrapper._getHdrFtr();
-		if (paragraphs != null) {
-			for (int i = 0; i < paragraphs.length; i++) {
-				/* CTP p = */ ftr.addNewP();
-				ftr.setPArray(i, paragraphs[i].getCTP());
-			}
+    private CTHdrFtr buildHdr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
+        //CTHdrFtr hdr = buildHdrFtr(pStyle, pars);             // MB 24 May 2010
+        CTHdrFtr hdr = buildHdrFtr(pars, wrapper);        // MB 24 May 2010
+        setHeaderReference(type, wrapper);
+        return hdr;
+    }
+
+    /**
+     * MB 24 May 2010. Created this overloaded buildHdrFtr() method because testing demonstrated
+     * that the XWPFFooter or XWPFHeader object returned by calls to the createHeader(int, XWPFParagraph[])
+     * and createFooter(int, XWPFParagraph[]) methods or the getXXXXXHeader/Footer methods where
+     * headers or footers had been added to a document since it had been created/opened, returned
+     * an object that contained no XWPFParagraph objects even if the header/footer itself did contain
+     * text. The reason was that this line of code; CTHdrFtr ftr = CTHdrFtr.Factory.newInstance();
+     * created a brand new instance of the CTHDRFtr class which was then populated with data when
+     * it should have recovered the CTHdrFtr object encapsulated within the XWPFHeaderFooter object
+     * that had previoulsy been instantiated in the createHeader(int, XWPFParagraph[]) or
+     * createFooter(int, XWPFParagraph[]) methods.
+     */
+    private CTHdrFtr buildHdrFtr(XWPFParagraph[] paragraphs, XWPFHeaderFooter wrapper) {
+        CTHdrFtr ftr = wrapper._getHdrFtr();
+        if (paragraphs != null) {
+            for (int i = 0; i < paragraphs.length; i++) {
+                /*CTP p =*/ ftr.addNewP();
+                ftr.setPArray(i, paragraphs[i].getCTP());
+            }
 //        } else {
 //            CTP p = ftr.addNewP();
 //            CTBody body = doc.getDocument().getBody();
@@ -285,206 +291,211 @@ public class XWPFHeaderFooterPolicy {
 //            }
 //            CTPPr pPr = p.addNewPPr();
 //            pPr.addNewPStyle().setVal(pStyle);
-		}
-		return ftr;
-	}
+        }
+        return ftr;
+    }
 
-	private void setFooterReference(Enum type, XWPFHeaderFooter wrapper) {
-		CTHdrFtrRef ref = this.sectPr.addNewFooterReference();
-		ref.setType(type);
-		ref.setId(doc.getRelationId(wrapper));
-	}
 
-	private void setHeaderReference(Enum type, XWPFHeaderFooter wrapper) {
-		CTHdrFtrRef ref = this.sectPr.addNewHeaderReference();
-		ref.setType(type);
-		ref.setId(doc.getRelationId(wrapper));
-	}
+    private void setFooterReference(Enum type, XWPFHeaderFooter wrapper) {
+        CTHdrFtrRef ref = this.sectPr.addNewFooterReference();
+        ref.setType(type);
+        ref.setId(doc.getRelationId(wrapper));
+    }
 
-	public XWPFHeader getFirstPageHeader() {
-		return firstPageHeader;
-	}
 
-	public XWPFFooter getFirstPageFooter() {
-		return firstPageFooter;
-	}
+    private void setHeaderReference(Enum type, XWPFHeaderFooter wrapper) {
+        CTHdrFtrRef ref = this.sectPr.addNewHeaderReference();
+        ref.setType(type);
+        ref.setId(doc.getRelationId(wrapper));
+    }
 
-	/**
-	 * Returns the odd page header. This is also the same as the default one...
-	 */
-	public XWPFHeader getOddPageHeader() {
-		return defaultHeader;
-	}
+    public XWPFHeader getFirstPageHeader() {
+        return firstPageHeader;
+    }
 
-	/**
-	 * Returns the odd page footer. This is also the same as the default one...
-	 */
-	public XWPFFooter getOddPageFooter() {
-		return defaultFooter;
-	}
+    public XWPFFooter getFirstPageFooter() {
+        return firstPageFooter;
+    }
 
-	public XWPFHeader getEvenPageHeader() {
-		return evenPageHeader;
-	}
+    /**
+     * Returns the odd page header. This is
+     * also the same as the default one...
+     */
+    public XWPFHeader getOddPageHeader() {
+        return defaultHeader;
+    }
 
-	public XWPFFooter getEvenPageFooter() {
-		return evenPageFooter;
-	}
+    /**
+     * Returns the odd page footer. This is
+     * also the same as the default one...
+     */
+    public XWPFFooter getOddPageFooter() {
+        return defaultFooter;
+    }
 
-	public XWPFHeader getDefaultHeader() {
-		return defaultHeader;
-	}
+    public XWPFHeader getEvenPageHeader() {
+        return evenPageHeader;
+    }
 
-	public XWPFFooter getDefaultFooter() {
-		return defaultFooter;
-	}
+    public XWPFFooter getEvenPageFooter() {
+        return evenPageFooter;
+    }
 
-	/**
-	 * Get the header that applies to the given (1 based) page.
-	 *
-	 * @param pageNumber The one based page number
-	 */
-	public XWPFHeader getHeader(int pageNumber) {
-		if (pageNumber == 1 && firstPageHeader != null) {
-			return firstPageHeader;
-		}
-		if (pageNumber % 2 == 0 && evenPageHeader != null) {
-			return evenPageHeader;
-		}
-		return defaultHeader;
-	}
+    public XWPFHeader getDefaultHeader() {
+        return defaultHeader;
+    }
 
-	/**
-	 * Get this section header for the given type
-	 *
-	 * @param type of header to return
-	 * @return {@link XWPFHeader} object
-	 */
-	public XWPFHeader getHeader(Enum type) {
-		if (type == STHdrFtr.EVEN) {
-			return evenPageHeader;
-		} else if (type == STHdrFtr.FIRST) {
-			return firstPageHeader;
-		}
-		return defaultHeader;
-	}
+    public XWPFFooter getDefaultFooter() {
+        return defaultFooter;
+    }
 
-	/**
-	 * Get the footer that applies to the given (1 based) page.
-	 *
-	 * @param pageNumber The one based page number
-	 */
-	public XWPFFooter getFooter(int pageNumber) {
-		if (pageNumber == 1 && firstPageFooter != null) {
-			return firstPageFooter;
-		}
-		if (pageNumber % 2 == 0 && evenPageFooter != null) {
-			return evenPageFooter;
-		}
-		return defaultFooter;
-	}
+    /**
+     * Get the header that applies to the given
+     * (1 based) page.
+     *
+     * @param pageNumber The one based page number
+     */
+    public XWPFHeader getHeader(int pageNumber) {
+        if (pageNumber == 1 && firstPageHeader != null) {
+            return firstPageHeader;
+        }
+        if (pageNumber % 2 == 0 && evenPageHeader != null) {
+            return evenPageHeader;
+        }
+        return defaultHeader;
+    }
 
-	/**
-	 * Get this section footer for the given type
-	 *
-	 * @param type of footer to return
-	 * @return {@link XWPFFooter} object
-	 */
-	public XWPFFooter getFooter(Enum type) {
-		if (type == STHdrFtr.EVEN) {
-			return evenPageFooter;
-		} else if (type == STHdrFtr.FIRST) {
-			return firstPageFooter;
-		}
-		return defaultFooter;
-	}
+    /**
+     * Get this section header for the given type
+     *
+     * @param type of header to return
+     * @return {@link XWPFHeader} object
+     */
+    public XWPFHeader getHeader(Enum type) {
+        if (type == STHdrFtr.EVEN) {
+            return evenPageHeader;
+        } else if (type == STHdrFtr.FIRST) {
+            return firstPageHeader;
+        }
+        return defaultHeader;
+    }
 
-	public void createWatermark(String text) {
-		XWPFParagraph[] pars = new XWPFParagraph[1];
-		pars[0] = getWatermarkParagraph(text, 1);
-		createHeader(DEFAULT, pars);
-		pars[0] = getWatermarkParagraph(text, 2);
-		createHeader(FIRST, pars);
-		pars[0] = getWatermarkParagraph(text, 3);
-		createHeader(EVEN, pars);
-	}
+    /**
+     * Get the footer that applies to the given
+     * (1 based) page.
+     *
+     * @param pageNumber The one based page number
+     */
+    public XWPFFooter getFooter(int pageNumber) {
+        if (pageNumber == 1 && firstPageFooter != null) {
+            return firstPageFooter;
+        }
+        if (pageNumber % 2 == 0 && evenPageFooter != null) {
+            return evenPageFooter;
+        }
+        return defaultFooter;
+    }
 
-	/*
-	 * This is the default Watermark paragraph; the only variable is the text
-	 * message TODO: manage all the other variables
-	 */
-	private XWPFParagraph getWatermarkParagraph(String text, int idx) {
-		CTP p = CTP.Factory.newInstance();
-		CTBody ctBody = doc.getDocument().getBody();
-		byte[] rsidr = null;
-		byte[] rsidrdefault = null;
-		if (ctBody.sizeOfPArray() == 0) {
-			// TODO generate rsidr and rsidrdefault
-		} else {
-			CTP ctp = ctBody.getPArray(0);
-			rsidr = ctp.getRsidR();
-			rsidrdefault = ctp.getRsidRDefault();
-		}
-		p.setRsidP(rsidr);
-		p.setRsidRDefault(rsidrdefault);
-		CTPPr pPr = p.addNewPPr();
-		pPr.addNewPStyle().setVal("Header");
-		// start watermark paragraph
-		CTR r = p.addNewR();
-		CTRPr rPr = r.addNewRPr();
-		rPr.addNewNoProof();
-		CTPicture pict = r.addNewPict();
-		CTGroup group = CTGroup.Factory.newInstance();
-		CTShapetype shapetype = group.addNewShapetype();
-		shapetype.setId("_x0000_t136");
-		shapetype.setCoordsize("1600,21600");
-		shapetype.setSpt(136);
-		shapetype.setAdj("10800");
-		shapetype.setPath2("m@7,0l@8,0m@5,21600l@6,21600e");
-		CTFormulas formulas = shapetype.addNewFormulas();
-		formulas.addNewF().setEqn("sum #0 0 10800");
-		formulas.addNewF().setEqn("prod #0 2 1");
-		formulas.addNewF().setEqn("sum 21600 0 @1");
-		formulas.addNewF().setEqn("sum 0 0 @2");
-		formulas.addNewF().setEqn("sum 21600 0 @3");
-		formulas.addNewF().setEqn("if @0 @3 0");
-		formulas.addNewF().setEqn("if @0 21600 @1");
-		formulas.addNewF().setEqn("if @0 0 @2");
-		formulas.addNewF().setEqn("if @0 @4 21600");
-		formulas.addNewF().setEqn("mid @5 @6");
-		formulas.addNewF().setEqn("mid @8 @5");
-		formulas.addNewF().setEqn("mid @7 @8");
-		formulas.addNewF().setEqn("mid @6 @7");
-		formulas.addNewF().setEqn("sum @6 0 @5");
-		CTPath path = shapetype.addNewPath();
-		path.setTextpathok(STTrueFalse.T);
-		path.setConnecttype(STConnectType.CUSTOM);
-		path.setConnectlocs("@9,0;@10,10800;@11,21600;@12,10800");
-		path.setConnectangles("270,180,90,0");
-		CTTextPath shapeTypeTextPath = shapetype.addNewTextpath();
-		shapeTypeTextPath.setOn(STTrueFalse.T);
-		shapeTypeTextPath.setFitshape(STTrueFalse.T);
-		CTHandles handles = shapetype.addNewHandles();
-		CTH h = handles.addNewH();
-		h.setPosition("#0,bottomRight");
-		h.setXrange("6629,14971");
-		CTLock lock = shapetype.addNewLock();
-		lock.setExt(STExt.EDIT);
-		CTShape shape = group.addNewShape();
-		shape.setId("PowerPlusWaterMarkObject" + idx);
-		shape.setSpid("_x0000_s102" + (4 + idx));
-		shape.setType("#_x0000_t136");
-		shape.setStyle(
-				"position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;z-index:-251654144;mso-wrap-edited:f;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin");
-		shape.setWrapcoords(
-				"616 5068 390 16297 39 16921 -39 17155 7265 17545 7186 17467 -39 17467 18904 17467 10507 17467 8710 17545 18904 17077 18787 16843 18358 16297 18279 12554 19178 12476 20701 11774 20779 11228 21131 10059 21248 8811 21248 7563 20975 6316 20935 5380 19490 5146 14022 5068 2616 5068");
-		shape.setFillcolor("black");
-		shape.setStroked(STTrueFalse.FALSE);
-		CTTextPath shapeTextPath = shape.addNewTextpath();
-		shapeTextPath.setStyle("font-family:&quot;Cambria&quot;;font-size:1pt");
-		shapeTextPath.setString(text);
-		pict.set(group);
-		// end watermark paragraph
-		return new XWPFParagraph(p, doc);
-	}
+    /**
+     * Get this section footer for the given type
+     *
+     * @param type of footer to return
+     * @return {@link XWPFFooter} object
+     */
+    public XWPFFooter getFooter(Enum type) {
+        if (type == STHdrFtr.EVEN) {
+            return evenPageFooter;
+        } else if (type == STHdrFtr.FIRST) {
+            return firstPageFooter;
+        }
+        return defaultFooter;
+    }
+
+
+    public void createWatermark(String text) {
+        XWPFParagraph[] pars = new XWPFParagraph[1];
+        pars[0] = getWatermarkParagraph(text, 1);
+        createHeader(DEFAULT, pars);
+        pars[0] = getWatermarkParagraph(text, 2);
+        createHeader(FIRST, pars);
+        pars[0] = getWatermarkParagraph(text, 3);
+        createHeader(EVEN, pars);
+    }
+
+    /*
+     * This is the default Watermark paragraph; the only variable is the text message
+     * TODO: manage all the other variables
+     */
+    private XWPFParagraph getWatermarkParagraph(String text, int idx) {
+        CTP p = CTP.Factory.newInstance();
+        CTBody ctBody = doc.getDocument().getBody();
+        byte[] rsidr = null;
+        byte[] rsidrdefault = null;
+        if (ctBody.sizeOfPArray() == 0) {
+            // TODO generate rsidr and rsidrdefault
+        } else {
+            CTP ctp = ctBody.getPArray(0);
+            rsidr = ctp.getRsidR();
+            rsidrdefault = ctp.getRsidRDefault();
+        }
+        p.setRsidP(rsidr);
+        p.setRsidRDefault(rsidrdefault);
+        CTPPr pPr = p.addNewPPr();
+        pPr.addNewPStyle().setVal("Header");
+        // start watermark paragraph
+        CTR r = p.addNewR();
+        CTRPr rPr = r.addNewRPr();
+        rPr.addNewNoProof();
+        CTPicture pict = r.addNewPict();
+        CTGroup group = CTGroup.Factory.newInstance();
+        CTShapetype shapetype = group.addNewShapetype();
+        shapetype.setId("_x0000_t136");
+        shapetype.setCoordsize("1600,21600");
+        shapetype.setSpt(136);
+        shapetype.setAdj("10800");
+        shapetype.setPath2("m@7,0l@8,0m@5,21600l@6,21600e");
+        CTFormulas formulas = shapetype.addNewFormulas();
+        formulas.addNewF().setEqn("sum #0 0 10800");
+        formulas.addNewF().setEqn("prod #0 2 1");
+        formulas.addNewF().setEqn("sum 21600 0 @1");
+        formulas.addNewF().setEqn("sum 0 0 @2");
+        formulas.addNewF().setEqn("sum 21600 0 @3");
+        formulas.addNewF().setEqn("if @0 @3 0");
+        formulas.addNewF().setEqn("if @0 21600 @1");
+        formulas.addNewF().setEqn("if @0 0 @2");
+        formulas.addNewF().setEqn("if @0 @4 21600");
+        formulas.addNewF().setEqn("mid @5 @6");
+        formulas.addNewF().setEqn("mid @8 @5");
+        formulas.addNewF().setEqn("mid @7 @8");
+        formulas.addNewF().setEqn("mid @6 @7");
+        formulas.addNewF().setEqn("sum @6 0 @5");
+        CTPath path = shapetype.addNewPath();
+        path.setTextpathok(STTrueFalse.T);
+        path.setConnecttype(STConnectType.CUSTOM);
+        path.setConnectlocs("@9,0;@10,10800;@11,21600;@12,10800");
+        path.setConnectangles("270,180,90,0");
+        CTTextPath shapeTypeTextPath = shapetype.addNewTextpath();
+        shapeTypeTextPath.setOn(STTrueFalse.T);
+        shapeTypeTextPath.setFitshape(STTrueFalse.T);
+        CTHandles handles = shapetype.addNewHandles();
+        CTH h = handles.addNewH();
+        h.setPosition("#0,bottomRight");
+        h.setXrange("6629,14971");
+        CTLock lock = shapetype.addNewLock();
+        lock.setExt(STExt.EDIT);
+        CTShape shape = group.addNewShape();
+        shape.setId("PowerPlusWaterMarkObject" + idx);
+        shape.setSpid("_x0000_s102" + (4 + idx));
+        shape.setType("#_x0000_t136");
+        shape.setStyle("position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;z-index:-251654144;mso-wrap-edited:f;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin");
+        shape.setWrapcoords("616 5068 390 16297 39 16921 -39 17155 7265 17545 7186 17467 -39 17467 18904 17467 10507 17467 8710 17545 18904 17077 18787 16843 18358 16297 18279 12554 19178 12476 20701 11774 20779 11228 21131 10059 21248 8811 21248 7563 20975 6316 20935 5380 19490 5146 14022 5068 2616 5068");
+        shape.setFillcolor("black");
+        shape.setStroked(STTrueFalse.FALSE);
+        CTTextPath shapeTextPath = shape.addNewTextpath();
+        shapeTextPath.setStyle("font-family:&quot;Cambria&quot;;font-size:1pt");
+        shapeTextPath.setString(text);
+        pict.set(group);
+        // end watermark paragraph
+        return new XWPFParagraph(p, doc);
+    }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/model/XWPFHeaderFooterPolicy.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/model/XWPFHeaderFooterPolicy.java
@@ -16,17 +16,6 @@
 ==================================================================== */
 package org.apache.poi.xwpf.model;
 
-import com.microsoft.schemas.office.office.CTLock;
-import com.microsoft.schemas.office.office.STConnectType;
-import com.microsoft.schemas.vml.CTFormulas;
-import com.microsoft.schemas.vml.CTGroup;
-import com.microsoft.schemas.vml.CTH;
-import com.microsoft.schemas.vml.CTHandles;
-import com.microsoft.schemas.vml.CTPath;
-import com.microsoft.schemas.vml.CTShape;
-import com.microsoft.schemas.vml.CTShapetype;
-import com.microsoft.schemas.vml.CTTextPath;
-import com.microsoft.schemas.vml.STExt;
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLDocumentPart.RelationPart;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
@@ -52,227 +41,236 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.HdrDocument;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr.Enum;
 
+import com.microsoft.schemas.office.office.CTLock;
+import com.microsoft.schemas.office.office.STConnectType;
+import com.microsoft.schemas.vml.CTFormulas;
+import com.microsoft.schemas.vml.CTGroup;
+import com.microsoft.schemas.vml.CTH;
+import com.microsoft.schemas.vml.CTHandles;
+import com.microsoft.schemas.vml.CTPath;
+import com.microsoft.schemas.vml.CTShape;
+import com.microsoft.schemas.vml.CTShapetype;
+import com.microsoft.schemas.vml.CTTextPath;
+import com.microsoft.schemas.vml.STExt;
+
 /**
- * A .docx file can have no headers/footers, the same header/footer
- * on each page, odd/even page footers, and optionally also
- * a different header/footer on the first page.
- * This class handles sorting out what there is, and giving you
+ * A .docx file can have no headers/footers, the same header/footer on each
+ * page, odd/even page footers, and optionally also a different header/footer on
+ * the first page. This class handles sorting out what there is, and giving you
  * the right headers and footers for the document.
  */
 public class XWPFHeaderFooterPolicy {
-    public static final Enum DEFAULT = STHdrFtr.DEFAULT;
-    public static final Enum EVEN = STHdrFtr.EVEN;
-    public static final Enum FIRST = STHdrFtr.FIRST;
+	public static final Enum DEFAULT = STHdrFtr.DEFAULT;
+	public static final Enum EVEN = STHdrFtr.EVEN;
+	public static final Enum FIRST = STHdrFtr.FIRST;
 
-    private XWPFDocument doc;
+	private XWPFDocument doc;
 
-    private XWPFHeader firstPageHeader;
-    private XWPFFooter firstPageFooter;
+	private XWPFHeader firstPageHeader;
+	private XWPFFooter firstPageFooter;
 
-    private XWPFHeader evenPageHeader;
-    private XWPFFooter evenPageFooter;
+	private XWPFHeader evenPageHeader;
+	private XWPFFooter evenPageFooter;
 
-    private XWPFHeader defaultHeader;
-    private XWPFFooter defaultFooter;
+	private XWPFHeader defaultHeader;
+	private XWPFFooter defaultFooter;
+	// This variable stores a reference to the section, it allows the sections to
+	// have different headers and footers
+	private CTSectPr sectPr;
 
-    /**
-     * Figures out the policy for the given document,
-     * and creates any header and footer objects
-     * as required.
-     */
-    public XWPFHeaderFooterPolicy(XWPFDocument doc) {
-        this(doc, null);
-    }
+	/**
+	 * Figures out the policy for the given document, and creates any header and
+	 * footer objects as required.
+	 */
+	public XWPFHeaderFooterPolicy(XWPFDocument doc) {
+		this(doc, null);
+	}
 
-    /**
-     * Figures out the policy for the given document,
-     * and creates any header and footer objects
-     * as required.
-     */
-    public XWPFHeaderFooterPolicy(XWPFDocument doc, CTSectPr sectPr) {
-        // Grab what headers and footers have been defined
-        // For now, we don't care about different ranges, as it
-        //  doesn't seem that .docx properly supports that
-        //  feature of the file format yet
-        if (sectPr == null) {
-            CTBody ctBody = doc.getDocument().getBody();
-            sectPr = ctBody.isSetSectPr()
-                    ? ctBody.getSectPr()
-                    : ctBody.addNewSectPr();
-        }
-        this.doc = doc;
-        for (int i = 0; i < sectPr.sizeOfHeaderReferenceArray(); i++) {
-            // Get the header
-            CTHdrFtrRef ref = sectPr.getHeaderReferenceArray(i);
-            POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
-            XWPFHeader hdr = null;
-            if (relatedPart != null && relatedPart instanceof XWPFHeader) {
-                hdr = (XWPFHeader) relatedPart;
-            }
-            // Assign it; treat invalid options as "default" POI-60293
-            Enum type;
-            try {
-                type = ref.getType();
-            } catch (XmlValueOutOfRangeException e) {
-                type = STHdrFtr.DEFAULT;
-            }
+	/**
+	 * Figures out the policy for the given document, and creates any header and
+	 * footer objects as required.
+	 */
+	public XWPFHeaderFooterPolicy(XWPFDocument doc, CTSectPr sectPr) {
+		// Grab what headers and footers have been defined
+		// For now, we don't care about different ranges, as it
+		// doesn't seem that .docx properly supports that
+		// feature of the file format yet
+		if (sectPr == null) {
+			CTBody ctBody = doc.getDocument().getBody();
+			sectPr = ctBody.isSetSectPr() ? ctBody.getSectPr() : ctBody.addNewSectPr();
+		}
+		this.doc = doc;
+		this.sectPr = sectPr;
+		for (int i = 0; i < sectPr.sizeOfHeaderReferenceArray(); i++) {
+			// Get the header
+			CTHdrFtrRef ref = sectPr.getHeaderReferenceArray(i);
+			POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
+			XWPFHeader hdr = null;
+			if (relatedPart != null && relatedPart instanceof XWPFHeader) {
+				hdr = (XWPFHeader) relatedPart;
+			}
+			// Assign it; treat invalid options as "default" POI-60293
+			Enum type;
+			try {
+				type = ref.getType();
+			} catch (XmlValueOutOfRangeException e) {
+				type = STHdrFtr.DEFAULT;
+			}
 
-            assignHeader(hdr, type);
-        }
-        for (int i = 0; i < sectPr.sizeOfFooterReferenceArray(); i++) {
-            // Get the footer
-            CTHdrFtrRef ref = sectPr.getFooterReferenceArray(i);
-            POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
-            XWPFFooter ftr = null;
-            if (relatedPart != null && relatedPart instanceof XWPFFooter) {
-                ftr = (XWPFFooter) relatedPart;
-            }
-            // Assign it; treat invalid options as "default" POI-60293
-            Enum type;
-            try {
-                type = ref.getType();
-            } catch (XmlValueOutOfRangeException e) {
-                type = STHdrFtr.DEFAULT;
-            }
-            assignFooter(ftr, type);
-        }
-    }
+			assignHeader(hdr, type);
+		}
+		for (int i = 0; i < sectPr.sizeOfFooterReferenceArray(); i++) {
+			// Get the footer
+			CTHdrFtrRef ref = sectPr.getFooterReferenceArray(i);
+			POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
+			XWPFFooter ftr = null;
+			if (relatedPart != null && relatedPart instanceof XWPFFooter) {
+				ftr = (XWPFFooter) relatedPart;
+			}
+			// Assign it; treat invalid options as "default" POI-60293
+			Enum type;
+			try {
+				type = ref.getType();
+			} catch (XmlValueOutOfRangeException e) {
+				type = STHdrFtr.DEFAULT;
+			}
+			assignFooter(ftr, type);
+		}
+	}
 
-    private void assignFooter(XWPFFooter ftr, Enum type) {
-        if (type == STHdrFtr.FIRST) {
-            firstPageFooter = ftr;
-        } else if (type == STHdrFtr.EVEN) {
-            evenPageFooter = ftr;
-        } else {
-            defaultFooter = ftr;
-        }
-    }
+	private void assignFooter(XWPFFooter ftr, Enum type) {
+		if (type == STHdrFtr.FIRST) {
+			firstPageFooter = ftr;
+		} else if (type == STHdrFtr.EVEN) {
+			evenPageFooter = ftr;
+		} else {
+			defaultFooter = ftr;
+		}
+	}
 
-    private void assignHeader(XWPFHeader hdr, Enum type) {
-        if (type == STHdrFtr.FIRST) {
-            firstPageHeader = hdr;
-        } else if (type == STHdrFtr.EVEN) {
-            evenPageHeader = hdr;
-        } else {
-            defaultHeader = hdr;
-        }
-    }
+	private void assignHeader(XWPFHeader hdr, Enum type) {
+		if (type == STHdrFtr.FIRST) {
+			firstPageHeader = hdr;
+		} else if (type == STHdrFtr.EVEN) {
+			evenPageHeader = hdr;
+		} else {
+			defaultHeader = hdr;
+		}
+	}
 
-    /**
-     * Creates an empty header of the specified type, containing a single
-     * empty paragraph, to which you can then set text, add more paragraphs etc.
-     */
-    public XWPFHeader createHeader(Enum type) {
-        return createHeader(type, null);
-    }
+	/**
+	 * Creates an empty header of the specified type, containing a single empty
+	 * paragraph, to which you can then set text, add more paragraphs etc.
+	 */
+	public XWPFHeader createHeader(Enum type) {
+		return createHeader(type, null);
+	}
 
-    /**
-     * Creates a new header of the specified type, to which the
-     * supplied (and previously unattached!) paragraphs are
-     * added to.
-     */
-    public XWPFHeader createHeader(Enum type, XWPFParagraph[] pars) {
-        XWPFHeader header = getHeader(type);
+	/**
+	 * Creates a new header of the specified type, to which the supplied (and
+	 * previously unattached!) paragraphs are added to.
+	 */
+	public XWPFHeader createHeader(Enum type, XWPFParagraph[] pars) {
+		XWPFHeader header = getHeader(type);
 
-        if (header == null) {
-            HdrDocument hdrDoc = HdrDocument.Factory.newInstance();
+		if (header == null) {
+			HdrDocument hdrDoc = HdrDocument.Factory.newInstance();
 
-            XWPFRelation relation = XWPFRelation.HEADER;
-            int i = getRelationIndex(relation);
+			XWPFRelation relation = XWPFRelation.HEADER;
+			int i = getRelationIndex(relation);
 
-            XWPFHeader wrapper = (XWPFHeader) doc.createRelationship(relation,
-                    XWPFFactory.getInstance(), i);
-            wrapper.setXWPFDocument(doc);
+			XWPFHeader wrapper = (XWPFHeader) doc.createRelationship(relation, XWPFFactory.getInstance(), i);
+			wrapper.setXWPFDocument(doc);
 
-            CTHdrFtr hdr = buildHdr(type, wrapper, pars);
-            wrapper.setHeaderFooter(hdr);
-            hdrDoc.setHdr(hdr);
-            assignHeader(wrapper, type);
-            header = wrapper;
-        }
+			CTHdrFtr hdr = buildHdr(type, wrapper, pars);
+			wrapper.setHeaderFooter(hdr);
+			hdrDoc.setHdr(hdr);
+			assignHeader(wrapper, type);
+			header = wrapper;
+		}
 
-        return header;
-    }
+		return header;
+	}
 
-    /**
-     * Creates an empty footer of the specified type, containing a single
-     * empty paragraph, to which you can then set text, add more paragraphs etc.
-     */
-    public XWPFFooter createFooter(Enum type) {
-        return createFooter(type, null);
-    }
+	/**
+	 * Creates an empty footer of the specified type, containing a single empty
+	 * paragraph, to which you can then set text, add more paragraphs etc.
+	 */
+	public XWPFFooter createFooter(Enum type) {
+		return createFooter(type, null);
+	}
 
-    /**
-     * Creates a new footer of the specified type, to which the
-     * supplied (and previously unattached!) paragraphs are
-     * added to.
-     */
-    public XWPFFooter createFooter(Enum type, XWPFParagraph[] pars) {
-        XWPFFooter footer = getFooter(type);
+	/**
+	 * Creates a new footer of the specified type, to which the supplied (and
+	 * previously unattached!) paragraphs are added to.
+	 */
+	public XWPFFooter createFooter(Enum type, XWPFParagraph[] pars) {
+		XWPFFooter footer = getFooter(type);
 
-        if (footer == null) {
-            FtrDocument ftrDoc = FtrDocument.Factory.newInstance();
+		if (footer == null) {
+			FtrDocument ftrDoc = FtrDocument.Factory.newInstance();
 
-            XWPFRelation relation = XWPFRelation.FOOTER;
-            int i = getRelationIndex(relation);
+			XWPFRelation relation = XWPFRelation.FOOTER;
+			int i = getRelationIndex(relation);
 
-            XWPFFooter wrapper = (XWPFFooter) doc.createRelationship(relation,
-                    XWPFFactory.getInstance(), i);
-            wrapper.setXWPFDocument(doc);
+			XWPFFooter wrapper = (XWPFFooter) doc.createRelationship(relation, XWPFFactory.getInstance(), i);
+			wrapper.setXWPFDocument(doc);
 
-            CTHdrFtr ftr = buildFtr(type, wrapper, pars);
-            wrapper.setHeaderFooter(ftr);
-            ftrDoc.setFtr(ftr);
-            assignFooter(wrapper, type);
-            footer = wrapper;
-        }
+			CTHdrFtr ftr = buildFtr(type, wrapper, pars);
+			wrapper.setHeaderFooter(ftr);
+			ftrDoc.setFtr(ftr);
+			assignFooter(wrapper, type);
+			footer = wrapper;
+		}
 
-        return footer;
-    }
+		return footer;
+	}
 
-    private int getRelationIndex(XWPFRelation relation) {
-        int i = 1;
-        for (RelationPart rp : doc.getRelationParts()) {
-            if (rp.getRelationship().getRelationshipType().equals(relation.getRelation())) {
-                i++;
-            }
-        }
-        return i;
-    }
+	private int getRelationIndex(XWPFRelation relation) {
+		int i = 1;
+		for (RelationPart rp : doc.getRelationParts()) {
+			if (rp.getRelationship().getRelationshipType().equals(relation.getRelation())) {
+				i++;
+			}
+		}
+		return i;
+	}
 
-    private CTHdrFtr buildFtr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
-        //CTHdrFtr ftr = buildHdrFtr(pStyle, pars);             // MB 24 May 2010
-        CTHdrFtr ftr = buildHdrFtr(pars, wrapper);        // MB 24 May 2010
-        setFooterReference(type, wrapper);
-        return ftr;
-    }
+	private CTHdrFtr buildFtr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
+		// CTHdrFtr ftr = buildHdrFtr(pStyle, pars); // MB 24 May 2010
+		CTHdrFtr ftr = buildHdrFtr(pars, wrapper); // MB 24 May 2010
+		setFooterReference(type, wrapper);
+		return ftr;
+	}
 
-    private CTHdrFtr buildHdr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
-        //CTHdrFtr hdr = buildHdrFtr(pStyle, pars);             // MB 24 May 2010
-        CTHdrFtr hdr = buildHdrFtr(pars, wrapper);        // MB 24 May 2010
-        setHeaderReference(type, wrapper);
-        return hdr;
-    }
+	private CTHdrFtr buildHdr(Enum type, XWPFHeaderFooter wrapper, XWPFParagraph[] pars) {
+		// CTHdrFtr hdr = buildHdrFtr(pStyle, pars); // MB 24 May 2010
+		CTHdrFtr hdr = buildHdrFtr(pars, wrapper); // MB 24 May 2010
+		setHeaderReference(type, wrapper);
+		return hdr;
+	}
 
-    /**
-     * MB 24 May 2010. Created this overloaded buildHdrFtr() method because testing demonstrated
-     * that the XWPFFooter or XWPFHeader object returned by calls to the createHeader(int, XWPFParagraph[])
-     * and createFooter(int, XWPFParagraph[]) methods or the getXXXXXHeader/Footer methods where
-     * headers or footers had been added to a document since it had been created/opened, returned
-     * an object that contained no XWPFParagraph objects even if the header/footer itself did contain
-     * text. The reason was that this line of code; CTHdrFtr ftr = CTHdrFtr.Factory.newInstance();
-     * created a brand new instance of the CTHDRFtr class which was then populated with data when
-     * it should have recovered the CTHdrFtr object encapsulated within the XWPFHeaderFooter object
-     * that had previoulsy been instantiated in the createHeader(int, XWPFParagraph[]) or
-     * createFooter(int, XWPFParagraph[]) methods.
-     */
-    private CTHdrFtr buildHdrFtr(XWPFParagraph[] paragraphs, XWPFHeaderFooter wrapper) {
-        CTHdrFtr ftr = wrapper._getHdrFtr();
-        if (paragraphs != null) {
-            for (int i = 0; i < paragraphs.length; i++) {
-                /*CTP p =*/ ftr.addNewP();
-                ftr.setPArray(i, paragraphs[i].getCTP());
-            }
+	/**
+	 * MB 24 May 2010. Created this overloaded buildHdrFtr() method because testing
+	 * demonstrated that the XWPFFooter or XWPFHeader object returned by calls to
+	 * the createHeader(int, XWPFParagraph[]) and createFooter(int, XWPFParagraph[])
+	 * methods or the getXXXXXHeader/Footer methods where headers or footers had
+	 * been added to a document since it had been created/opened, returned an object
+	 * that contained no XWPFParagraph objects even if the header/footer itself did
+	 * contain text. The reason was that this line of code; CTHdrFtr ftr =
+	 * CTHdrFtr.Factory.newInstance(); created a brand new instance of the CTHDRFtr
+	 * class which was then populated with data when it should have recovered the
+	 * CTHdrFtr object encapsulated within the XWPFHeaderFooter object that had
+	 * previoulsy been instantiated in the createHeader(int, XWPFParagraph[]) or
+	 * createFooter(int, XWPFParagraph[]) methods.
+	 */
+	private CTHdrFtr buildHdrFtr(XWPFParagraph[] paragraphs, XWPFHeaderFooter wrapper) {
+		CTHdrFtr ftr = wrapper._getHdrFtr();
+		if (paragraphs != null) {
+			for (int i = 0; i < paragraphs.length; i++) {
+				/* CTP p = */ ftr.addNewP();
+				ftr.setPArray(i, paragraphs[i].getCTP());
+			}
 //        } else {
 //            CTP p = ftr.addNewP();
 //            CTBody body = doc.getDocument().getBody();
@@ -287,211 +285,206 @@ public class XWPFHeaderFooterPolicy {
 //            }
 //            CTPPr pPr = p.addNewPPr();
 //            pPr.addNewPStyle().setVal(pStyle);
-        }
-        return ftr;
-    }
+		}
+		return ftr;
+	}
 
+	private void setFooterReference(Enum type, XWPFHeaderFooter wrapper) {
+		CTHdrFtrRef ref = this.sectPr.addNewFooterReference();
+		ref.setType(type);
+		ref.setId(doc.getRelationId(wrapper));
+	}
 
-    private void setFooterReference(Enum type, XWPFHeaderFooter wrapper) {
-        CTHdrFtrRef ref = doc.getDocument().getBody().getSectPr().addNewFooterReference();
-        ref.setType(type);
-        ref.setId(doc.getRelationId(wrapper));
-    }
+	private void setHeaderReference(Enum type, XWPFHeaderFooter wrapper) {
+		CTHdrFtrRef ref = this.sectPr.addNewHeaderReference();
+		ref.setType(type);
+		ref.setId(doc.getRelationId(wrapper));
+	}
 
+	public XWPFHeader getFirstPageHeader() {
+		return firstPageHeader;
+	}
 
-    private void setHeaderReference(Enum type, XWPFHeaderFooter wrapper) {
-        CTHdrFtrRef ref = doc.getDocument().getBody().getSectPr().addNewHeaderReference();
-        ref.setType(type);
-        ref.setId(doc.getRelationId(wrapper));
-    }
+	public XWPFFooter getFirstPageFooter() {
+		return firstPageFooter;
+	}
 
-    public XWPFHeader getFirstPageHeader() {
-        return firstPageHeader;
-    }
+	/**
+	 * Returns the odd page header. This is also the same as the default one...
+	 */
+	public XWPFHeader getOddPageHeader() {
+		return defaultHeader;
+	}
 
-    public XWPFFooter getFirstPageFooter() {
-        return firstPageFooter;
-    }
+	/**
+	 * Returns the odd page footer. This is also the same as the default one...
+	 */
+	public XWPFFooter getOddPageFooter() {
+		return defaultFooter;
+	}
 
-    /**
-     * Returns the odd page header. This is
-     * also the same as the default one...
-     */
-    public XWPFHeader getOddPageHeader() {
-        return defaultHeader;
-    }
+	public XWPFHeader getEvenPageHeader() {
+		return evenPageHeader;
+	}
 
-    /**
-     * Returns the odd page footer. This is
-     * also the same as the default one...
-     */
-    public XWPFFooter getOddPageFooter() {
-        return defaultFooter;
-    }
+	public XWPFFooter getEvenPageFooter() {
+		return evenPageFooter;
+	}
 
-    public XWPFHeader getEvenPageHeader() {
-        return evenPageHeader;
-    }
+	public XWPFHeader getDefaultHeader() {
+		return defaultHeader;
+	}
 
-    public XWPFFooter getEvenPageFooter() {
-        return evenPageFooter;
-    }
+	public XWPFFooter getDefaultFooter() {
+		return defaultFooter;
+	}
 
-    public XWPFHeader getDefaultHeader() {
-        return defaultHeader;
-    }
+	/**
+	 * Get the header that applies to the given (1 based) page.
+	 *
+	 * @param pageNumber The one based page number
+	 */
+	public XWPFHeader getHeader(int pageNumber) {
+		if (pageNumber == 1 && firstPageHeader != null) {
+			return firstPageHeader;
+		}
+		if (pageNumber % 2 == 0 && evenPageHeader != null) {
+			return evenPageHeader;
+		}
+		return defaultHeader;
+	}
 
-    public XWPFFooter getDefaultFooter() {
-        return defaultFooter;
-    }
+	/**
+	 * Get this section header for the given type
+	 *
+	 * @param type of header to return
+	 * @return {@link XWPFHeader} object
+	 */
+	public XWPFHeader getHeader(Enum type) {
+		if (type == STHdrFtr.EVEN) {
+			return evenPageHeader;
+		} else if (type == STHdrFtr.FIRST) {
+			return firstPageHeader;
+		}
+		return defaultHeader;
+	}
 
-    /**
-     * Get the header that applies to the given
-     * (1 based) page.
-     *
-     * @param pageNumber The one based page number
-     */
-    public XWPFHeader getHeader(int pageNumber) {
-        if (pageNumber == 1 && firstPageHeader != null) {
-            return firstPageHeader;
-        }
-        if (pageNumber % 2 == 0 && evenPageHeader != null) {
-            return evenPageHeader;
-        }
-        return defaultHeader;
-    }
+	/**
+	 * Get the footer that applies to the given (1 based) page.
+	 *
+	 * @param pageNumber The one based page number
+	 */
+	public XWPFFooter getFooter(int pageNumber) {
+		if (pageNumber == 1 && firstPageFooter != null) {
+			return firstPageFooter;
+		}
+		if (pageNumber % 2 == 0 && evenPageFooter != null) {
+			return evenPageFooter;
+		}
+		return defaultFooter;
+	}
 
-    /**
-     * Get this section header for the given type
-     *
-     * @param type of header to return
-     * @return {@link XWPFHeader} object
-     */
-    public XWPFHeader getHeader(Enum type) {
-        if (type == STHdrFtr.EVEN) {
-            return evenPageHeader;
-        } else if (type == STHdrFtr.FIRST) {
-            return firstPageHeader;
-        }
-        return defaultHeader;
-    }
+	/**
+	 * Get this section footer for the given type
+	 *
+	 * @param type of footer to return
+	 * @return {@link XWPFFooter} object
+	 */
+	public XWPFFooter getFooter(Enum type) {
+		if (type == STHdrFtr.EVEN) {
+			return evenPageFooter;
+		} else if (type == STHdrFtr.FIRST) {
+			return firstPageFooter;
+		}
+		return defaultFooter;
+	}
 
-    /**
-     * Get the footer that applies to the given
-     * (1 based) page.
-     *
-     * @param pageNumber The one based page number
-     */
-    public XWPFFooter getFooter(int pageNumber) {
-        if (pageNumber == 1 && firstPageFooter != null) {
-            return firstPageFooter;
-        }
-        if (pageNumber % 2 == 0 && evenPageFooter != null) {
-            return evenPageFooter;
-        }
-        return defaultFooter;
-    }
+	public void createWatermark(String text) {
+		XWPFParagraph[] pars = new XWPFParagraph[1];
+		pars[0] = getWatermarkParagraph(text, 1);
+		createHeader(DEFAULT, pars);
+		pars[0] = getWatermarkParagraph(text, 2);
+		createHeader(FIRST, pars);
+		pars[0] = getWatermarkParagraph(text, 3);
+		createHeader(EVEN, pars);
+	}
 
-    /**
-     * Get this section footer for the given type
-     *
-     * @param type of footer to return
-     * @return {@link XWPFFooter} object
-     */
-    public XWPFFooter getFooter(Enum type) {
-        if (type == STHdrFtr.EVEN) {
-            return evenPageFooter;
-        } else if (type == STHdrFtr.FIRST) {
-            return firstPageFooter;
-        }
-        return defaultFooter;
-    }
-
-
-    public void createWatermark(String text) {
-        XWPFParagraph[] pars = new XWPFParagraph[1];
-        pars[0] = getWatermarkParagraph(text, 1);
-        createHeader(DEFAULT, pars);
-        pars[0] = getWatermarkParagraph(text, 2);
-        createHeader(FIRST, pars);
-        pars[0] = getWatermarkParagraph(text, 3);
-        createHeader(EVEN, pars);
-    }
-
-    /*
-     * This is the default Watermark paragraph; the only variable is the text message
-     * TODO: manage all the other variables
-     */
-    private XWPFParagraph getWatermarkParagraph(String text, int idx) {
-        CTP p = CTP.Factory.newInstance();
-        CTBody ctBody = doc.getDocument().getBody();
-        byte[] rsidr = null;
-        byte[] rsidrdefault = null;
-        if (ctBody.sizeOfPArray() == 0) {
-            // TODO generate rsidr and rsidrdefault
-        } else {
-            CTP ctp = ctBody.getPArray(0);
-            rsidr = ctp.getRsidR();
-            rsidrdefault = ctp.getRsidRDefault();
-        }
-        p.setRsidP(rsidr);
-        p.setRsidRDefault(rsidrdefault);
-        CTPPr pPr = p.addNewPPr();
-        pPr.addNewPStyle().setVal("Header");
-        // start watermark paragraph
-        CTR r = p.addNewR();
-        CTRPr rPr = r.addNewRPr();
-        rPr.addNewNoProof();
-        CTPicture pict = r.addNewPict();
-        CTGroup group = CTGroup.Factory.newInstance();
-        CTShapetype shapetype = group.addNewShapetype();
-        shapetype.setId("_x0000_t136");
-        shapetype.setCoordsize("1600,21600");
-        shapetype.setSpt(136);
-        shapetype.setAdj("10800");
-        shapetype.setPath2("m@7,0l@8,0m@5,21600l@6,21600e");
-        CTFormulas formulas = shapetype.addNewFormulas();
-        formulas.addNewF().setEqn("sum #0 0 10800");
-        formulas.addNewF().setEqn("prod #0 2 1");
-        formulas.addNewF().setEqn("sum 21600 0 @1");
-        formulas.addNewF().setEqn("sum 0 0 @2");
-        formulas.addNewF().setEqn("sum 21600 0 @3");
-        formulas.addNewF().setEqn("if @0 @3 0");
-        formulas.addNewF().setEqn("if @0 21600 @1");
-        formulas.addNewF().setEqn("if @0 0 @2");
-        formulas.addNewF().setEqn("if @0 @4 21600");
-        formulas.addNewF().setEqn("mid @5 @6");
-        formulas.addNewF().setEqn("mid @8 @5");
-        formulas.addNewF().setEqn("mid @7 @8");
-        formulas.addNewF().setEqn("mid @6 @7");
-        formulas.addNewF().setEqn("sum @6 0 @5");
-        CTPath path = shapetype.addNewPath();
-        path.setTextpathok(STTrueFalse.T);
-        path.setConnecttype(STConnectType.CUSTOM);
-        path.setConnectlocs("@9,0;@10,10800;@11,21600;@12,10800");
-        path.setConnectangles("270,180,90,0");
-        CTTextPath shapeTypeTextPath = shapetype.addNewTextpath();
-        shapeTypeTextPath.setOn(STTrueFalse.T);
-        shapeTypeTextPath.setFitshape(STTrueFalse.T);
-        CTHandles handles = shapetype.addNewHandles();
-        CTH h = handles.addNewH();
-        h.setPosition("#0,bottomRight");
-        h.setXrange("6629,14971");
-        CTLock lock = shapetype.addNewLock();
-        lock.setExt(STExt.EDIT);
-        CTShape shape = group.addNewShape();
-        shape.setId("PowerPlusWaterMarkObject" + idx);
-        shape.setSpid("_x0000_s102" + (4 + idx));
-        shape.setType("#_x0000_t136");
-        shape.setStyle("position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;z-index:-251654144;mso-wrap-edited:f;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin");
-        shape.setWrapcoords("616 5068 390 16297 39 16921 -39 17155 7265 17545 7186 17467 -39 17467 18904 17467 10507 17467 8710 17545 18904 17077 18787 16843 18358 16297 18279 12554 19178 12476 20701 11774 20779 11228 21131 10059 21248 8811 21248 7563 20975 6316 20935 5380 19490 5146 14022 5068 2616 5068");
-        shape.setFillcolor("black");
-        shape.setStroked(STTrueFalse.FALSE);
-        CTTextPath shapeTextPath = shape.addNewTextpath();
-        shapeTextPath.setStyle("font-family:&quot;Cambria&quot;;font-size:1pt");
-        shapeTextPath.setString(text);
-        pict.set(group);
-        // end watermark paragraph
-        return new XWPFParagraph(p, doc);
-    }
+	/*
+	 * This is the default Watermark paragraph; the only variable is the text
+	 * message TODO: manage all the other variables
+	 */
+	private XWPFParagraph getWatermarkParagraph(String text, int idx) {
+		CTP p = CTP.Factory.newInstance();
+		CTBody ctBody = doc.getDocument().getBody();
+		byte[] rsidr = null;
+		byte[] rsidrdefault = null;
+		if (ctBody.sizeOfPArray() == 0) {
+			// TODO generate rsidr and rsidrdefault
+		} else {
+			CTP ctp = ctBody.getPArray(0);
+			rsidr = ctp.getRsidR();
+			rsidrdefault = ctp.getRsidRDefault();
+		}
+		p.setRsidP(rsidr);
+		p.setRsidRDefault(rsidrdefault);
+		CTPPr pPr = p.addNewPPr();
+		pPr.addNewPStyle().setVal("Header");
+		// start watermark paragraph
+		CTR r = p.addNewR();
+		CTRPr rPr = r.addNewRPr();
+		rPr.addNewNoProof();
+		CTPicture pict = r.addNewPict();
+		CTGroup group = CTGroup.Factory.newInstance();
+		CTShapetype shapetype = group.addNewShapetype();
+		shapetype.setId("_x0000_t136");
+		shapetype.setCoordsize("1600,21600");
+		shapetype.setSpt(136);
+		shapetype.setAdj("10800");
+		shapetype.setPath2("m@7,0l@8,0m@5,21600l@6,21600e");
+		CTFormulas formulas = shapetype.addNewFormulas();
+		formulas.addNewF().setEqn("sum #0 0 10800");
+		formulas.addNewF().setEqn("prod #0 2 1");
+		formulas.addNewF().setEqn("sum 21600 0 @1");
+		formulas.addNewF().setEqn("sum 0 0 @2");
+		formulas.addNewF().setEqn("sum 21600 0 @3");
+		formulas.addNewF().setEqn("if @0 @3 0");
+		formulas.addNewF().setEqn("if @0 21600 @1");
+		formulas.addNewF().setEqn("if @0 0 @2");
+		formulas.addNewF().setEqn("if @0 @4 21600");
+		formulas.addNewF().setEqn("mid @5 @6");
+		formulas.addNewF().setEqn("mid @8 @5");
+		formulas.addNewF().setEqn("mid @7 @8");
+		formulas.addNewF().setEqn("mid @6 @7");
+		formulas.addNewF().setEqn("sum @6 0 @5");
+		CTPath path = shapetype.addNewPath();
+		path.setTextpathok(STTrueFalse.T);
+		path.setConnecttype(STConnectType.CUSTOM);
+		path.setConnectlocs("@9,0;@10,10800;@11,21600;@12,10800");
+		path.setConnectangles("270,180,90,0");
+		CTTextPath shapeTypeTextPath = shapetype.addNewTextpath();
+		shapeTypeTextPath.setOn(STTrueFalse.T);
+		shapeTypeTextPath.setFitshape(STTrueFalse.T);
+		CTHandles handles = shapetype.addNewHandles();
+		CTH h = handles.addNewH();
+		h.setPosition("#0,bottomRight");
+		h.setXrange("6629,14971");
+		CTLock lock = shapetype.addNewLock();
+		lock.setExt(STExt.EDIT);
+		CTShape shape = group.addNewShape();
+		shape.setId("PowerPlusWaterMarkObject" + idx);
+		shape.setSpid("_x0000_s102" + (4 + idx));
+		shape.setType("#_x0000_t136");
+		shape.setStyle(
+				"position:absolute;margin-left:0;margin-top:0;width:415pt;height:207.5pt;z-index:-251654144;mso-wrap-edited:f;mso-position-horizontal:center;mso-position-horizontal-relative:margin;mso-position-vertical:center;mso-position-vertical-relative:margin");
+		shape.setWrapcoords(
+				"616 5068 390 16297 39 16921 -39 17155 7265 17545 7186 17467 -39 17467 18904 17467 10507 17467 8710 17545 18904 17077 18787 16843 18358 16297 18279 12554 19178 12476 20701 11774 20779 11228 21131 10059 21248 8811 21248 7563 20975 6316 20935 5380 19490 5146 14022 5068 2616 5068");
+		shape.setFillcolor("black");
+		shape.setStroked(STTrueFalse.FALSE);
+		CTTextPath shapeTextPath = shape.addNewTextpath();
+		shapeTextPath.setStyle("font-family:&quot;Cambria&quot;;font-size:1pt");
+		shapeTextPath.setString(text);
+		pict.set(group);
+		// end watermark paragraph
+		return new XWPFParagraph(p, doc);
+	}
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestMultiSectionHeaders.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestMultiSectionHeaders.java
@@ -17,12 +17,6 @@
 
 package org.apache.poi.xwpf.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import java.io.IOException;
-
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFFooter;
 import org.apache.poi.xwpf.usermodel.XWPFHeader;
@@ -32,6 +26,12 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPPr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSectPr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestMultiSectionHeaders {
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestMultiSectionHeaders.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestMultiSectionHeaders.java
@@ -1,0 +1,213 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.xwpf.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFFooter;
+import org.apache.poi.xwpf.usermodel.XWPFHeader;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.junit.jupiter.api.Test;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTPPr;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSectPr;
+import org.openxmlformats.schemas.wordprocessingml.x2006.main.STHdrFtr;
+
+public class TestMultiSectionHeaders {
+
+	@Test
+	void testAddHeadersForTwoDistinctSections() throws IOException {
+
+		String header1Text = "Header 1 Text";
+		String header2Text = "Header 2 Text";
+
+		XWPFDocument doc = new XWPFDocument();
+
+		// Add first body/section paragraph
+		XWPFParagraph par1 = doc.createParagraph();
+
+		CTP ctp1 = par1.getCTP();
+		ctp1.addNewR().addNewT().setStringValue("Text for first body paragraph");
+
+		CTPPr ppr1 = null;
+		if (!ctp1.isSetPPr()) {
+			ctp1.addNewPPr();
+		}
+		ppr1 = ctp1.getPPr();
+
+		CTSectPr sec1 = null;
+		if (!ppr1.isSetSectPr()) {
+			ppr1.addNewSectPr();
+		}
+
+		sec1 = ppr1.getSectPr();
+
+		// Create paragraph of the first header
+		CTP parCTP = CTP.Factory.newInstance();
+		parCTP.addNewR().addNewT().setStringValue(header1Text);
+		XWPFParagraph headerPar1 = new XWPFParagraph(parCTP, doc);
+
+		XWPFParagraph[] headerPars1 = { headerPar1 };
+
+		XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
+		XWPFHeader header1 = pol1.createHeader(STHdrFtr.DEFAULT, headerPars1);
+
+		// Add second body/section paragraph
+		XWPFParagraph par2 = doc.createParagraph();
+
+		CTP ctp2 = par2.getCTP();
+		ctp2.addNewR().addNewT().setStringValue("Text for second body paragraph");
+
+		CTPPr ppr2 = null;
+		if (!ctp2.isSetPPr()) {
+			ctp2.addNewPPr();
+		}
+		ppr2 = ctp2.getPPr();
+
+		CTSectPr sec2 = null;
+		if (!ppr2.isSetSectPr()) {
+			ppr2.addNewSectPr();
+		}
+
+		sec2 = ppr2.getSectPr();
+
+		// Create paragraph of the second header
+		CTP parCTP2 = CTP.Factory.newInstance();
+		parCTP2.addNewR().addNewT().setStringValue(header2Text);
+		XWPFParagraph headerPar2 = new XWPFParagraph(parCTP2, doc);
+
+		XWPFParagraph[] headerPars2 = { headerPar2 };
+
+		XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
+		XWPFHeader header2 = pol2.createHeader(STHdrFtr.DEFAULT, headerPars2);
+
+		// Validate the headers are not null
+		assertNotNull(header1.getListParagraph().get(0));
+		assertNotNull(header2.getListParagraph().get(0));
+
+		// Validate the headers are not equal
+		assertNotEquals(header1, header2);
+
+		String textFromHeader1 = header1.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+				.getStringValue();
+		// Validate the text is equal to the text we assigned
+		assertEquals(header1Text, textFromHeader1);
+
+		String textFromHeader2 = header2.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+				.getStringValue();
+		// Validate the text is equal to the text we assigned
+		assertEquals(header2Text, textFromHeader2);
+
+		// Validate the headers text are not equal
+		assertNotEquals(header1Text, header2Text);
+	}
+
+	@Test
+	void testAddFootersForTwoDistinctSections() throws IOException {
+
+		String footer1Text = "Footer 1 Text";
+		String footer2Text = "Footer 2 Text";
+
+		XWPFDocument doc = new XWPFDocument();
+
+		// Add first body/section paragraph
+		XWPFParagraph par1 = doc.createParagraph();
+
+		CTP ctp1 = par1.getCTP();
+		ctp1.addNewR().addNewT().setStringValue("Text for first body paragraph");
+
+		CTPPr ppr1 = null;
+		if (!ctp1.isSetPPr()) {
+			ctp1.addNewPPr();
+		}
+		ppr1 = ctp1.getPPr();
+
+		CTSectPr sec1 = null;
+		if (!ppr1.isSetSectPr()) {
+			ppr1.addNewSectPr();
+		}
+
+		sec1 = ppr1.getSectPr();
+
+		// Create paragraph of the first footer
+		CTP parCTP = CTP.Factory.newInstance();
+		parCTP.addNewR().addNewT().setStringValue(footer1Text);
+		XWPFParagraph footerPar1 = new XWPFParagraph(parCTP, doc);
+
+		XWPFParagraph[] footerPars1 = { footerPar1 };
+
+		XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
+		XWPFFooter footer1 = pol1.createFooter(STHdrFtr.DEFAULT, footerPars1);
+
+		// Add second body/section paragraph
+		XWPFParagraph par2 = doc.createParagraph();
+
+		CTP ctp2 = par2.getCTP();
+		ctp2.addNewR().addNewT().setStringValue("Text for second body paragraph");
+
+		CTPPr ppr2 = null;
+		if (!ctp2.isSetPPr()) {
+			ctp2.addNewPPr();
+		}
+		ppr2 = ctp2.getPPr();
+
+		CTSectPr sec2 = null;
+		if (!ppr2.isSetSectPr()) {
+			ppr2.addNewSectPr();
+		}
+
+		sec2 = ppr2.getSectPr();
+
+		// Create paragraph of the second footer
+		CTP parCTP2 = CTP.Factory.newInstance();
+		parCTP2.addNewR().addNewT().setStringValue(footer2Text);
+		XWPFParagraph footerPar2 = new XWPFParagraph(parCTP2, doc);
+
+		XWPFParagraph[] footerPars2 = { footerPar2 };
+
+		XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
+		XWPFFooter footer2 = pol2.createFooter(STHdrFtr.DEFAULT, footerPars2);
+
+		// Validate the footers are not null
+		assertNotNull(footer1.getListParagraph().get(0));
+		assertNotNull(footer2.getListParagraph().get(0));
+
+		// Validate the footers are not equal, as objects
+		assertNotEquals(footer1, footer2);
+
+		String textFromHeader1 = footer1.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+				.getStringValue();
+		// Validate the text is equal to the text we assigned
+		assertEquals(footer1Text, textFromHeader1);
+
+		String textFromHeader2 = footer2.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+				.getStringValue();
+		// Validate the text is equal to the text we assigned
+		assertEquals(footer2Text, textFromHeader2);
+
+		// Validate the footers text are not equal
+		assertNotEquals(footer1Text, footer2Text);
+
+	}
+
+}

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestMultiSectionHeaders.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestMultiSectionHeaders.java
@@ -35,179 +35,179 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestMultiSectionHeaders {
 
-	@Test
-	void testAddHeadersForTwoDistinctSections() throws IOException {
+    @Test
+    void testAddHeadersForTwoDistinctSections() throws IOException {
 
-		String header1Text = "Header 1 Text";
-		String header2Text = "Header 2 Text";
+        String header1Text = "Header 1 Text";
+        String header2Text = "Header 2 Text";
 
-		XWPFDocument doc = new XWPFDocument();
+        XWPFDocument doc = new XWPFDocument();
 
-		// Add first body/section paragraph
-		XWPFParagraph par1 = doc.createParagraph();
+        // Add first body/section paragraph
+        XWPFParagraph par1 = doc.createParagraph();
 
-		CTP ctp1 = par1.getCTP();
-		ctp1.addNewR().addNewT().setStringValue("Text for first body paragraph");
+        CTP ctp1 = par1.getCTP();
+        ctp1.addNewR().addNewT().setStringValue("Text for first body paragraph");
 
-		CTPPr ppr1 = null;
-		if (!ctp1.isSetPPr()) {
-			ctp1.addNewPPr();
-		}
-		ppr1 = ctp1.getPPr();
+        CTPPr ppr1 = null;
+        if (!ctp1.isSetPPr()) {
+            ctp1.addNewPPr();
+        }
+        ppr1 = ctp1.getPPr();
 
-		CTSectPr sec1 = null;
-		if (!ppr1.isSetSectPr()) {
-			ppr1.addNewSectPr();
-		}
+        CTSectPr sec1 = null;
+        if (!ppr1.isSetSectPr()) {
+            ppr1.addNewSectPr();
+        }
 
-		sec1 = ppr1.getSectPr();
+        sec1 = ppr1.getSectPr();
 
-		// Create paragraph of the first header
-		CTP parCTP = CTP.Factory.newInstance();
-		parCTP.addNewR().addNewT().setStringValue(header1Text);
-		XWPFParagraph headerPar1 = new XWPFParagraph(parCTP, doc);
+        // Create paragraph of the first header
+        CTP parCTP = CTP.Factory.newInstance();
+        parCTP.addNewR().addNewT().setStringValue(header1Text);
+        XWPFParagraph headerPar1 = new XWPFParagraph(parCTP, doc);
 
-		XWPFParagraph[] headerPars1 = { headerPar1 };
+        XWPFParagraph[] headerPars1 = { headerPar1 };
 
-		XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
-		XWPFHeader header1 = pol1.createHeader(STHdrFtr.DEFAULT, headerPars1);
+        XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
+        XWPFHeader header1 = pol1.createHeader(STHdrFtr.DEFAULT, headerPars1);
 
-		// Add second body/section paragraph
-		XWPFParagraph par2 = doc.createParagraph();
+        // Add second body/section paragraph
+        XWPFParagraph par2 = doc.createParagraph();
 
-		CTP ctp2 = par2.getCTP();
-		ctp2.addNewR().addNewT().setStringValue("Text for second body paragraph");
+        CTP ctp2 = par2.getCTP();
+        ctp2.addNewR().addNewT().setStringValue("Text for second body paragraph");
 
-		CTPPr ppr2 = null;
-		if (!ctp2.isSetPPr()) {
-			ctp2.addNewPPr();
-		}
-		ppr2 = ctp2.getPPr();
+        CTPPr ppr2 = null;
+        if (!ctp2.isSetPPr()) {
+            ctp2.addNewPPr();
+        }
+        ppr2 = ctp2.getPPr();
 
-		CTSectPr sec2 = null;
-		if (!ppr2.isSetSectPr()) {
-			ppr2.addNewSectPr();
-		}
+        CTSectPr sec2 = null;
+        if (!ppr2.isSetSectPr()) {
+            ppr2.addNewSectPr();
+        }
 
-		sec2 = ppr2.getSectPr();
+        sec2 = ppr2.getSectPr();
 
-		// Create paragraph of the second header
-		CTP parCTP2 = CTP.Factory.newInstance();
-		parCTP2.addNewR().addNewT().setStringValue(header2Text);
-		XWPFParagraph headerPar2 = new XWPFParagraph(parCTP2, doc);
+        // Create paragraph of the second header
+        CTP parCTP2 = CTP.Factory.newInstance();
+        parCTP2.addNewR().addNewT().setStringValue(header2Text);
+        XWPFParagraph headerPar2 = new XWPFParagraph(parCTP2, doc);
 
-		XWPFParagraph[] headerPars2 = { headerPar2 };
+        XWPFParagraph[] headerPars2 = { headerPar2 };
 
-		XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
-		XWPFHeader header2 = pol2.createHeader(STHdrFtr.DEFAULT, headerPars2);
+        XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
+        XWPFHeader header2 = pol2.createHeader(STHdrFtr.DEFAULT, headerPars2);
 
-		// Validate the headers are not null
-		assertNotNull(header1.getListParagraph().get(0));
-		assertNotNull(header2.getListParagraph().get(0));
+        // Validate the headers are not null
+        assertNotNull(header1.getListParagraph().get(0));
+        assertNotNull(header2.getListParagraph().get(0));
 
-		// Validate the headers are not equal
-		assertNotEquals(header1, header2);
+        // Validate the headers are not equal
+        assertNotEquals(header1, header2);
 
-		String textFromHeader1 = header1.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
-				.getStringValue();
-		// Validate the text is equal to the text we assigned
-		assertEquals(header1Text, textFromHeader1);
+        String textFromHeader1 = header1.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+                .getStringValue();
+        // Validate the text is equal to the text we assigned
+        assertEquals(header1Text, textFromHeader1);
 
-		String textFromHeader2 = header2.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
-				.getStringValue();
-		// Validate the text is equal to the text we assigned
-		assertEquals(header2Text, textFromHeader2);
+        String textFromHeader2 = header2.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+                .getStringValue();
+        // Validate the text is equal to the text we assigned
+        assertEquals(header2Text, textFromHeader2);
 
-		// Validate the headers text are not equal
-		assertNotEquals(header1Text, header2Text);
-	}
+        // Validate the headers text are not equal
+        assertNotEquals(header1Text, header2Text);
+    }
 
-	@Test
-	void testAddFootersForTwoDistinctSections() throws IOException {
+    @Test
+    void testAddFootersForTwoDistinctSections() throws IOException {
 
-		String footer1Text = "Footer 1 Text";
-		String footer2Text = "Footer 2 Text";
+        String footer1Text = "Footer 1 Text";
+        String footer2Text = "Footer 2 Text";
 
-		XWPFDocument doc = new XWPFDocument();
+        XWPFDocument doc = new XWPFDocument();
 
-		// Add first body/section paragraph
-		XWPFParagraph par1 = doc.createParagraph();
+        // Add first body/section paragraph
+        XWPFParagraph par1 = doc.createParagraph();
 
-		CTP ctp1 = par1.getCTP();
-		ctp1.addNewR().addNewT().setStringValue("Text for first body paragraph");
+        CTP ctp1 = par1.getCTP();
+        ctp1.addNewR().addNewT().setStringValue("Text for first body paragraph");
 
-		CTPPr ppr1 = null;
-		if (!ctp1.isSetPPr()) {
-			ctp1.addNewPPr();
-		}
-		ppr1 = ctp1.getPPr();
+        CTPPr ppr1 = null;
+        if (!ctp1.isSetPPr()) {
+            ctp1.addNewPPr();
+        }
+        ppr1 = ctp1.getPPr();
 
-		CTSectPr sec1 = null;
-		if (!ppr1.isSetSectPr()) {
-			ppr1.addNewSectPr();
-		}
+        CTSectPr sec1 = null;
+        if (!ppr1.isSetSectPr()) {
+            ppr1.addNewSectPr();
+        }
 
-		sec1 = ppr1.getSectPr();
+        sec1 = ppr1.getSectPr();
 
-		// Create paragraph of the first footer
-		CTP parCTP = CTP.Factory.newInstance();
-		parCTP.addNewR().addNewT().setStringValue(footer1Text);
-		XWPFParagraph footerPar1 = new XWPFParagraph(parCTP, doc);
+        // Create paragraph of the first footer
+        CTP parCTP = CTP.Factory.newInstance();
+        parCTP.addNewR().addNewT().setStringValue(footer1Text);
+        XWPFParagraph footerPar1 = new XWPFParagraph(parCTP, doc);
 
-		XWPFParagraph[] footerPars1 = { footerPar1 };
+        XWPFParagraph[] footerPars1 = { footerPar1 };
 
-		XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
-		XWPFFooter footer1 = pol1.createFooter(STHdrFtr.DEFAULT, footerPars1);
+        XWPFHeaderFooterPolicy pol1 = new XWPFHeaderFooterPolicy(doc, sec1);
+        XWPFFooter footer1 = pol1.createFooter(STHdrFtr.DEFAULT, footerPars1);
 
-		// Add second body/section paragraph
-		XWPFParagraph par2 = doc.createParagraph();
+        // Add second body/section paragraph
+        XWPFParagraph par2 = doc.createParagraph();
 
-		CTP ctp2 = par2.getCTP();
-		ctp2.addNewR().addNewT().setStringValue("Text for second body paragraph");
+        CTP ctp2 = par2.getCTP();
+        ctp2.addNewR().addNewT().setStringValue("Text for second body paragraph");
 
-		CTPPr ppr2 = null;
-		if (!ctp2.isSetPPr()) {
-			ctp2.addNewPPr();
-		}
-		ppr2 = ctp2.getPPr();
+        CTPPr ppr2 = null;
+        if (!ctp2.isSetPPr()) {
+            ctp2.addNewPPr();
+        }
+        ppr2 = ctp2.getPPr();
 
-		CTSectPr sec2 = null;
-		if (!ppr2.isSetSectPr()) {
-			ppr2.addNewSectPr();
-		}
+        CTSectPr sec2 = null;
+        if (!ppr2.isSetSectPr()) {
+            ppr2.addNewSectPr();
+        }
 
-		sec2 = ppr2.getSectPr();
+        sec2 = ppr2.getSectPr();
 
-		// Create paragraph of the second footer
-		CTP parCTP2 = CTP.Factory.newInstance();
-		parCTP2.addNewR().addNewT().setStringValue(footer2Text);
-		XWPFParagraph footerPar2 = new XWPFParagraph(parCTP2, doc);
+        // Create paragraph of the second footer
+        CTP parCTP2 = CTP.Factory.newInstance();
+        parCTP2.addNewR().addNewT().setStringValue(footer2Text);
+        XWPFParagraph footerPar2 = new XWPFParagraph(parCTP2, doc);
 
-		XWPFParagraph[] footerPars2 = { footerPar2 };
+        XWPFParagraph[] footerPars2 = { footerPar2 };
 
-		XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
-		XWPFFooter footer2 = pol2.createFooter(STHdrFtr.DEFAULT, footerPars2);
+        XWPFHeaderFooterPolicy pol2 = new XWPFHeaderFooterPolicy(doc, sec2);
+        XWPFFooter footer2 = pol2.createFooter(STHdrFtr.DEFAULT, footerPars2);
 
-		// Validate the footers are not null
-		assertNotNull(footer1.getListParagraph().get(0));
-		assertNotNull(footer2.getListParagraph().get(0));
+        // Validate the footers are not null
+        assertNotNull(footer1.getListParagraph().get(0));
+        assertNotNull(footer2.getListParagraph().get(0));
 
-		// Validate the footers are not equal, as objects
-		assertNotEquals(footer1, footer2);
+        // Validate the footers are not equal, as objects
+        assertNotEquals(footer1, footer2);
 
-		String textFromHeader1 = footer1.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
-				.getStringValue();
-		// Validate the text is equal to the text we assigned
-		assertEquals(footer1Text, textFromHeader1);
+        String textFromHeader1 = footer1.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+                .getStringValue();
+        // Validate the text is equal to the text we assigned
+        assertEquals(footer1Text, textFromHeader1);
 
-		String textFromHeader2 = footer2.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
-				.getStringValue();
-		// Validate the text is equal to the text we assigned
-		assertEquals(footer2Text, textFromHeader2);
+        String textFromHeader2 = footer2.getListParagraph().get(0).getCTP().getRArray()[0].getTArray()[0]
+                .getStringValue();
+        // Validate the text is equal to the text we assigned
+        assertEquals(footer2Text, textFromHeader2);
 
-		// Validate the footers text are not equal
-		assertNotEquals(footer1Text, footer2Text);
+        // Validate the footers text are not equal
+        assertNotEquals(footer1Text, footer2Text);
 
-	}
+    }
 
 }


### PR DESCRIPTION
The below variable was added in the class XWPFHeaderFooterPolicy.java. The variable allows to save a header policy for each section in the document. This variable is used to add header and footer references.

Tests and one example were added.

```
// This allows to have a reference to any section and have distinct headers for
// sections.
private CTSectPr sectPr;
``

![MultiSectionHeaders](https://user-images.githubusercontent.com/37852154/156886953-0b1e278d-6dab-4bfd-a1a5-214b736b22a8.png)
`