### PR TITLE
fix bug: when transfer .ppt(which is encrypted) to .pdf by using poi and itexpdf,can cause NullPointException.

### DIFF
--- a/poi/src/main/java/org/apache/poi/sl/draw/DrawTextParagraph.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/DrawTextParagraph.java
@@ -403,7 +403,7 @@ public class DrawTextParagraph implements Drawable {
         if (ft == null) {
             return getRenderableText(tr);
         }
-        if (!tr.getRawText().isEmpty()) {
+        if (tr.getRawText()!=null && !tr.getRawText().isEmpty()) {
             switch (ft) {
                 case SLIDE_NUMBER: {
                     Slide<?, ?> slide = (Slide<?, ?>) graphics.getRenderingHint(Drawable.CURRENT_SLIDE);


### PR DESCRIPTION
When i try to transfer .ppt to .pdf,that can work well.But When i try to transfer .ppt(Note: this file is encrypted) to .pdf,the file `DrawTextParagraph.java#getRenderableText()` can cause `NullPointException`.This pr can fix it.