### PR TITLE
Performance improvements when writing many cells with SXSSF

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
@@ -141,7 +141,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
         checkBounds(column);
         SXSSFCell cell = new SXSSFCell(this, type, column);
         _cells.put(column, cell);
-        _sheet.trackNewCell(cell);
+        _sheet.trackNewCell(column);
         return cell;
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFSheet.java
@@ -2154,9 +2154,9 @@ public class SXSSFSheet implements Sheet, OoxmlSheetExtensions {
         throw new UnsupportedOperationException("Not Implemented");
     }
 
-    void trackNewCell(SXSSFCell cell) {
-        leftMostColumn = Math.min(cell.getColumnIndex(), leftMostColumn);
-        rightMostColumn = Math.max(cell.getColumnIndex(), rightMostColumn);
+    void trackNewCell(int column) {
+        leftMostColumn = Math.min(column, leftMostColumn);
+        rightMostColumn = Math.max(column, rightMostColumn);
     }
 
     void deriveDimension() {


### PR DESCRIPTION
SXSSFCell.getColumnIndex() gets slow when writing thousands of columns because we linearly search through all the cells in a row. 
Since the column index is already known when creating a new cell we can just use it to track the left/right most column.