### PR TITLE
Increase performance of CodepointsUtil.java by 5x

### DIFF
--- a/poi/src/main/java/org/apache/poi/util/CodepointsUtil.java
+++ b/poi/src/main/java/org/apache/poi/util/CodepointsUtil.java
@@ -28,7 +28,7 @@ public class CodepointsUtil {
      * @return iterator with Strings representing the codepoints
      */
   public static Iterator<String> iteratorFor(String text) {
-    PrimitiveIterator.OfInt iter = text.codePoints().iterator();
+    PrimitiveIterator.OfInt iter = primitiveIterator(text);
     return new Iterator<String>() {
       @Override
       public boolean hasNext() {

--- a/poi/src/main/java/org/apache/poi/util/CodepointsUtil.java
+++ b/poi/src/main/java/org/apache/poi/util/CodepointsUtil.java
@@ -26,13 +26,21 @@ public class CodepointsUtil {
     /**
      * @param text to iterate over
      * @return iterator with Strings representing the codepoints
-     * @see #primitiveIterator(String) a more performant iterator
      */
-    public static Iterator<String> iteratorFor(String text) {
-        return text.codePoints()
-                .mapToObj(codePoint -> new String(Character.toChars(codePoint)))
-                .iterator();
-    }
+  public static Iterator<String> iteratorFor(String text) {
+    PrimitiveIterator.OfInt iter = text.codePoints().iterator();
+    return new Iterator<String>() {
+      @Override
+      public boolean hasNext() {
+        return iter.hasNext();
+      }
+
+      @Override
+      public String next() {
+        return Character.toString(iter.next());
+      }
+    };
+  }
 
     /**
      * @param text to iterate over


### PR DESCRIPTION
This code path gets invoked millions of times for my pretty basic excel file b/c it is called for every single cell.

I guess java's native streams are pretty slow, because this sped things up by a LOT