### PR TITLE
Make exported sheet names compatible with Excel

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/formula/SheetNameFormatter.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/SheetNameFormatter.java
@@ -164,6 +164,9 @@ public final class SheetNameFormatter {
         if (nameLooksLikeBooleanLiteral(rawSheetName)) {
             return true;
         }
+        if (nameStartsWithR1C1CellReference(rawSheetName)) {
+            return true;
+        }
         // Error constant literals all contain '#' and other special characters
         // so they don't get this far
         return false;
@@ -263,5 +266,38 @@ public final class SheetNameFormatter {
         String lettersPrefix = matcher.group(1);
         String numbersSuffix = matcher.group(2);
         return cellReferenceIsWithinRange(lettersPrefix, numbersSuffix);
+    }
+
+    /**
+     * Checks if the sheet name starts with R1C1 style cell reference.
+     * If this is the case Excel requires the sheet name to be enclosed in single quotes.
+     * @return {@code true} if the specified rawSheetName starts with R1C1 style cell reference
+     */
+    static boolean nameStartsWithR1C1CellReference(String rawSheetName) {
+        int len = rawSheetName.length();
+        char ch = rawSheetName.charAt(0);
+        if (ch == 'R' || ch == 'r') {
+            if (len > 1) {
+                ch = rawSheetName.charAt(1);
+                if (ch == 'C' || ch == 'c') {
+                    if (len > 2) {
+                        ch = rawSheetName.charAt(2);
+                        return Character.isDigit(ch);
+                    } else {
+                        return true;
+                    }
+                }
+            } else {
+                return true;
+            }
+        } else if (ch == 'C' || ch == 'c') {
+            if (len > 1) {
+                ch = rawSheetName.charAt(1);
+                return Character.isDigit(ch);
+            } else {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/poi/src/main/java/org/apache/poi/ss/formula/SheetNameFormatter.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/SheetNameFormatter.java
@@ -275,25 +275,27 @@ public final class SheetNameFormatter {
      */
     static boolean nameStartsWithR1C1CellReference(String rawSheetName) {
         int len = rawSheetName.length();
-        char ch = rawSheetName.charAt(0);
-        if (ch == 'R' || ch == 'r') {
+        char firstChar = rawSheetName.charAt(0);
+        if (firstChar == 'R' || firstChar == 'r') {
             if (len > 1) {
-                ch = rawSheetName.charAt(1);
-                if (ch == 'C' || ch == 'c') {
+                char secondChar = rawSheetName.charAt(1);
+                if (secondChar == 'C' || secondChar == 'c') {
                     if (len > 2) {
-                        ch = rawSheetName.charAt(2);
-                        return Character.isDigit(ch);
+                        char thirdChar = rawSheetName.charAt(2);
+                        return Character.isDigit(thirdChar);
                     } else {
                         return true;
                     }
+                } else {
+                    return Character.isDigit(secondChar);
                 }
             } else {
                 return true;
             }
-        } else if (ch == 'C' || ch == 'c') {
+        } else if (firstChar == 'C' || firstChar == 'c') {
             if (len > 1) {
-                ch = rawSheetName.charAt(1);
-                return Character.isDigit(ch);
+                char secondChar = rawSheetName.charAt(1);
+                return Character.isDigit(secondChar);
             } else {
                 return true;
             }

--- a/poi/src/test/java/org/apache/poi/ss/formula/TestSheetNameFormatter.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/TestSheetNameFormatter.java
@@ -54,6 +54,7 @@ final class TestSheetNameFormatter {
         confirmFormat("C", "'C'"); // R1C1 style ref
         confirmFormat("rCsheet", "rCsheet"); // 'rc' + character is not qualified as R1C1 style ref
         confirmFormat("ra", "ra"); // 'r' + character is not qualified as R1C1 style ref
+        confirmFormat("r1a", "'r1a'"); // 'r1' is R1C1 style ref
         confirmFormat("Rc1sheet", "'Rc1sheet'"); // 'rc1' is R1C1 style ref
 
         confirmFormat(null, "#REF");

--- a/poi/src/test/java/org/apache/poi/ss/formula/TestSheetNameFormatter.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/TestSheetNameFormatter.java
@@ -48,6 +48,14 @@ final class TestSheetNameFormatter {
         confirmFormat("A12220", "'A12220'");
         confirmFormat("TAXRETURN19980415", "TAXRETURN19980415");
 
+        confirmFormat("RC9Sheet", "'RC9Sheet'"); // starts with R1C1 style ref ('RC9')
+        confirmFormat("r", "'r'"); // R1C1 style ref
+        confirmFormat("rc", "'rc'"); // R1C1 style ref
+        confirmFormat("C", "'C'"); // R1C1 style ref
+        confirmFormat("rCsheet", "rCsheet"); // 'rc' + character is not qualified as R1C1 style ref
+        confirmFormat("ra", "ra"); // 'r' + character is not qualified as R1C1 style ref
+        confirmFormat("Rc1sheet", "'Rc1sheet'"); // 'rc1' is R1C1 style ref
+
         confirmFormat(null, "#REF");
     }
 


### PR DESCRIPTION
Sheets starting with R1C1 cell style reference are enclosed in single quotes.

If this is not the case Microsoft Excel treats formulas with references to such sheets as erroneous. 
It proposes to "repair" corrupted workbook and as a result clears affected cells as seen in the image below:
![image](https://github.com/apache/poi/assets/43913143/7141f9fe-31d0-43e6-ae40-32c55acc1e1d)

E.g. sheet name `RC123Test`. It should be enclosed in single quotes. Whereas `RA` can be left as is, as 'R' following alpha character is not a valid R1C1 cell style reference.

This behavior is also described here:
https://stackoverflow.com/questions/41677779/when-does-excel-surround-sheet-names-with-single-quotes-in-workbook-xml-or-othe/53483274#53483274