### PR TITLE
Fix Bug 68200 

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Rate.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Rate.java
@@ -74,11 +74,14 @@ public class Rate implements Function {
     }
 
     private static double _g_div_gp(double r, double n, double p, double x, double y, double w) {
-        double t1 = Math.pow(r+1, n);
-        double t2 = Math.pow(r+1, n-1);
-        return (y + t1*x + p*(t1 - 1)*(r*w + 1)/r) /
-                (n*t2*x - p*(t1 - 1)*(r*w + 1)/(Math.pow(r, 2) + n*p*t2*(r*w + 1)/r +
-                        p*(t1 - 1)*w/r));
+        double t1 = Math.pow(r + 1.0, n);
+        double t2 = Math.pow(r + 1.0, n - 1.0);
+        double g = y + t1 * x + p * (t1 - 1.0) * (r * w + 1.0) / r;
+        double gp = (n * t2 * x
+                - p * (t1 - 1.0) * (r * w + 1.0) / (Math.pow(r, 2.0))
+                + n * p * t2 * (r * w + 1.0) / r
+                + p * (t1 - 1.0) * w / r);
+        return g / gp;
     }
 
     /**

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestRate.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestRate.java
@@ -171,7 +171,7 @@ final class TestRate {
     }
 
     @Test
-    void testBugxxxxx() throws Exception {
+    void testBug68200() throws Exception {
         try (HSSFWorkbook wb = new HSSFWorkbook()) {
             HSSFSheet sheet = wb.createSheet();
             HSSFRow row = sheet.createRow(0);

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestRate.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestRate.java
@@ -169,4 +169,16 @@ final class TestRate {
             assertDouble(fe, cell, "RATE(360.0,6.56,-2000.0)", 0.0009480170844060, 0.000001);
         }
     }
+
+    @Test
+    void testBugxxxxx() throws Exception {
+        try (HSSFWorkbook wb = new HSSFWorkbook()) {
+            HSSFSheet sheet = wb.createSheet();
+            HSSFRow row = sheet.createRow(0);
+            HSSFFormulaEvaluator fe = new HSSFFormulaEvaluator(wb);
+            HSSFCell cell = row.createCell(0);
+            assertDouble(fe, cell, "RATE(22,30000,20000,-82257625,0,0.1)", 0.35397960290713076, 0.000001);
+            assertDouble(fe, cell, "RATE(22,10000,10000,-313562750,0,0.1)", 0.5252278265995758, 0.000001);
+        }
+    }
 }


### PR DESCRIPTION
Hi Team,

Here some cases, `calculateRate` will return `Double.NaN` -> [#NUM!],
(https://github.com/apache/poi/blob/trunk/poi/src/main/java/org/apache/poi/ss/formula/functions/Rate.java#L99)

But it can get the right result in Numbers

case1:

RATE(22,30000,20000,-82257625,0,0.1)

Result: Double.NaN

whereas in Numbers I get: 0.35397960290713076

--

case2:

RATE(22,10000,10000,-313562750,0,0.1)

Result: Double.NaN

whereas in Numbers I get: 0.35397960290713076

Following the implementation of numpy-financial, I try to fix the bug.

https://github.com/numpy/numpy-financial/blob/d02edfb65dcdf23bd571c2cded7fcd4a0528c6af/numpy_financial/_financial.py#L582