### PR TITLE
Optimize AffineTransform.createTransformedShape call at DrawShape.java

### DIFF
--- a/poi/src/main/java/org/apache/poi/sl/draw/DrawShape.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/DrawShape.java
@@ -192,8 +192,8 @@ public class DrawShape implements Drawable {
         }
 
 
-        final java.awt.Shape anc = tx.createTransformedShape(normalizedShape);
-        return (anc != null) ? anc.getBounds2D() : normalizedShape;
+        return (normalizedShape != null) ? tx.createTransformedShape(normalizedShape).getBounds2D()
+                : null;
     }
 
     public static Rectangle2D getAnchor(Graphics2D graphics, Rectangle2D anchor) {
@@ -202,7 +202,7 @@ public class DrawShape implements Drawable {
         }
 
         AffineTransform tx = (AffineTransform)graphics.getRenderingHint(Drawable.GROUP_TRANSFORM);
-        if(tx != null && !tx.isIdentity() && tx.createTransformedShape(anchor) != null) {
+        if(tx != null && !tx.isIdentity() && anchor != null) {
             anchor = tx.createTransformedShape(anchor).getBounds2D();
         }
         return anchor;


### PR DESCRIPTION
If we look at [javadoc ](https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/java/awt/geom/AffineTransform.html#createTransformedShape(java.awt.Shape))

`AffineTransform.createTransformedShape(pSrc)` return `a new Shape object that defines the geometry of the transformed Shape, or null if pSrc is null.`

So this PR restructure the `AffineTransform.createTransformedShape` so that it checks the source whether it is null first instead of calling the method and check the return Shape value.

