### PR TITLE
fix bug: when transfer .ppt(which include the object such as excel...…

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/draw/HemfImageRenderer.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/draw/HemfImageRenderer.java
@@ -107,6 +107,8 @@ public class HemfImageRenderer implements ImageRenderer, EmbeddedExtractor {
             return false;
         }
 
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
         Charset cs = (Charset)graphics.getRenderingHint(Drawable.DEFAULT_CHARSET);
         if (cs != null && !charsetInitialized) {
             setDefaultCharset(cs);


### PR DESCRIPTION
When i try to transfer .ppt to .pdf,that can work well.But When i try to transfer .ppt(Note: this file include the object such as excel...) to .pdf,that can cause infinite loop.

I found one way to solve this by calling `graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);` in `HemfImageRenderer.java#drawImage()`
