### PR TITLE
Fix issue with orphaned (in package) images and notes post slide removal.

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
@@ -466,6 +466,15 @@ public class XMLSlideShow extends POIXMLDocument
         sldIdLst.setSldIdArray(entries);
     }
 
+    /**
+     * Remove a slide from this presentation.
+     * *
+     * @param index The slide number to remove.
+     * @return The slide that was removed.
+     *
+     * @throws RuntimeException a number of other runtime exceptions can be thrown, especially if there are problems with the
+     * input format*
+     */
     public XSLFSlide removeSlide(int index) {
         XSLFSlide slide = _slides.remove(index);
         removeRelation(slide);
@@ -478,6 +487,9 @@ public class XMLSlideShow extends POIXMLDocument
             } else if (p instanceof XSLFSlideLayout) {
                 XSLFSlideLayout layout = (XSLFSlideLayout) p;
                 slide.removeLayoutRelation(layout);
+            } else if (p instanceof XSLFNotes) {
+                XSLFNotes notes = slide.removeNotes(_notesMaster);
+                removeRelation(notes);
             }
         }
         return slide;

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
@@ -490,9 +490,33 @@ public class XMLSlideShow extends POIXMLDocument
             } else if (p instanceof XSLFNotes) {
                 XSLFNotes notes = slide.removeNotes(_notesMaster);
                 removeRelation(notes);
+            } else if (p instanceof XSLFPictureData) {
+                XSLFPictureData picture = (XSLFPictureData) p;
+                removePictureRelations(slide, picture);
+                _pictures.remove(picture);
             }
         }
         return slide;
