### PR TITLE
Round up seconds in CellElapsedFormatter

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/format/CellElapsedFormatter.java
+++ b/poi/src/main/java/org/apache/poi/ss/format/CellElapsedFormatter.java
@@ -59,7 +59,7 @@ public class CellElapsedFormatter extends CellFormatter {
                 val = elapsed / factor;
             else
                 val = elapsed / factor % modBy;
-            if (type == '0')
+            if (type == '0' || type == 's')
                 return Math.round(val);
             else
                 return (long) val;

--- a/poi/src/test/java/org/apache/poi/ss/format/TestCellFormat.java
+++ b/poi/src/test/java/org/apache/poi/ss/format/TestCellFormat.java
@@ -1046,4 +1046,11 @@ class TestCellFormat {
                 .map(CellFormatPart.NAMED_COLORS::get)
                 .forEach(Assertions::assertNotNull);
     }
+
+    @Test
+    void testElapsedSecondsRound() {
+        CellFormatPart part = new CellFormatPart("[h]\\h m\\m s\\s");
+        assertNotNull(part);
+        assertEquals("0h 0m 9s", part.apply(0.0001).text);
+    }
 }


### PR DESCRIPTION
Seconds should round up in the elapsed formatter. If you have a value like 0.0001 and format it with [h]\h m\m s\s, you get "0h 0m 8s" whereas Excel outputs "0h 0m 9s".