### PR TITLE
Add MutiValued Types and repair how CLS ID GUID Type is Handled

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/PropertiesChunk.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/PropertiesChunk.java
@@ -254,7 +254,7 @@ public abstract class PropertiesChunk extends Chunk {
                 // to another chunk which holds the data itself
                 boolean isPointer = false;
                 int length = type.getLength();
-                if (!type.isPointer()) {
+                if (type.isPointer()) {
                     isPointer = true;
                     length = 8;
                 }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/PropertiesChunk.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/PropertiesChunk.java
@@ -254,7 +254,7 @@ public abstract class PropertiesChunk extends Chunk {
                 // to another chunk which holds the data itself
                 boolean isPointer = false;
                 int length = type.getLength();
-                if (!type.isFixedLength()) {
+                if (!type.isPointer()) {
                     isPointer = true;
                     length = 8;
                 }
@@ -379,7 +379,7 @@ public abstract class PropertiesChunk extends Chunk {
             LittleEndian.putUInt(value.getFlags(), out); // readable + writable
 
             MAPIType type = getTypeMapping(value.getActualType());
-            if (type.isFixedLength()) {
+            if (type.isFixedLength() && !type.isPointer()) {
                 // page 11, point 2.1.2
                 writeFixedLengthValueHeader(out, property, type, value);
             } else {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/Types.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/Types.java
@@ -81,6 +81,20 @@ public final class Types {
     /** A string, from Outlook 3.0 onwards. Normally unicode */
     public static final MAPIType UNICODE_STRING = new MAPIType(0x001F, "Unicode String", -1);
 
+    /** MultiValued Properties */
+    public static final MAPIType MV_SHORT = new MAPIType(0x1002, "MV Short", -1);
+    public static final MAPIType MV_LONG = new MAPIType(0x1003, "MV Long", -1);
+    public static final MAPIType MV_FLOAT = new MAPIType(0x1004, "MV Float", -1);
+    public static final MAPIType MV_DOUBLE = new MAPIType(0x1005, "MV Double", -1);
+    public static final MAPIType MV_CURRENCY = new MAPIType(0x1006, "MV Currency", -1);
+    public static final MAPIType MV_APP_TIME = new MAPIType(0x1007, "MV Application Time", -1);
+    public static final MAPIType MV_LONG_LONG = new MAPIType(0x1014, "MV Long Long", -1);
+    public static final MAPIType MV_TIME = new MAPIType(0x1040, "MV Time", -1);
+    public static final MAPIType MV_CLS_ID = new MAPIType(0x1048, "MV CLS ID GUID", -1);
+    public static final MAPIType MV_BINARY = new MAPIType(0x1102, "MV Binary", -1);
+    public static final MAPIType MV_ASCII_STRING = new MAPIType(0x101E, "MV ASCII String", -1);
+    public static final MAPIType MV_UNICODE_STRING = new MAPIType(0x101F, "MV Unicode String", -1);
+
     /** MultiValued - Value part contains multiple values */
     public static final int MULTIVALUED_FLAG = 0x1000;
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/Types.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/Types.java
@@ -138,6 +138,10 @@ public final class Types {
             return ((length != -1) && (length <= 8)) || (id == Types.CLS_ID.id);
         }
 
+        public boolean isPointer() {
+            return (length == -1) || (length > 8);
+        }
+
         public int getId() {
             return id;
         }


### PR DESCRIPTION
MutiValued Property Types inside `__properties_version1.0` caused the reading of the properties stream to stop and skip all the rest of the stream (missing out on alot of properties in some cases).
CLS ID GUID has a fixed length, however according to [](https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxmsg/08185828-e9e9-4ef2-bcd2-f6e69c00891b) it is not read in the `__properties_version1.0`  stream. It is (like variable length) properties in another file. So I added another method `isPointer` since no property longer than 8 bytes should be included inside the `__properties_version1.0`.

I included my test-message here. 
[Test1.zip](https://github.com/apache/poi/files/9932914/Test1.zip)

```java
MAPIMessage msg = new MAPIMessage("Test1.msg");
System.out.println("#found properties: " + msg.getMainChunks().getProperties().size());
```

The current 5.2.3 extracts 25 properties
With my patch all 151 properties included in  `__properties_version1.0`