+    }
+
+    private void removePictureRelations(XSLFSlide slide, XSLFPictureData picture) {
+        removePictureRelations(slide, slide, picture);
+    }
+
+    private void removePictureRelations(XSLFSlide slide, XSLFShapeContainer container, XSLFPictureData picture) {
+        for (XSLFShape shape : container.getShapes()) {
+            // Find either group shapes (and recurse) ...
+            if (shape instanceof XSLFGroupShape) {
+                removePictureRelations(slide, (XSLFGroupShape)shape, picture);
+            }
+            // ... or the picture shape with this picture data and remove it's relation to the picture data.
+            if (shape instanceof XSLFPictureShape) {
+                XSLFPictureShape pic = (XSLFPictureShape) shape;
+                if (pic.getPictureData() == picture) {
+                    slide.removePictureRelation(pic);
+                }
+            }
+        }
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFNotes.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFNotes.java
@@ -111,4 +111,9 @@ implements Notes<XSLFShape,XSLFTextParagraph> {
     String mapSchemeColor(String schemeColor) {
         return mapSchemeColor(_notes.getClrMapOvr(), schemeColor);
     }
+
+    void removeRelations(XSLFSlide slide, XSLFNotesMaster master) {
+        super.removeRelation(slide);
+        super.removeRelation(master);
+    }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSlide.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSlide.java
@@ -239,6 +239,21 @@ implements Slide<XSLFShape,XSLFTextParagraph> {
         return _notes;
     }
 
+    public XSLFNotes removeNotes(XSLFNotesMaster master) {
+        XSLFNotes notesForSlide = getNotes();
+        if (notesForSlide == null) {
+            // No notes to remove.
+            return null;
+        }
+
+        notesForSlide.removeRelations(this, master);
+        removeRelation(notesForSlide);
+
+        _notes = null;
+
+        return notesForSlide;
+    }
+
     @Override
     public String getTitle(){
         XSLFTextShape txt = getTextShapeByType(Placeholder.TITLE);

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
@@ -21,12 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.sl.usermodel.Placeholder;
 import org.apache.poi.xslf.XSLFTestDataSamples;
 import org.junit.jupiter.api.Test;
@@ -94,7 +97,8 @@ class TestXSLFSlideShow {
 
     /**
      * This test ensures that if a slide (with notes) is removed, that it
-     * is ACTUALLY removed, and not left orphaned when the PPTX is later written.
+     * is ACTUALLY removed (including the notes), and not left orphaned
+     * when the PPTX is later written.
      *
      * @throws IOException If there is an I/O issue during the test.
      */
@@ -136,6 +140,133 @@ class TestXSLFSlideShow {
         String notePartRegEx = "/ppt/notesSlides/notesSlide[0-9]+\\.xml";
         List<PackagePart> noteParts = ppt2.getPackage().getPartsByName(Pattern.compile(notePartRegEx));
         assertEquals(0, noteParts.size());
+
+        ppt2.close();
+        ppt.close();
+    }
+
+
+    /**
+     * This test ensures that if a slide (with notes and images) is removed, that it
+     * is ACTUALLY removed (including the notes and images), and not left orphaned
+     * when the PPTX is later written.
+     *
+     * @throws IOException If there is an I/O issue during the test.
+     */
+    @Test
+    void testRemoveSlideThatHasNotesAndImages() throws IOException {
+        XMLSlideShow  ppt = new XMLSlideShow();
+        assertEquals(0, ppt.getSlides().size());
+
+        XSLFSlide slide1 = ppt.createSlide();
+        XSLFSlide slide2 = ppt.createSlide();
+
+        // NOTE: This image is INVALID but this doesnt matter for THIS test.
+        XSLFPictureData pictData = ppt.addPicture(
+            new ByteArrayInputStream(new byte[] { 00, 01, 02 }), PictureData.PictureType.PNG);
+        XSLFPictureShape picShape = slide1.createPicture(pictData);
+        picShape.setAnchor(new Rectangle(10, 10, 200, 100));
+
+        XSLFNotes note = ppt.getNotesSlide(slide1);
+        for (XSLFTextShape shape : note.getPlaceholders()) {
+            if (shape.getTextType() == Placeholder.BODY) {
+                shape.setText("Some notes");
+                break;
+            }
+        }
+
+        assertEquals(2, ppt.getSlides().size());
+        assertSame(slide1, ppt.getSlides().get(0));
+        assertSame(slide2, ppt.getSlides().get(1));
+
+        XSLFSlide removedSlide = ppt.removeSlide(0);
+        assertSame(slide1, removedSlide);
+
+        assertEquals(1, ppt.getSlides().size());
+        assertSame(slide2, ppt.getSlides().get(0));
+
+        XMLSlideShow ppt2 = XSLFTestDataSamples.writeOutAndReadBack(ppt);
+        assertEquals(1, ppt2.getSlides().size());
+
+        // Check that the slide is actually removed from the package.
+        String slidePartRegEx = "/ppt/slides/slide[0-9]+\\.xml";
+        List<PackagePart> slideParts = ppt2.getPackage().getPartsByName(Pattern.compile(slidePartRegEx));
+        assertEquals(1, slideParts.size());
+
+        // Check that there is no note slide part.
+        String notePartRegEx = "/ppt/notesSlides/notesSlide[0-9]+\\.xml";
+        List<PackagePart> noteParts = ppt2.getPackage().getPartsByName(Pattern.compile(notePartRegEx));
+        assertEquals(0, noteParts.size());
+
+        // Check that there is no image slide part.
+        String imagePartRegEx = "/ppt/media/image[0-9]+\\.png";
+        List<PackagePart> imageParts = ppt2.getPackage().getPartsByName(Pattern.compile(imagePartRegEx));
+        imageParts.forEach(System.out::println);
+        assertEquals(0, imageParts.size());
+
+        ppt2.close();
+        ppt.close();
+    }
+
+    /**
+     * This test ensures that if a slide (with notes and images [inside a group])
+     * is removed, that it is ACTUALLY removed (including the notes and images),
+     * and not left orphaned when the PPTX is later written.
+     *
+     * @throws IOException If there is an I/O issue during the test.
+     */
+    @Test
+    void testRemoveSlideThatHasNotesAndImagesInsideAGroup() throws IOException {
+        XMLSlideShow  ppt = new XMLSlideShow();
+        assertEquals(0, ppt.getSlides().size());
+
+        XSLFSlide slide1 = ppt.createSlide();
+        XSLFSlide slide2 = ppt.createSlide();
+
+        XSLFGroupShape group = slide1.createGroup();
+
+        // NOTE: This image is INVALID but this doesnt matter for THIS test.
+        XSLFPictureData pictData = ppt.addPicture(
+            new ByteArrayInputStream(new byte[] { 00, 01, 02 }), PictureData.PictureType.PNG);
+        XSLFPictureShape picShape = group.createPicture(pictData);
+        picShape.setAnchor(new Rectangle(10, 10, 200, 100));
+
+        XSLFNotes note = ppt.getNotesSlide(slide1);
+        for (XSLFTextShape shape : note.getPlaceholders()) {
+            if (shape.getTextType() == Placeholder.BODY) {
+                shape.setText("Some notes");
+                break;
+            }
+        }
+
+        assertEquals(2, ppt.getSlides().size());
+        assertSame(slide1, ppt.getSlides().get(0));
+        assertSame(slide2, ppt.getSlides().get(1));
+
+        XSLFSlide removedSlide = ppt.removeSlide(0);
+        assertSame(slide1, removedSlide);
+
+        assertEquals(1, ppt.getSlides().size());
+        assertSame(slide2, ppt.getSlides().get(0));
+
+        XMLSlideShow ppt2 = XSLFTestDataSamples.writeOutAndReadBack(ppt);
+        assertEquals(1, ppt2.getSlides().size());
+
+        // Check that the slide is actually removed from the package.
+        String slidePartRegEx = "/ppt/slides/slide[0-9]+\\.xml";
+        List<PackagePart> slideParts = ppt2.getPackage().getPartsByName(Pattern.compile(slidePartRegEx));
+        assertEquals(1, slideParts.size());
+
+        // Check that there is no note slide part.
+        String notePartRegEx = "/ppt/notesSlides/notesSlide[0-9]+\\.xml";
+        List<PackagePart> noteParts = ppt2.getPackage().getPartsByName(Pattern.compile(notePartRegEx));
+        assertEquals(0, noteParts.size());
+
+        // Check that there is no image slide part.
+        String imagePartRegEx = "/ppt/media/image[0-9]+\\.png";
+        List<PackagePart> imageParts = ppt2.getPackage().getPartsByName(Pattern.compile(imagePartRegEx));
+        imageParts.forEach(System.out::println);
+        assertEquals(0, imageParts.size());
 
         ppt2.close();
         ppt.close();


### PR DESCRIPTION
When removing a slide from a loaded (XMLSlideShow) presentation, it is observed that the resulting output, whilst removing the actual slides leaves dangling (orphaned) artefacts in the written package. i.e. the notes slides and image data are left in the package. This results in larger than needed package output - something that is considerably visible when the original deck is of a large size (e.g. 100MB+) 

This PR resolves the issue by ensuring that the package part relations are correctly removed for note and picture relations when a slide is remove from a deck.