### PR TITLE
close XSSFWorkbook on SXSSFWorkbook.write() method

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
@@ -967,6 +967,7 @@ public class SXSSFWorkbook implements Workbook {
         try {
             try (FileOutputStream os = new FileOutputStream(tmplFile)) {
                 _wb.write(os);
+                _wb.close();
             }
 
             //Substitute the template entries with the generated sheet data files


### PR DESCRIPTION
Please check code change.
Why close is not called after underlying XSSFWorkbook is written? 