### PR TITLE
Support SVGs in XWPF

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/Document.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/Document.java
@@ -74,4 +74,9 @@ public interface Document {
      * WordPerfect graphics (.wpg)
      */
     public static final int PICTURE_TYPE_WPG = PictureType.WPG.ooxmlId;
+
+    /**
+     * SVG graphics (.svg)
+     */
+    public static final int PICTURE_TYPE_SVG = PictureType.SVG.ooxmlId;
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFPictureData.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFPictureData.java
@@ -58,7 +58,7 @@ public class XWPFPictureData extends POIXMLDocumentPart {
     protected static final POIXMLRelation[] RELATIONS;
 
     static {
-        RELATIONS = new POIXMLRelation[14];
+        RELATIONS = new POIXMLRelation[15];
         RELATIONS[PictureType.EMF.ooxmlId] = XWPFRelation.IMAGE_EMF;
         RELATIONS[PictureType.WMF.ooxmlId] = XWPFRelation.IMAGE_WMF;
         RELATIONS[PictureType.PICT.ooxmlId] = XWPFRelation.IMAGE_PICT;
@@ -71,6 +71,7 @@ public class XWPFPictureData extends POIXMLDocumentPart {
         RELATIONS[PictureType.BMP.ooxmlId] = XWPFRelation.IMAGE_BMP;
         RELATIONS[PictureType.WPG.ooxmlId] = XWPFRelation.IMAGE_WPG;
         RELATIONS[PictureType.WDP.ooxmlId] = XWPFRelation.HDPHOTO_WDP;
+        RELATIONS[PictureType.SVG.ooxmlId] = XWPFRelation.IMAGE_SVG;
     }
 
     private Long checksum;
@@ -149,6 +150,7 @@ public class XWPFPictureData extends POIXMLDocumentPart {
      * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_PNG
      * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_GIF
      * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_DIB
+     * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_SVG
      * @see #getPictureTypeEnum()
      */
     public int getPictureType() {

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRelation.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRelation.java
@@ -234,6 +234,12 @@ public final class XWPFRelation extends POIXMLRelation {
             "/ppt/media/hdphoto#.wdp",
             XWPFPictureData::new, XWPFPictureData::new
     );
+    public static final XWPFRelation IMAGE_SVG = new XWPFRelation(
+        PictureType.SVG.contentType,
+        IMAGE_PART,
+        "/word/media/image#.svg",
+        XWPFPictureData::new, XWPFPictureData::new
+);
     public static final XWPFRelation IMAGES = new XWPFRelation(
             null,
             IMAGE_PART,

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -1207,6 +1207,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
      * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_PNG
      * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_GIF
      * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_DIB
+     * @see org.apache.poi.xwpf.usermodel.Document#PICTURE_TYPE_SVG
      * @see #addPicture(InputStream, PictureType, String, int, int)
      */
     public XWPFPicture addPicture(InputStream pictureData, int pictureType, String filename, int width, int height)

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFDocument.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFDocument.java
@@ -191,11 +191,12 @@ public final class TestXWPFDocument {
             doc.addPictureData(new byte[18], Document.PICTURE_TYPE_EPS);
             doc.addPictureData(new byte[19], Document.PICTURE_TYPE_BMP);
             doc.addPictureData(new byte[20], Document.PICTURE_TYPE_WPG);
+            doc.addPictureData(new byte[21], Document.PICTURE_TYPE_SVG);
 
-            assertEquals(11, doc.getAllPictures().size());
+            assertEquals(12, doc.getAllPictures().size());
 
             try (XWPFDocument doc2 = XWPFTestDataSamples.writeOutAndReadBack(doc)) {
-                assertEquals(11, doc2.getAllPictures().size());
+                assertEquals(12, doc2.getAllPictures().size());
             }
         }
     }

--- a/poi/src/main/java/org/apache/poi/common/usermodel/PictureType.java
+++ b/poi/src/main/java/org/apache/poi/common/usermodel/PictureType.java
@@ -53,7 +53,7 @@ public enum PictureType {
     /** Microsoft Windows Media Photo image (.wdp) */
     WDP("image/vnd.ms-photo", ".wdp", 13),
     /** Scalable vector graphics (.svg) - supported by Office 2016 and higher */
-    SVG("image/svg+xml", ".svg", -1),
+    SVG("image/svg+xml", ".svg", 14),
     /** Unknown picture type - specific to escher bse record */
     UNKNOWN("", ".dat", -1),
     /** Picture type error - specific to escher bse record */


### PR DESCRIPTION
# Context
It is currently not possible to add SVGs to XWPF documents ... but it is possible in other formats such as XSLF ([here](https://github.com/Etienne-Gautier/poi/blob/25f00ba7c2db9bd897cffa67d12b1cfa31583516/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFRelation.java#L240)).

This PR adds this feature + a basic test.