### PR TITLE
Add the ability to avoid adding cellStyle to improve writing performance

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/GZIPSheetDataWriter.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/GZIPSheetDataWriter.java
@@ -49,6 +49,14 @@ public class GZIPSheetDataWriter extends SheetDataWriter {
     }
 
     /**
+     * @param sharedStringsTable the shared strings table, or null if inline text is used
+     * @param ignoreCellStyle whether to use cell style
+     */
+    public GZIPSheetDataWriter(SharedStringsTable sharedStringsTable, boolean ignoreCellStyle) throws IOException {
+        super(sharedStringsTable, ignoreCellStyle);
+    }
+
+    /**
      * @return temp file to write sheet data
      * @deprecated no need for this be public, will be made private or protected in an upcoming release
      */


### PR DESCRIPTION
In [bug-51037] we apply the default column style if no style is set (https://svn.apache.org/viewvc?view=revision&revision=1902391)
We change :
```
    @Override
    public CellStyle getCellStyle()
    {
        if(_style == null){
            SXSSFWorkbook wb = (SXSSFWorkbook)getRow().getSheet().getWorkbook();
            return wb.getCellStyleAt(0);
        } else {
            return _style;
        }
    }
```
by : 
```
@Override
    public CellStyle getCellStyle()
    {
        if (_style == null) {
            CellStyle style = getDefaultCellStyleFromColumn();
            if (style == null) {
                SXSSFWorkbook wb = getSheet().getWorkbook();
                style = wb.getCellStyleAt(0);
            }
            return style;
        } else {
            return _style;
        }
    }
    private CellStyle getDefaultCellStyleFromColumn() {
        CellStyle style = null;
        SXSSFSheet sheet = getSheet();
        if (sheet != null) {
            style = sheet.getColumnStyle(getColumnIndex());
        }
        return style;
    }
```
When we try to write a lot of rows, we have this flamegraph : 
<img width="1317" alt="Capture d’écran 2022-12-12 à 16 49 05" src="https://user-images.githubusercontent.com/1484916/207091120-30c4b03e-b6b0-40ae-9347-aafc9d522684.png">

The method `SXXSFCell.getCellStyle` can take approximatively 20% of `SheetDataWriter.writeCell`.

I add the `ignoreCellStyle` because if I want to write a simple excel file without style, I can skip this call.