### PR TITLE
Remove unnecessary LOGGER in POIFSDocumentPath.java

### DIFF
--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSDocumentPath.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSDocumentPath.java
@@ -25,17 +25,11 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 /**
  * Class POIFSDocumentPath
  */
 
 public class POIFSDocumentPath {
-
-    private static final Logger LOGGER = LogManager.getLogger(POIFSDocumentPath.class);
-
     private final String[] components;
     private int hashcode; //lazy-compute hashCode
 


### PR DESCRIPTION
Hi as per title,

LOGGER is not used in POIFSDocumentPath.java