### PR TITLE
Handle missing font system error on Java 21

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/util/SheetUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/SheetUtil.java
@@ -351,7 +351,7 @@ public class SheetUtil {
         try {
             TextLayout layout = new TextLayout(str.getIterator(), fontRenderContext);
             return layout.getAdvance();
-        } catch (UnsatisfiedLinkError | NoClassDefFoundError | InternalError e) {
+        } catch (UnsatisfiedLinkError | NoClassDefFoundError | InternalError | RuntimeException e) {
             if (ignoreMissingFontSystem) {
                 return DEFAULT_CHAR_WIDTH;
             }


### PR DESCRIPTION
In Java 21 the RuntimeException from `sun.awt.FontConfiguration` is not wrapped in an `InternalError` anymore and appears directly as a `RuntimeException` when constructing a `TextLayout`.

So, when `ignoreMissingFontSystem` is set also allow a `RuntimeException` to indicate a missing font system.

A demonstration of the difference (without POI and assuming JDK >=17 and Docker are available):

1. Create `Test.java` with content:
    ```java
    public class Test {
        public static void main(String args[]) {
            var frc = new java.awt.font.FontRenderContext(null, true, true);
            var str = new java.text.AttributedString(String.valueOf('W'));
            var layout = new java.awt.font.TextLayout(str.getIterator(), frc);

            System.out.println(layout.getAdvance());
        }
    }
    ```
3. Compile
2. Run on Java 17:
    ```shell
   docker run -it --rm -v $(pwd)/Test.class:/Test.class amazoncorretto:17-alpine java Test
    ```
3. Run on Java 21:
    ```shell
    docker run -it --rm -v $(pwd)/Test.class:/Test.class amazoncorretto:21-alpine java Test
    ```

On Java 17, you’ll see:

```
Exception in thread "main" java.lang.InternalError: java.lang.reflect.InvocationTargetException
…
Caused by: java.lang.RuntimeException: Fontconfig head is null, check your fonts or fonts configuration
```

On Java 21, the result is:

```
Exception in thread "main" java.lang.RuntimeException: Fontconfig head is null, check your fonts or fonts configuration
…
```