### PR TITLE
Insert paragraphs and tables into `XWPFDocuments` recursively

### DIFF
--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/TestXWPFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/TestXWPFBugs.java
@@ -44,6 +44,7 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.xwpf.extractor.XWPFWordExtractor;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.xmlbeans.XmlCursor;
 import org.apache.xmlbeans.XmlException;
@@ -197,6 +198,16 @@ class TestXWPFBugs {
     }
 
     @Test
+    void insertTableDirectlyIntoBody() throws IOException {
+        try (XWPFDocument document = new XWPFDocument(samples.openResourceAsStream("bug66312.docx"))) {
+            XWPFParagraph paragraph = document.getParagraphArray(0);
+            insertTable(paragraph, document);
+            assertEquals("Hello", document.getTableArray(0).getRow(0).getCell(0).getText());
+            assertEquals("World", document.getParagraphArray(0).getText());
+        }
+    }
+
+    @Test
     void insertParagraphIntoTable() throws IOException {
         try (XWPFDocument document = new XWPFDocument(samples.openResourceAsStream("bug66312.docx"))) {
             XWPFTableCell cell = document.getTableArray(0).getRow(0).getCell(0);
@@ -207,9 +218,27 @@ class TestXWPFBugs {
         }
     }
 
+    @Test
+    void insertTableIntoTable() throws IOException {
+        try (XWPFDocument document = new XWPFDocument(samples.openResourceAsStream("bug66312.docx"))) {
+            XWPFTableCell cell = document.getTableArray(0).getRow(0).getCell(0);
+            XWPFParagraph paragraph = cell.getParagraphArray(0);
+            insertTable(paragraph, document);
+            assertEquals("Hello", cell.getTableArray(0).getRow(0).getCell(0).getText());
+            assertEquals("World", cell.getParagraphArray(0).getText());
+        }
+    }
+
+
     public static void insertParagraph(XWPFParagraph xwpfParagraph, XWPFDocument document) {
         XmlCursor xmlCursor = xwpfParagraph.getCTP().newCursor();
         XWPFParagraph xwpfParagraph2 = document.insertNewParagraph(xmlCursor);
         xwpfParagraph2.createRun().setText("Hello");
+    }
+
+    public static void insertTable(XWPFParagraph xwpfParagraph, XWPFDocument document) {
+        XmlCursor xmlCursor = xwpfParagraph.getCTP().newCursor();
+        XWPFTable xwpfTable = document.insertNewTbl(xmlCursor);
+        xwpfTable.getRow(0).getCell(0).setText("Hello");
     }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/TestXWPFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/TestXWPFBugs.java
@@ -202,8 +202,8 @@ class TestXWPFBugs {
             XWPFTableCell cell = document.getTableArray(0).getRow(0).getCell(0);
             XWPFParagraph paragraph = cell.getParagraphArray(0);
             insertParagraph(paragraph, document);
-            //TODO the issue reporter thinks that there should be 2 paragraphs (with 'Hello' and 'World' repectively).
-            assertEquals("World", cell.getParagraphArray(0).getText());
+            assertEquals("Hello", cell.getParagraphArray(0).getText());
+            assertEquals("World", cell.getParagraphArray(1).getText());
         }
     }
 


### PR DESCRIPTION
Up until now, the `XWPFDocument#insertNew[Paragraph|Table](XmlCursor)` methods were only able to insert the elements if they were present in the `XWPFDocument`-internal lists representing the top-level objects not nested in other elements  (`XWPFDocument.paragraphs`/`XWPFDocument.tables`).

This commit updates the insertion code for both methods such that objects can also be inserted if the `XmlCursor` does not point
to an element in the top-level list but to a nested object (for example a paragraph in a table).
This is done by first figuring out the path to the cursor by repeated calls to `XmlCursor#toParent()`, and then traversing down
the `XWPFDocument` internal structure to find the parent object where the new paragraph or table should be inserted.

Tests verifying this behavior have been added.