### PR TITLE
use async task to avoid calculating dowstream result in same thread

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/formula/WorkbookEvaluator.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/WorkbookEvaluator.java
@@ -90,7 +90,7 @@ public final class WorkbookEvaluator {
     private int dbgEvaluationOutputIndent = -1;
 
     /**
-     * @return whether WorkbookEvaluators use a {@link ExecutorService} to run some work asynchronously
+     * @return whether WorkbookEvaluators use an {@link ExecutorService} to run some work asynchronously
      * @since POI 5.2.3
      */
     public static boolean usesAsyncTasks() {
@@ -98,6 +98,10 @@ public final class WorkbookEvaluator {
     }
 
     /**
+     * Set whether WorkbookEvaluators should use an {@link ExecutorService} to run some work asynchronously.
+     * This is recommended if you have to evaluate formulas that depend on cells via a deeply nested path.
+     * The default is <code>false</code>.
+     *
      * @param useAsyncTasks sets whether WorkbookEvaluators use a {@link ExecutorService} to run some work asynchronously
      * @since POI 5.2.3
      */

--- a/poi/src/test/java/org/apache/poi/ss/formula/TestFormulaEval.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/TestFormulaEval.java
@@ -74,7 +74,7 @@ class TestFormulaEval {
         }
     }
 
-    @Disabled("currently causes a StackOverflowError")
+    //@Disabled("currently causes a StackOverflowError")
     @Test
     void testBug66152() throws IOException {
         try (HSSFWorkbook wb = new HSSFWorkbook()) {

--- a/poi/src/test/java/org/apache/poi/ss/formula/TestFormulaEval.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/TestFormulaEval.java
@@ -100,14 +100,16 @@ class TestFormulaEval {
             HSSFCell c0 = r0.createCell(0);
             c0.setCellValue(1);
             HSSFCell cell = null;
-            for (int i = 1; i < 1200; i++) {
+            final int size = 1200;
+            for (int i = 1; i < size; i++) {
                 HSSFRow row = sheet.createRow(i);
                 cell = row.createCell(0);
-                cell.setCellFormula("SUM(A" + i + " + 1)");
+                cell.setCellFormula("A" + i + " + 1");
             }
             HSSFFormulaEvaluator formulaEvaluator = wb.getCreationHelper().createFormulaEvaluator();
             //formulaEvaluator.evaluateAll(); //this workaround avoids the stackoverflow issue
             assertEquals(CellType.NUMERIC, formulaEvaluator.evaluateFormulaCell(cell));
+            assertEquals(size, cell.getNumericCellValue());
         }
     }
 }


### PR DESCRIPTION
Relates to https://bz.apache.org/bugzilla/show_bug.cgi?id=66152

This is work in progress.

* See the uncommented test in this PR to see how to reproduce the issue.
* By calculating the value of the cell that we rely on using an async task, we avoid creating a Java call stack that can get too big if cells depend on cells that depend on other cells, etc. - too many layers of nesting and we will stack overflow
* The main downside is that we have more threads - in this case, a ForkJoinPool
* We could make this configurable, maybe a static method on WorkbookEvaluator that allows you to enable/disable the use of the ForkJoinPool
  * configuring POI is a bit of a mess - many different classes with their own static methods
  * probably too late to try to centralise the config