### PR TITLE
Increase performance of StylesTable.putStyle by 100%

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
@@ -467,10 +467,12 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
     public int putStyle(XSSFCellStyle style) {
         CTXf mainXF = style.getCoreXf();
 
-        if(! xfs.contains(mainXF)) {
+        int ret = xfs.indexOf(mainXF);
+        if(ret == -1) {
             xfs.add(mainXF);
+            ret = xfs.size() - 1;
         }
-        return xfs.indexOf(mainXF);
+        return ret;
     }
 
     @Override


### PR DESCRIPTION
When exporting a large spreadsheet, this method took 2.3 seconds of execution time.  See VisualVM screenshot:

<img width="586" alt="image" src="https://user-images.githubusercontent.com/847857/209012831-52c35859-aa14-4ef1-91b1-ef889409af68.png">

This change would ensure that only one linear lookup is made into the xfs collection instead of the current two lookups per invocation of this method.