### PR TITLE
Add equals() and hashCode() to PaneInformation

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/util/PaneInformation.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/PaneInformation.java
@@ -17,6 +17,8 @@
 
 package org.apache.poi.ss.util;
 
+import java.util.Objects;
+
 /**
  * Holds information regarding a split plane or freeze plane for a sheet.
  *
@@ -101,5 +103,31 @@ public class PaneInformation
      */
     public boolean isFreezePane() {
         return frozen;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PaneInformation)) return false;
+
+        PaneInformation that = (PaneInformation) o;
+
+        if (x != that.x) return false;
+        if (y != that.y) return false;
+        if (topRow != that.topRow) return false;
+        if (leftColumn != that.leftColumn) return false;
+        if (activePane != that.activePane) return false;
+        return frozen == that.frozen;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            x,
+            y,
+            topRow,
+            leftColumn,
+            activePane,
+            frozen);
     }
 }

--- a/poi/src/test/java/org/apache/poi/ss/util/TestPaneInformation.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/TestPaneInformation.java
@@ -1,0 +1,52 @@
+package org.apache.poi.ss.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+final class TestPaneInformation {
+  @Test
+  void testEquals() {
+    PaneInformation pi1 = new PaneInformation((short) 1, (short) 2, (short) 3, (short) 4, (byte) 5, true);
+    PaneInformation p12 = new PaneInformation((short) 1, (short) 2, (short) 3, (short) 4, (byte) 5, true);
+    assertEquals(pi1, p12);
+    assertEquals(pi1.hashCode(), p12.hashCode());
+  }
+
+  @Test
+  void testNotEquals() {
+    PaneInformation pi1 = new PaneInformation((short) 1, (short) 1, (short) 1, (short) 1, (byte) 1, true);
+    PaneInformation pi2 = new PaneInformation((short) 1, (short) 1, (short) 1, (short) 1, (byte) 1, false);
+    PaneInformation pi3 = new PaneInformation((short) 1, (short) 1, (short) 1, (short) 1, (byte) 2, true);
+    PaneInformation pi4 = new PaneInformation((short) 1, (short) 1, (short) 1, (short) 2, (byte) 1, true);
+    PaneInformation pi5 = new PaneInformation((short) 1, (short) 1, (short) 1, (short) 2, (byte) 1, false);
+    PaneInformation pi6 = new PaneInformation((short) 1, (short) 1, (short) 2, (short) 1, (byte) 1, true);
+    PaneInformation pi7 = new PaneInformation((short) 1, (short) 1, (short) 2, (short) 1, (byte) 1, false);
+    PaneInformation pi8 = new PaneInformation((short) 1, (short) 2, (short) 1, (short) 1, (byte) 1, true);
+    PaneInformation pi9 = new PaneInformation((short) 1, (short) 2, (short) 1, (short) 1, (byte) 1, false);
+    PaneInformation pi10 = new PaneInformation((short) 2, (short) 1, (short) 1, (short) 1, (byte) 1, true);
+    PaneInformation pi11 = new PaneInformation((short) 2, (short) 1, (short) 1, (short) 1, (byte) 1, false);
+    assertNotEquals(pi1, pi2);
+    assertNotEquals(pi1, pi3);
+    assertNotEquals(pi1, pi4);
+    assertNotEquals(pi1, pi5);
+    assertNotEquals(pi1, pi6);
+    assertNotEquals(pi1, pi7);
+    assertNotEquals(pi1, pi8);
+    assertNotEquals(pi1, pi9);
+    assertNotEquals(pi1, pi10);
+    assertNotEquals(pi1, pi11);
+    assertNotEquals(pi1.hashCode(), pi2.hashCode());
+    assertNotEquals(pi1.hashCode(), pi3.hashCode());
+    assertNotEquals(pi1.hashCode(), pi4.hashCode());
+    assertNotEquals(pi1.hashCode(), pi5.hashCode());
+    assertNotEquals(pi1.hashCode(), pi6.hashCode());
+    assertNotEquals(pi1.hashCode(), pi7.hashCode());
+    assertNotEquals(pi1.hashCode(), pi8.hashCode());
+    assertNotEquals(pi1.hashCode(), pi9.hashCode());
+    assertNotEquals(pi1.hashCode(), pi10.hashCode());
+    assertNotEquals(pi1.hashCode(), pi11.hashCode());
+  }
+
+}


### PR DESCRIPTION
Currently there is no way to compare `PaneInformation` equality except by manually comparing all its properties