### PR TITLE
XWPF: fix _getText in XWPFRun(ignore w:delInstrText, convert w:noBreakHyphen to "‑")

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -1521,10 +1521,10 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
 
         if (o instanceof CTText) {
             final Node node = o.getDomNode();
-            // Field Codes (w:instrText, defined in spec sec. 17.16.23)
+            // Field Codes (w:instrText, defined in spec sec. 17.16.23 and w:delInstrText, defined in spec sec. 17.16.13)
             //  come up as instances of CTText, but we don't want them
             //  in the normal text output
-            if (!("instrText".equals(node.getLocalName()) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI()))) {
+            if (!("instrText".equals(node.getLocalName()) && !("delInstrText".equals(node.getLocalName()) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI()))) {
                 String textValue = ((CTText) o).getStringValue();
                 if (textValue != null) {
                     if (isCapitalized() || isSmallCaps()) {
@@ -1564,6 +1564,9 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
             final Node node = o.getDomNode();
             if (XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI())) {
                 switch (node.getLocalName()) {
+                    case "noBreakHyphen":
+                        text.append('‑');
+                        break;
                     case "tab":
                         text.append('\t');
                         break;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -1524,7 +1524,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
             // Field Codes (w:instrText, defined in spec sec. 17.16.23 and w:delInstrText, defined in spec sec. 17.16.13)
             //  come up as instances of CTText, but we don't want them
             //  in the normal text output
-            if (!("instrText".equals(node.getLocalName()) && !("delInstrText".equals(node.getLocalName()) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI()))) {
+            if (!("instrText".equals(node.getLocalName())) && !("delInstrText".equals(node.getLocalName())) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI())) {
                 String textValue = ((CTText) o).getStringValue();
                 if (textValue != null) {
                     if (isCapitalized() || isSmallCaps()) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -1524,7 +1524,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
             // Field Codes (w:instrText, defined in spec sec. 17.16.23 and w:delInstrText, defined in spec sec. 17.16.13)
             //  come up as instances of CTText, but we don't want them
             //  in the normal text output
-            if (!("instrText".equals(node.getLocalName())) && !("delInstrText".equals(node.getLocalName())) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI())) {
+            if (!(("instrText".equals(node.getLocalName()) || "delInstrText".equals(node.getLocalName())) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI()))) {
                 String textValue = ((CTText) o).getStringValue();
                 if (textValue != null) {
                     if (isCapitalized() || isSmallCaps()) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -99,6 +99,17 @@ class TestXWPFRun {
         //fail("Position wrong");
     }
 
+    @Test
+    void testText() {
+        ctRun.addNewT().setStringValue("TEST STRING 1");
+        ctRun.addNewInstrText().setStringValue("InstrText");
+        ctRun.addNewNoBreakHyphen();
+        ctRun.addNewDelInstrText().setStringValue("DelInstrText");
+        ctRun.addNewT().setStringValue("1");
+        XWPFRun run = new XWPFRun(ctRun, irb);
+        assertEquals("TEST STRING 1‑1", run.text());
+    }
+
     /*
      * bug 59208
      * Purpose: test all valid boolean-like values


### PR DESCRIPTION
1. w:delInstrText also need to be ignored
2. w:noBreakHyphen needs to be converted to "‑"
@pjfanning Please help review the code