### PR TITLE
Avoid long literals ending with lowercase 'l'. These literals may be …

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Notes.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Notes.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 public final class Notes extends SheetContainer
 {
     private byte[] _header;
-    private static long _type = 1008l;
+    private static long _type = 1008L;
 
     // Links to our more interesting children
     private NotesAtom notesAtom;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/NotesAtom.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/NotesAtom.java
@@ -35,7 +35,7 @@ import org.apache.poi.util.LittleEndian;
 public final class NotesAtom extends RecordAtom {
 
     private byte[] _header;
-    private static long _type = 1009l;
+    private static long _type = 1009L;
 
     private int slideID;
     private boolean followMasterObjects;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Slide.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Slide.java
@@ -31,7 +31,7 @@ import org.apache.poi.util.LittleEndian;
 public final class Slide extends SheetContainer
 {
     private byte[] _header;
-    private static long _type = 1006l;
+    private static long _type = 1006L;
 
     // Links to our more interesting children
     private SlideAtom slideAtom;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/SlideAtom.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/SlideAtom.java
@@ -39,7 +39,7 @@ public final class SlideAtom extends RecordAtom {
     // private static final int MASTER_SLIDE_ID      =  0x00000000;
 
     private byte[] _header;
-    private static long _type = 1007l;
+    private static long _type = 1007L;
 
     private int masterID;
     private int notesID;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/SlidePersistAtom.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/SlidePersistAtom.java
@@ -38,7 +38,7 @@ public final class SlidePersistAtom extends RecordAtom {
     //arbitrarily selected; may need to increase
     private static final int MAX_RECORD_LENGTH = 32;
 
-    private static final long _type = 1011l;
+    private static final long _type = 1011L;
     private static final int HAS_SHAPES_OTHER_THAN_PLACEHOLDERS = 4;
 
     private static final int[] FLAGS_MASKS = { HAS_SHAPES_OTHER_THAN_PLACEHOLDERS };


### PR DESCRIPTION
Avoid long literals ending with lowercase 'l'. These literals may be confusing, as lowercase 'l' looks very similar to '1'. Use 'L' instead