### PR TITLE
Bug: Auto sizing not working properly due to rounding error when calculating defaultCharWidth

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/AutoSizeColumnTracker.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/AutoSizeColumnTracker.java
@@ -47,7 +47,7 @@ import org.apache.poi.util.Internal;
 */
 @Internal
 /*package*/ class AutoSizeColumnTracker {
-    private final int defaultCharWidth;
+    private final double defaultCharWidth;
     private final DataFormatter dataFormatter = new DataFormatter();
 
     // map of tracked columns, with values containing the best-fit width for the column

--- a/poi/src/main/java/org/apache/poi/ss/util/SheetUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/SheetUtil.java
@@ -118,7 +118,7 @@ public class SheetUtil {
      * @param useMergedCells    whether to use merged cells
      * @return  the width in pixels or -1 if cell is empty
      */
-    public static double getCellWidth(Cell cell, int defaultCharWidth, DataFormatter formatter, boolean useMergedCells) {
+    public static double getCellWidth(Cell cell, double defaultCharWidth, DataFormatter formatter, boolean useMergedCells) {
         List<CellRangeAddress> mergedRegions = cell.getSheet().getMergedRegions();
         return getCellWidth(cell, defaultCharWidth, formatter, useMergedCells, mergedRegions);
     }
@@ -137,7 +137,7 @@ public class SheetUtil {
      * @param mergedRegions The list of merged regions as received via cell.getSheet().getMergedRegions()
      * @return  the width in pixels or -1 if cell is empty
      */
-    public static double getCellWidth(Cell cell, int defaultCharWidth, DataFormatter formatter, boolean useMergedCells,
+    public static double getCellWidth(Cell cell, double defaultCharWidth, DataFormatter formatter, boolean useMergedCells,
                                       List<CellRangeAddress> mergedRegions) {
         Sheet sheet = cell.getSheet();
         Workbook wb = sheet.getWorkbook();
@@ -219,7 +219,7 @@ public class SheetUtil {
      * @param str the text contained in the cell
      * @return the best fit cell width
      */
-    private static double getCellWidth(int defaultCharWidth, int colspan,
+    private static double getCellWidth(double defaultCharWidth, int colspan,
             CellStyle style, double minWidth, AttributedString str) {
         TextLayout layout = new TextLayout(str.getIterator(), fontRenderContext);
         final Rectangle2D bounds;
@@ -270,7 +270,7 @@ public class SheetUtil {
      */
     public static double getColumnWidth(Sheet sheet, int column, boolean useMergedCells, int firstRow, int lastRow){
         DataFormatter formatter = new DataFormatter();
-        int defaultCharWidth = getDefaultCharWidth(sheet.getWorkbook());
+        double defaultCharWidth = getDefaultCharWidth(sheet.getWorkbook());
 
         List<CellRangeAddress> mergedRegions = sheet.getMergedRegions();
         double width = -1;
@@ -292,14 +292,14 @@ public class SheetUtil {
      * @return default character width in pixels
      */
     @Internal
-    public static int getDefaultCharWidth(final Workbook wb) {
+    public static double getDefaultCharWidth(final Workbook wb) {
         Font defaultFont = wb.getFontAt( 0);
 
         AttributedString str = new AttributedString(String.valueOf(defaultChar));
         copyAttributes(defaultFont, str, 0, 1);
         try {
             TextLayout layout = new TextLayout(str.getIterator(), fontRenderContext);
-            return Math.round(layout.getAdvance());
+            return layout.getAdvance();
         } catch (UnsatisfiedLinkError | NoClassDefFoundError | InternalError e) {
             if (ignoreMissingFontSystem) {
                 return DEFAULT_CHAR_WIDTH;
@@ -321,7 +321,7 @@ public class SheetUtil {
      * @return  the width in pixels or -1 if cell is empty
      */
     private static double getColumnWidthForRow(
-            Row row, int column, int defaultCharWidth, DataFormatter formatter, boolean useMergedCells,
+            Row row, int column, double defaultCharWidth, DataFormatter formatter, boolean useMergedCells,
             List<CellRangeAddress> mergedRegions) {
         if( row == null ) {
             return -1;


### PR DESCRIPTION
The XSSFSheet#autoSizeColumn method doesn't work properly for some specific cell values and font metrics.

The following code snippet is an example for this behavior:
```java
String sheetName = "Sheet 1";
String cellText = "Auto sizing incorrect! :(";

try (XSSFWorkbook workbook = new XSSFWorkbook()) {

    final XSSFSheet sheet = workbook.createSheet(sheetName);

    final XSSFCell cell = sheet.createRow(0).createCell(0);

    cell.setCellValue(cellText);

    final XSSFFont font = workbook.createFont();
    font.setFontName("Arial");
    font.setFontHeight(15);
    font.setBold(true);

    final XSSFCellStyle style = workbook.createCellStyle();
    style.setFont(font);
    cell.setCellStyle(style);

    sheet.autoSizeColumn(0, false);

    try (FileOutputStream fOS = new FileOutputStream("./test-excel.xlsx")) {
        workbook.write(fOS);
    }
}
```

Generated excel file:
![image](https://github.com/apache/poi/assets/149682193/bcc52217-4da9-44e1-b095-56d560636793)

The bug is caused by a rounding error in SheetUtil#getDefaultCharWidth:
https://github.com/apache/poi/blob/5533d35cefd15e98fd988a458ac41c5e8aad06f7/poi/src/main/java/org/apache/poi/ss/util/SheetUtil.java#L301-L302

Rounding is not necessary at all, removing the operation and converting the return type of getDefaultCharWidth() to double solves the issue.

The column width calculation that causes the error (and uses a value returned by SheetUtil#getDefaultCharWidth) occurs in SheetUtil#getCellWidth:
https://github.com/apache/poi/blob/5533d35cefd15e98fd988a458ac41c5e8aad06f7/poi/src/main/java/org/apache/poi/ss/util/SheetUtil.java#L244