### PR TITLE
CellUtil constants to enum - CellPropertyType

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFCell.java
@@ -572,7 +572,7 @@ public class SXSSFCell extends CellBase {
      * the Workbook.</p>
      *
      * <p>To change the style of a cell without affecting other cells that use the same style,
-     * use {@link org.apache.poi.ss.util.CellUtil#setCellStyleProperties(Cell, Map)}</p>
+     * use {@link org.apache.poi.ss.util.CellUtil#setCellStylePropertiesEnum(Cell, Map)}</p>
      *
      * @param style  reference contained in the workbook.
      * If the value is null then the style information is removed causing the cell to used the default workbook style.

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFCell.java
@@ -606,7 +606,7 @@ public final class XSSFCell extends CellBase {
      * the XSSFWorkbook.</p>
      *
      * <p>To change the style of a cell without affecting other cells that use the same style,
-     * use {@link org.apache.poi.ss.util.CellUtil#setCellStyleProperties(Cell, java.util.Map)}</p>
+     * use {@link org.apache.poi.ss.util.CellUtil#setCellStylePropertiesEnum(Cell, java.util.Map)}</p>
      *
      * @param style  reference contained in the workbook.
      * If the value is null then the style information is removed causing the cell to use the default workbook style.

--- a/poi-ooxml/src/test/java/org/apache/poi/ss/tests/util/TestXSSFCellUtil.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ss/tests/util/TestXSSFCellUtil.java
@@ -19,12 +19,7 @@ package org.apache.poi.ss.tests.util;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.FillPatternType;
-import org.apache.poi.ss.usermodel.IndexedColors;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.BaseTestCellUtil;
 import org.apache.poi.ss.util.CellUtil;
 import org.apache.poi.xssf.XSSFITestDataProvider;
@@ -32,9 +27,7 @@ import org.apache.poi.xssf.usermodel.XSSFColor;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -57,7 +50,7 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertNull(cell.getCellStyle().getFillForegroundColorColor());
 
             CellUtil.setCellStyleProperty(
-                    cell, CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+                    cell, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
 
             assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
         }
@@ -76,12 +69,12 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertNull(cell.getCellStyle().getFillForegroundColorColor());
 
             CellUtil.setCellStyleProperty(
-                    cell, CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+                    cell, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
 
             assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
 
             CellUtil.setCellStyleProperty(
-                    cell, CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
+                    cell, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
 
             assertNotEquals(color, cell.getCellStyle().getFillForegroundColorColor());
             assertNull(cell.getCellStyle().getFillForegroundColorColor());
@@ -100,10 +93,10 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             final XSSFColor color = new XSSFColor(Hex.decodeHex("FF0000"));
 
             {
-                final Map<String, Object> properties = new LinkedHashMap<>();
+                final Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
-                properties.put(CellUtil.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }
@@ -111,10 +104,10 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertEquals(FillPatternType.SOLID_FOREGROUND, cell.getCellStyle().getFillPattern());
 
             {
-                final Map<String, Object> properties = new LinkedHashMap<>();
+                final Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
-                properties.put(CellUtil.FILL_PATTERN, FillPatternType.NO_FILL);
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }
@@ -138,11 +131,11 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertNull(cell.getCellStyle().getFillBackgroundColorColor());
 
             {
-                Map<String, Object> properties = new LinkedHashMap<>();
+                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
-                properties.put(CellUtil.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
-                properties.put(CellUtil.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }
@@ -151,11 +144,11 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertNull(cell.getCellStyle().getFillBackgroundColorColor());
 
             {
-                Map<String, Object> properties = new LinkedHashMap<>();
+                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
-                properties.put(CellUtil.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
-                properties.put(CellUtil.FILL_PATTERN, FillPatternType.NO_FILL);
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }
@@ -179,10 +172,10 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertNull(cell.getCellStyle().getFillBackgroundColorColor());
 
             {
-                Map<String, Object> properties = new LinkedHashMap<>();
+                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
-                properties.put(CellUtil.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }
@@ -192,10 +185,10 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
                     ((XSSFColor) cell.getCellStyle().getFillBackgroundColorColor()).getIndex());
 
             {
-                Map<String, Object> properties = new LinkedHashMap<>();
+                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
-                properties.put(CellUtil.FILL_PATTERN, FillPatternType.NO_FILL);
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }

--- a/poi-ooxml/src/test/java/org/apache/poi/ss/tests/util/TestXSSFCellUtil.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ss/tests/util/TestXSSFCellUtil.java
@@ -39,7 +39,7 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    public void testSetForegroundColorCellStyleProperty() throws IOException, DecoderException {
+    public void testSetForegroundColorCellStylePropertyByEnum() throws IOException, DecoderException {
         try (Workbook workbook = new XSSFWorkbook()) {
 
             final Sheet sheet = workbook.createSheet("Sheet");
@@ -57,8 +57,26 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    public void testSetForegroundColorCellStylePropertyToNull() throws IOException, DecoderException {
+    @Deprecated
+    public void testSetForegroundColorCellStyleProperty() throws IOException, DecoderException {
+        try (Workbook workbook = new XSSFWorkbook()) {
 
+            final Sheet sheet = workbook.createSheet("Sheet");
+            final Row row = sheet.createRow(0);
+            final Cell cell = row.createCell(0);
+            final XSSFColor color = new XSSFColor(Hex.decodeHex("AAAAAA"));
+
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+
+            CellUtil.setCellStyleProperty(
+                    cell, CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+
+            assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
+        }
+    }
+
+    @Test
+    public void testSetForegroundColorCellStylePropertyToNullByEnum() throws IOException, DecoderException {
         try (Workbook workbook = new XSSFWorkbook()) {
 
             final Sheet sheet = workbook.createSheet("Sheet");
@@ -83,7 +101,33 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    public void testSetForegroundColorCellStylePropertiesToNull() throws IOException, DecoderException {
+    @Deprecated
+    public void testSetForegroundColorCellStylePropertyToNull() throws IOException, DecoderException {
+        try (Workbook workbook = new XSSFWorkbook()) {
+
+            final Sheet sheet = workbook.createSheet("Sheet");
+            final Row row = sheet.createRow(0);
+            final Cell cell = row.createCell(0);
+            final XSSFColor color = new XSSFColor(Hex.decodeHex("AAAAAA"));
+
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+
+            CellUtil.setCellStyleProperty(
+                    cell, CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+
+            assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
+
+            CellUtil.setCellStyleProperty(
+                    cell, CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
+
+            assertNotEquals(color, cell.getCellStyle().getFillForegroundColorColor());
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertEquals(IndexedColors.AUTOMATIC.getIndex(), cell.getCellStyle().getFillForegroundColor());
+        }
+    }
+
+    @Test
+    public void testSetForegroundColorCellStylePropertiesToNullByEnum() throws IOException, DecoderException {
 
         try (Workbook workbook = new XSSFWorkbook()) {
 
@@ -98,7 +142,7 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
                 properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
                 properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
 
-                CellUtil.setCellStyleProperties(cell, properties);
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
             }
             assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
             assertEquals(FillPatternType.SOLID_FOREGROUND, cell.getCellStyle().getFillPattern());
@@ -109,7 +153,7 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
                 properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
                 properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
 
-                CellUtil.setCellStyleProperties(cell, properties);
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
             }
             assertNull(cell.getCellStyle().getFillForegroundColorColor());
             assertEquals(IndexedColors.AUTOMATIC.getIndex(), cell.getCellStyle().getFillForegroundColor());
@@ -118,8 +162,44 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    public void testBug66052WithWorkaround() throws IOException, DecoderException {
+    @Deprecated
+    public void testSetForegroundColorCellStylePropertiesToNull() throws IOException, DecoderException {
 
+        try (Workbook workbook = new XSSFWorkbook()) {
+
+            final Sheet sheet = workbook.createSheet("Sheet");
+            final Row row = sheet.createRow(0);
+            final Cell cell = row.createCell(0);
+            final XSSFColor color = new XSSFColor(Hex.decodeHex("FF0000"));
+
+            {
+                final Map<String, Object> properties = new LinkedHashMap<>();
+
+                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellUtil.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+
+                CellUtil.setCellStyleProperties(cell, properties);
+            }
+            assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
+            assertEquals(FillPatternType.SOLID_FOREGROUND, cell.getCellStyle().getFillPattern());
+
+            {
+                final Map<String, Object> properties = new LinkedHashMap<>();
+
+                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellUtil.FILL_PATTERN, FillPatternType.NO_FILL);
+
+                CellUtil.setCellStyleProperties(cell, properties);
+            }
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertEquals(IndexedColors.AUTOMATIC.getIndex(), cell.getCellStyle().getFillForegroundColor());
+            assertEquals(FillPatternType.NO_FILL, cell.getCellStyle().getFillPattern());
+        }
+    }
+
+
+    @Test
+    public void testBug66052WithWorkaroundByEnum() throws IOException, DecoderException {
         try (Workbook workbook = new XSSFWorkbook()) {
 
             final Sheet sheet = workbook.createSheet("Sheet");
@@ -137,7 +217,7 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
                 properties.put(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
                 properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
 
-                CellUtil.setCellStyleProperties(cell, properties);
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
             }
 
             assertNotNull(cell.getCellStyle().getFillForegroundColorColor());
@@ -150,6 +230,47 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
                 properties.put(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
                 properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
 
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
+            }
+
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertNull(cell.getCellStyle().getFillBackgroundColorColor());
+        }
+    }
+
+    @Test
+    @Deprecated
+    public void testBug66052WithWorkaround() throws IOException, DecoderException {
+        try (Workbook workbook = new XSSFWorkbook()) {
+
+            final Sheet sheet = workbook.createSheet("Sheet");
+            final Row row = sheet.createRow(0);
+            final Cell cell = row.createCell(0);
+            final XSSFColor color = new XSSFColor(Hex.decodeHex("FFAAAA"));
+
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertNull(cell.getCellStyle().getFillBackgroundColorColor());
+
+            {
+                Map<String, Object> properties = new LinkedHashMap<>();
+
+                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellUtil.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
+                properties.put(CellUtil.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+
+                CellUtil.setCellStyleProperties(cell, properties);
+            }
+
+            assertNotNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertNull(cell.getCellStyle().getFillBackgroundColorColor());
+
+            {
+                Map<String, Object> properties = new LinkedHashMap<>();
+
+                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellUtil.FILL_BACKGROUND_COLOR_COLOR, null); // WORKAROUND
+                properties.put(CellUtil.FILL_PATTERN, FillPatternType.NO_FILL);
+
                 CellUtil.setCellStyleProperties(cell, properties);
             }
 
@@ -159,6 +280,48 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
+    public void testBug66052WithoutWorkaroundByEnum() throws IOException, DecoderException {
+
+        try (Workbook workbook = new XSSFWorkbook()) {
+
+            final Sheet sheet = workbook.createSheet("Sheet");
+            final Row row = sheet.createRow(0);
+            final Cell cell = row.createCell(0);
+            final XSSFColor color = new XSSFColor(Hex.decodeHex("FFAAAA"));
+
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertNull(cell.getCellStyle().getFillBackgroundColorColor());
+
+            {
+                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
+
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
+            }
+
+            assertEquals(color, cell.getCellStyle().getFillForegroundColorColor());
+            assertEquals(IndexedColors.AUTOMATIC.getIndex(),
+                    ((XSSFColor) cell.getCellStyle().getFillBackgroundColorColor()).getIndex());
+
+            {
+                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
+
+                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
+
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
+            }
+
+            assertNull(cell.getCellStyle().getFillForegroundColorColor());
+            assertEquals(IndexedColors.AUTOMATIC.getIndex(),
+                    ((XSSFColor) cell.getCellStyle().getFillBackgroundColorColor()).getIndex());
+        }
+    }
+
+    @Test
+    @Deprecated
     public void testBug66052WithoutWorkaround() throws IOException, DecoderException {
 
         try (Workbook workbook = new XSSFWorkbook()) {
@@ -172,10 +335,10 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
             assertNull(cell.getCellStyle().getFillBackgroundColorColor());
 
             {
-                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
+                Map<String, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, color);
-                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
+                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, color);
+                properties.put(CellUtil.FILL_PATTERN, FillPatternType.SOLID_FOREGROUND);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }
@@ -185,10 +348,10 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
                     ((XSSFColor) cell.getCellStyle().getFillBackgroundColorColor()).getIndex());
 
             {
-                Map<CellPropertyType, Object> properties = new LinkedHashMap<>();
+                Map<String, Object> properties = new LinkedHashMap<>();
 
-                properties.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
-                properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.NO_FILL);
+                properties.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
+                properties.put(CellUtil.FILL_PATTERN, FillPatternType.NO_FILL);
 
                 CellUtil.setCellStyleProperties(cell, properties);
             }

--- a/poi-ooxml/src/test/java/org/apache/poi/ss/tests/util/TestXSSFCellUtil.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ss/tests/util/TestXSSFCellUtil.java
@@ -19,7 +19,13 @@ package org.apache.poi.ss.tests.util;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellPropertyType;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.BaseTestCellUtil;
 import org.apache.poi.ss.util.CellUtil;
 import org.apache.poi.xssf.XSSFITestDataProvider;
@@ -31,7 +37,10 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class TestXSSFCellUtil extends BaseTestCellUtil {
     public TestXSSFCellUtil() {
@@ -57,7 +66,6 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     public void testSetForegroundColorCellStyleProperty() throws IOException, DecoderException {
         try (Workbook workbook = new XSSFWorkbook()) {
 
@@ -101,7 +109,6 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     public void testSetForegroundColorCellStylePropertyToNull() throws IOException, DecoderException {
         try (Workbook workbook = new XSSFWorkbook()) {
 
@@ -162,7 +169,6 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     public void testSetForegroundColorCellStylePropertiesToNull() throws IOException, DecoderException {
 
         try (Workbook workbook = new XSSFWorkbook()) {
@@ -239,7 +245,6 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     public void testBug66052WithWorkaround() throws IOException, DecoderException {
         try (Workbook workbook = new XSSFWorkbook()) {
 
@@ -321,7 +326,6 @@ class TestXSSFCellUtil extends BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     public void testBug66052WithoutWorkaround() throws IOException, DecoderException {
 
         try (Workbook workbook = new XSSFWorkbook()) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestUnfixedBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestUnfixedBugs.java
@@ -160,7 +160,7 @@ public final class TestUnfixedBugs {
     // This test will run green, but the resulting file is formatted incorrectly,
     // see the bug at https://bz.apache.org/bugzilla/show_bug.cgi?id=55752
     @Test
-    void testBug55752() throws IOException {
+    void testBug55752ByEnum() throws IOException {
         try (Workbook wb = new XSSFWorkbook()) {
             Sheet sheet = wb.createSheet("test");
 
@@ -205,6 +205,65 @@ public final class TestUnfixedBugs {
             CellUtil.setCellStyleProperty(cell0, CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
             Cell cell1 = CellUtil.getCell(row3, 1);
             CellUtil.setCellStyleProperty(cell1, CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
+
+            RegionUtil.setBorderBottom(BorderStyle.THIN, range4, sheet);
+
+            // write to file for manual inspection
+            XSSFTestDataSamples.writeOut(wb, "bug 55752 for review");
+        }
+
+        fail("Test runs ok, but the resulting file is incorrectly formatted");
+    }
+
+    // This test will run green, but the resulting file is formatted incorrectly,
+    // see the bug at https://bz.apache.org/bugzilla/show_bug.cgi?id=55752
+    @Test
+    @Deprecated
+    void testBug55752() throws IOException {
+        try (Workbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("test");
+
+            for (int i = 0; i < 4; i++) {
+                Row row = sheet.createRow(i);
+                for (int j = 0; j < 2; j++) {
+                    Cell cell = row.createCell(j);
+                    cell.setCellStyle(wb.createCellStyle());
+                }
+            }
+
+            // set content
+            Row row1 = sheet.getRow(0);
+            row1.getCell(0).setCellValue("AAA");
+            Row row2 = sheet.getRow(1);
+            row2.getCell(0).setCellValue("BBB");
+            Row row3 = sheet.getRow(2);
+            row3.getCell(0).setCellValue("CCC");
+            Row row4 = sheet.getRow(3);
+            row4.getCell(0).setCellValue("DDD");
+
+            // merge cells
+            CellRangeAddress range1 = new CellRangeAddress(0, 0, 0, 1);
+            assertEquals(0, sheet.addMergedRegion(range1));
+            CellRangeAddress range2 = new CellRangeAddress(1, 1, 0, 1);
+            assertEquals(1, sheet.addMergedRegion(range2));
+            CellRangeAddress range3 = new CellRangeAddress(2, 2, 0, 1);
+            assertEquals(2, sheet.addMergedRegion(range3));
+            assertEquals(0, range3.getFirstColumn());
+            assertEquals(1, range3.getLastColumn());
+            assertEquals(2, range3.getLastRow());
+            CellRangeAddress range4 = new CellRangeAddress(3, 3, 0, 1);
+            assertEquals(3, sheet.addMergedRegion(range4));
+
+            // set border
+            RegionUtil.setBorderBottom(BorderStyle.THIN, range1, sheet);
+
+            row2.getCell(0).getCellStyle().setBorderBottom(BorderStyle.THIN);
+            row2.getCell(1).getCellStyle().setBorderBottom(BorderStyle.THIN);
+
+            Cell cell0 = CellUtil.getCell(row3, 0);
+            CellUtil.setCellStyleProperty(cell0, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            Cell cell1 = CellUtil.getCell(row3, 1);
+            CellUtil.setCellStyleProperty(cell1, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
 
             RegionUtil.setBorderBottom(BorderStyle.THIN, range4, sheet);
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestUnfixedBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestUnfixedBugs.java
@@ -39,14 +39,7 @@ import org.apache.poi.ss.formula.functions.FreeRefFunction;
 import org.apache.poi.ss.formula.udf.AggregatingUDFFinder;
 import org.apache.poi.ss.formula.udf.DefaultUDFFinder;
 import org.apache.poi.ss.formula.udf.UDFFinder;
-import org.apache.poi.ss.usermodel.BorderStyle;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.DateUtil;
-import org.apache.poi.ss.usermodel.FormulaEvaluator;
-import org.apache.poi.ss.usermodel.RichTextString;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellUtil;
@@ -209,9 +202,9 @@ public final class TestUnfixedBugs {
             row2.getCell(1).getCellStyle().setBorderBottom(BorderStyle.THIN);
 
             Cell cell0 = CellUtil.getCell(row3, 0);
-            CellUtil.setCellStyleProperty(cell0, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            CellUtil.setCellStyleProperty(cell0, CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
             Cell cell1 = CellUtil.getCell(row3, 1);
-            CellUtil.setCellStyleProperty(cell1, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            CellUtil.setCellStyleProperty(cell1, CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
 
             RegionUtil.setBorderBottom(BorderStyle.THIN, range4, sheet);
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestUnfixedBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestUnfixedBugs.java
@@ -39,7 +39,15 @@ import org.apache.poi.ss.formula.functions.FreeRefFunction;
 import org.apache.poi.ss.formula.udf.AggregatingUDFFinder;
 import org.apache.poi.ss.formula.udf.DefaultUDFFinder;
 import org.apache.poi.ss.formula.udf.UDFFinder;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellPropertyType;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellUtil;
@@ -218,7 +226,6 @@ public final class TestUnfixedBugs {
     // This test will run green, but the resulting file is formatted incorrectly,
     // see the bug at https://bz.apache.org/bugzilla/show_bug.cgi?id=55752
     @Test
-    @Deprecated
     void testBug55752() throws IOException {
         try (Workbook wb = new XSSFWorkbook()) {
             Sheet sheet = wb.createSheet("test");

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFBugs.java
@@ -2795,8 +2795,8 @@ public final class TestXSSFBugs extends BaseTestBugzillaIssues {
             assertNotNull(actual);
             assertEquals(color.getARGBHex(), actual.getARGBHex());
 
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            Map<CellPropertyType, Object> properties = new HashMap<>();
+            properties.put(CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
             CellUtil.setCellStyleProperties(cell, properties);
 
             // Now the cell is all black

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFBugs.java
@@ -2778,7 +2778,7 @@ public final class TestXSSFBugs extends BaseTestBugzillaIssues {
 
     @Disabled("bug 59442")
     @Test
-    void testSetRGBBackgroundColor() throws IOException {
+    void testSetRGBBackgroundColorByEnum() throws IOException {
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {
             XSSFCell cell = workbook.createSheet().createRow(0).createCell(0);
 
@@ -2797,6 +2797,51 @@ public final class TestXSSFBugs extends BaseTestBugzillaIssues {
 
             Map<CellPropertyType, Object> properties = new HashMap<>();
             properties.put(CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
+            CellUtil.setCellStylePropertiesEnum(cell, properties);
+
+            // Now the cell is all black
+            actual = cell.getCellStyle().getFillBackgroundColorColor();
+            assertNotNull(actual);
+            assertNull(actual.getARGBHex());
+            actual = cell.getCellStyle().getFillForegroundColorColor();
+            assertNotNull(actual);
+            assertEquals(color.getARGBHex(), actual.getARGBHex());
+
+            try (XSSFWorkbook nwb = writeOutAndReadBack(workbook)) {
+                XSSFCell ncell = nwb.getSheetAt(0).getRow(0).getCell(0);
+                XSSFColor ncolor = new XSSFColor(java.awt.Color.RED, workbook.getStylesSource().getIndexedColors());
+
+                // Now the cell is all black
+                XSSFColor nactual = ncell.getCellStyle().getFillBackgroundColorColor();
+                assertNotNull(nactual);
+                assertEquals(ncolor.getARGBHex(), nactual.getARGBHex());
+
+            }
+        }
+    }
+
+    @Disabled("bug 59442")
+    @Test
+    @Deprecated
+    void testSetRGBBackgroundColor() throws IOException {
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            XSSFCell cell = workbook.createSheet().createRow(0).createCell(0);
+
+            XSSFColor color = new XSSFColor(java.awt.Color.RED, workbook.getStylesSource().getIndexedColors());
+            XSSFCellStyle style = workbook.createCellStyle();
+            style.setFillForegroundColor(color);
+            style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+            cell.setCellStyle(style);
+
+            // Everything is fine at this point, cell is red
+            XSSFColor actual = cell.getCellStyle().getFillBackgroundColorColor();
+            assertNull(actual);
+            actual = cell.getCellStyle().getFillForegroundColorColor();
+            assertNotNull(actual);
+            assertEquals(color.getARGBHex(), actual.getARGBHex());
+
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
             CellUtil.setCellStyleProperties(cell, properties);
 
             // Now the cell is all black

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCell.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCell.java
@@ -946,7 +946,7 @@ public class HSSFCell extends CellBase {
      * the HSSFWorkbook.</p>
      *
      * <p>To change the style of a cell without affecting other cells that use the same style,
-     * use {@link org.apache.poi.ss.util.CellUtil#setCellStyleProperties(org.apache.poi.ss.usermodel.Cell, java.util.Map)}</p>
+     * use {@link org.apache.poi.ss.util.CellUtil#setCellStylePropertiesEnum(org.apache.poi.ss.usermodel.Cell, java.util.Map)}</p>
      *
      * @param style  reference contained in the workbook
      * @see org.apache.poi.hssf.usermodel.HSSFWorkbook#createCellStyle()

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Cell.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Cell.java
@@ -369,7 +369,7 @@ public interface Cell {
      * the Workbook.</p>
      *
      * <p>To change the style of a cell without affecting other cells that use the same style,
-     * use {@link org.apache.poi.ss.util.CellUtil#setCellStyleProperties(Cell, Map)}</p>
+     * use {@link org.apache.poi.ss.util.CellUtil#setCellStylePropertiesEnum(Cell, Map)}</p>
      *
      * @param style  reference contained in the workbook.
      * If the value is null then the style information is removed causing the cell to used the default workbook style.

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyCategory.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyCategory.java
@@ -1,0 +1,30 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+
+package org.apache.poi.ss.usermodel;
+
+public enum CellPropertyCategory {
+
+    SHORT,
+    COLOR,
+    INT,
+    BOOL,
+    BORDER_TYPE,
+    OTHER
+
+}

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyCategory.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyCategory.java
@@ -18,6 +18,12 @@
 
 package org.apache.poi.ss.usermodel;
 
+/**
+ * The {@code CellPropertyCategory} enum represents the different categories of cell properties.
+ * Each category is used to classify and organize the cell properties based on their characteristics.
+ *
+ * @since POI 5.3.1
+ */
 public enum CellPropertyCategory {
 
     SHORT,

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyType.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyType.java
@@ -1,0 +1,63 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.ss.usermodel;
+
+public enum CellPropertyType {
+
+
+    BORDER_BOTTOM(CellPropertyCategory.BORDER_TYPE),
+    BORDER_LEFT(CellPropertyCategory.BORDER_TYPE),
+    BORDER_RIGHT(CellPropertyCategory.BORDER_TYPE),
+    BORDER_TOP(CellPropertyCategory.BORDER_TYPE),
+
+    BOTTOM_BORDER_COLOR(CellPropertyCategory.SHORT),
+    LEFT_BORDER_COLOR(CellPropertyCategory.SHORT),
+    RIGHT_BORDER_COLOR(CellPropertyCategory.SHORT),
+    TOP_BORDER_COLOR(CellPropertyCategory.SHORT),
+    DATA_FORMAT(CellPropertyCategory.SHORT),
+    FILL_BACKGROUND_COLOR(CellPropertyCategory.SHORT),
+    FILL_FOREGROUND_COLOR(CellPropertyCategory.SHORT),
+    INDENTION(CellPropertyCategory.SHORT),
+    ROTATION(CellPropertyCategory.SHORT),
+
+    FILL_BACKGROUND_COLOR_COLOR(CellPropertyCategory.COLOR),
+    FILL_FOREGROUND_COLOR_COLOR(CellPropertyCategory.COLOR),
+
+    FONT(CellPropertyCategory.INT),
+
+    HIDDEN(CellPropertyCategory.BOOL),
+    LOCKED(CellPropertyCategory.BOOL),
+    WRAP_TEXT(CellPropertyCategory.BOOL),
+    SHRINK_TO_FIT(CellPropertyCategory.BOOL),
+    QUOTE_PREFIXED(CellPropertyCategory.BOOL),
+
+    ALIGNMENT(CellPropertyCategory.OTHER),
+    FILL_PATTERN(CellPropertyCategory.OTHER),
+    VERTICAL_ALIGNMENT(CellPropertyCategory.OTHER);
+
+    CellPropertyType(CellPropertyCategory category) {
+        this.category = category;
+    }
+
+    private final CellPropertyCategory category;
+
+    public CellPropertyCategory getCategory() {
+        return this.category;
+    }
+
+}

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyType.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyType.java
@@ -1,0 +1,47 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.ss.usermodel;
+
+public enum CellPropertyType {
+
+    ALIGNMENT,
+    BORDER_BOTTOM,
+    BORDER_LEFT,
+    BORDER_RIGHT,
+    BORDER_TOP,
+    BOTTOM_BORDER_COLOR,
+    LEFT_BORDER_COLOR,
+    RIGHT_BORDER_COLOR,
+    TOP_BORDER_COLOR,
+    DATA_FORMAT,
+    FILL_BACKGROUND_COLOR,
+    FILL_FOREGROUND_COLOR,
+    FILL_BACKGROUND_COLOR_COLOR,
+    FILL_FOREGROUND_COLOR_COLOR,
+    FILL_PATTERN,
+    FONT,
+    HIDDEN,
+    INDENTION,
+    LOCKED,
+    ROTATION,
+    VERTICAL_ALIGNMENT,
+    WRAP_TEXT,
+    SHRINK_TO_FIT,
+    QUOTE_PREFIXED
+
+}

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyType.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/CellPropertyType.java
@@ -17,6 +17,12 @@
 
 package org.apache.poi.ss.usermodel;
 
+/**
+ * The {@code CellPropertyType} enum represents the different types of cell properties that can be applied to a cell.
+ * Each type is associated with a specific category {@link CellPropertyCategory}, which classifies and organizes the properties based on their characteristics.
+ *
+ * @since POI 5.3.1
+ */
 public enum CellPropertyType {
 
 

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -17,10 +17,8 @@
 
 package org.apache.poi.ss.util;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +29,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.common.Duplicatable;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.util.Beta;
+
+import java.util.*;
 
 /**
  * Various utility functions that make working with a cells and rows easier. The various methods
@@ -43,72 +43,41 @@ public final class CellUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(CellUtil.class);
 
-    // FIXME: Move these constants into an enum
-    public static final String ALIGNMENT = "alignment";
-    public static final String BORDER_BOTTOM = "borderBottom";
-    public static final String BORDER_LEFT = "borderLeft";
-    public static final String BORDER_RIGHT = "borderRight";
-    public static final String BORDER_TOP = "borderTop";
-    public static final String BOTTOM_BORDER_COLOR = "bottomBorderColor";
-    public static final String LEFT_BORDER_COLOR = "leftBorderColor";
-    public static final String RIGHT_BORDER_COLOR = "rightBorderColor";
-    public static final String TOP_BORDER_COLOR = "topBorderColor";
-    public static final String DATA_FORMAT = "dataFormat";
-    public static final String FILL_BACKGROUND_COLOR = "fillBackgroundColor";
-    public static final String FILL_FOREGROUND_COLOR = "fillForegroundColor";
-    
-    public static final String FILL_BACKGROUND_COLOR_COLOR = "fillBackgroundColorColor";
-    public static final String FILL_FOREGROUND_COLOR_COLOR = "fillForegroundColorColor";
+    private static final Set<CellPropertyType> SHORT_VALUES = EnumSet.of(
+            CellPropertyType.BOTTOM_BORDER_COLOR,
+            CellPropertyType.LEFT_BORDER_COLOR,
+            CellPropertyType.RIGHT_BORDER_COLOR,
+            CellPropertyType.TOP_BORDER_COLOR,
+            CellPropertyType.FILL_FOREGROUND_COLOR,
+            CellPropertyType.FILL_BACKGROUND_COLOR,
+            CellPropertyType.INDENTION,
+            CellPropertyType.DATA_FORMAT,
+            CellPropertyType.ROTATION
+    );
 
-    public static final String FILL_PATTERN = "fillPattern";
-    public static final String FONT = "font";
-    public static final String HIDDEN = "hidden";
-    public static final String INDENTION = "indention";
-    public static final String LOCKED = "locked";
-    public static final String ROTATION = "rotation";
-    public static final String VERTICAL_ALIGNMENT = "verticalAlignment";
-    public static final String WRAP_TEXT = "wrapText";
-    public static final String SHRINK_TO_FIT = "shrinkToFit";
-    public static final String QUOTE_PREFIXED = "quotePrefixed";
+    private static final Set<CellPropertyType> COLOR_VALUES = EnumSet.of(
+            CellPropertyType.FILL_FOREGROUND_COLOR_COLOR,
+            CellPropertyType.FILL_BACKGROUND_COLOR_COLOR
+    );
 
-    private static final Set<String> shortValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    BOTTOM_BORDER_COLOR,
-                    LEFT_BORDER_COLOR,
-                    RIGHT_BORDER_COLOR,
-                    TOP_BORDER_COLOR,
-                    FILL_FOREGROUND_COLOR,
-                    FILL_BACKGROUND_COLOR,
-                    INDENTION,
-                    DATA_FORMAT,
-                    ROTATION
-            )));
-            
-    private static final Set<String> colorValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    FILL_FOREGROUND_COLOR_COLOR,
-                    FILL_BACKGROUND_COLOR_COLOR
-            )));
+    private static final Set<CellPropertyType> INT_VALUES = EnumSet.of(
+            CellPropertyType.FONT
+    );
 
-    private static final Set<String> intValues = Collections.unmodifiableSet(
-            new HashSet<>(Collections.singletonList(
-                FONT
-            )));
-    private static final Set<String> booleanValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    LOCKED,
-                    HIDDEN,
-                    WRAP_TEXT,
-                    SHRINK_TO_FIT,
-                    QUOTE_PREFIXED
-            )));
-    private static final Set<String> borderTypeValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    BORDER_BOTTOM,
-                    BORDER_LEFT,
-                    BORDER_RIGHT,
-                    BORDER_TOP
-            )));
+    private static final Set<CellPropertyType> BOOLEAN_VALUES = EnumSet.of(
+            CellPropertyType.LOCKED,
+            CellPropertyType.HIDDEN,
+            CellPropertyType.WRAP_TEXT,
+            CellPropertyType.SHRINK_TO_FIT,
+            CellPropertyType.QUOTE_PREFIXED
+    );
+
+    private static final Set<CellPropertyType> BORDER_TYPE_VALUES = EnumSet.of(
+            CellPropertyType.BORDER_BOTTOM,
+            CellPropertyType.BORDER_LEFT,
+            CellPropertyType.BORDER_RIGHT,
+            CellPropertyType.BORDER_TOP
+    );
 
 
     private static final UnicodeMapping[] unicodeMappings;
@@ -132,7 +101,7 @@ public final class CellUtil {
      * Get a row from the spreadsheet, and create it if it doesn't exist.
      *
      * @param rowIndex The 0 based row number
-     * @param sheet The sheet that the row is part of.
+     * @param sheet    The sheet that the row is part of.
      * @return The row indicated by the rowCounter
      */
     public static Row getRow(int rowIndex, Sheet sheet) {
@@ -147,7 +116,7 @@ public final class CellUtil {
     /**
      * Get a specific cell from a row. If the cell doesn't exist, then create it.
      *
-     * @param row The row that the cell is part of
+     * @param row         The row that the cell is part of
      * @param columnIndex The column index that the cell is in.
      * @return The cell indicated by the column.
      */
@@ -164,11 +133,11 @@ public final class CellUtil {
     /**
      * Creates a cell, gives it a value, and applies a style if provided
      *
-     * @param  row     the row to create the cell in
-     * @param  column  the column index to create the cell in
-     * @param  value   The value of the cell
-     * @param  style   If the style is not null, then set
-     * @return         A new Cell
+     * @param row    the row to create the cell in
+     * @param column the column index to create the cell in
+     * @param value  The value of the cell
+     * @param style  If the style is not null, then set
+     * @return A new Cell
      */
     public static Cell createCell(Row row, int column, String value, CellStyle style) {
         Cell cell = getCell(row, column);
@@ -185,10 +154,10 @@ public final class CellUtil {
     /**
      * Create a cell, and give it a value.
      *
-     *@param  row     the row to create the cell in
-     *@param  column  the column index to create the cell in
-     *@param  value   The value of the cell
-     *@return         A new Cell.
+     * @param row    the row to create the cell in
+     * @param column the column index to create the cell in
+     * @param value  The value of the cell
+     * @return A new Cell.
      */
     public static Cell createCell(Row row, int column, String value) {
         return createCell(row, column, value, null);
@@ -197,19 +166,19 @@ public final class CellUtil {
     /**
      * Copy cell value, formula and style, from srcCell per cell copy policy
      * If srcCell is null, clears the cell value and cell style per cell copy policy.
-     *
+     * <p>
      * Note that if you are copying from a source cell from a different type of then you may need to disable style copying
      * in the {@link CellCopyPolicy} (HSSF styles are not compatible with XSSF styles, for instance).
-     *
+     * <p>
      * This does not shift references in formulas. The <code>copyRowFrom</code> method on <code>XSSFRow</code>
      * and <code>HSSFRow</code> does attempt to shift references in formulas.
      *
-     * @param srcCell The cell to take value, formula and style from
+     * @param srcCell  The cell to take value, formula and style from
      * @param destCell The cell to copy to
-     * @param policy The policy for copying the information, see {@link CellCopyPolicy}
-     * @param context The context for copying, see {@link CellCopyContext}
+     * @param policy   The policy for copying the information, see {@link CellCopyPolicy}
+     * @param context  The context for copying, see {@link CellCopyContext}
      * @throws IllegalArgumentException if copy cell style and srcCell is from a different workbook
-     * @throws IllegalStateException if srcCell hyperlink is not an instance of {@link Duplicatable}
+     * @throws IllegalStateException    if srcCell hyperlink is not an instance of {@link Duplicatable}
      * @since POI 5.2.0
      */
     @Beta
@@ -228,8 +197,7 @@ public final class CellUtil {
                         // DataFormat is not copied unless policy.isCopyCellStyle is true
                         if (DateUtil.isCellDateFormatted(srcCell)) {
                             destCell.setCellValue(srcCell.getDateCellValue());
-                        }
-                        else {
+                        } else {
                             destCell.setCellValue(srcCell.getNumericCellValue());
                         }
                         break;
@@ -280,7 +248,7 @@ public final class CellUtil {
             // if srcCell doesn't have a hyperlink and destCell has a hyperlink, don't clear destCell's hyperlink
             if (srcHyperlink != null) {
                 if (srcHyperlink instanceof Duplicatable) {
-                    Hyperlink newHyperlink = (Hyperlink)((Duplicatable)srcHyperlink).copy();
+                    Hyperlink newHyperlink = (Hyperlink) ((Duplicatable) srcHyperlink).copy();
                     destCell.setHyperlink(newHyperlink);
                 } else {
                     throw new IllegalStateException("srcCell hyperlink is not an instance of Duplicatable");
@@ -292,7 +260,7 @@ public final class CellUtil {
             if (srcHyperlink == null) {
                 destCell.setHyperlink(null);
             } else if (srcHyperlink instanceof Duplicatable) {
-                Hyperlink newHyperlink = (Hyperlink)((Duplicatable)srcHyperlink).copy();
+                Hyperlink newHyperlink = (Hyperlink) ((Duplicatable) srcHyperlink).copy();
                 destCell.setHyperlink(newHyperlink);
             } else {
                 throw new IllegalStateException("srcCell hyperlink is not an instance of Duplicatable");
@@ -302,40 +270,38 @@ public final class CellUtil {
 
     /**
      * Take a cell, and align it.
-     *
+     * <p>
      * This is superior to cell.getCellStyle().setAlignment(align) because
      * this method will not modify the CellStyle object that may be referenced
      * by multiple cells. Instead, this method will search for existing CellStyles
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
      *
-     * @param cell the cell to set the alignment for
+     * @param cell  the cell to set the alignment for
      * @param align the horizontal alignment to use.
-     *
      * @see HorizontalAlignment for alignment options
      * @since POI 3.15 beta 3
      */
     public static void setAlignment(Cell cell, HorizontalAlignment align) {
-        setCellStyleProperty(cell, ALIGNMENT, align);
+        setCellStyleProperty(cell, CellPropertyType.ALIGNMENT, align);
     }
 
     /**
      * Take a cell, and vertically align it.
-     *
+     * <p>
      * This is superior to cell.getCellStyle().setVerticalAlignment(align) because
      * this method will not modify the CellStyle object that may be referenced
      * by multiple cells. Instead, this method will search for existing CellStyles
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
      *
-     * @param cell the cell to set the alignment for
+     * @param cell  the cell to set the alignment for
      * @param align the vertical alignment to use.
-     *
      * @see VerticalAlignment for alignment options
      * @since POI 3.15 beta 3
      */
     public static void setVerticalAlignment(Cell cell, VerticalAlignment align) {
-        setCellStyleProperty(cell, VERTICAL_ALIGNMENT, align);
+        setCellStyleProperty(cell, CellPropertyType.VERTICAL_ALIGNMENT, align);
     }
 
     /**
@@ -356,7 +322,7 @@ public final class CellUtil {
         // Check if cell belongs to workbook
         // (checked in setCellStyleProperty)
 
-        setCellStyleProperty(cell, FONT, fontIndex);
+        setCellStyleProperty(cell, CellPropertyType.FONT, fontIndex);
     }
 
     /**
@@ -370,7 +336,7 @@ public final class CellUtil {
      * <p>This is necessary because Excel has an upper limit on the number of styles that it supports.</p>
      *
      * <p>This function is more efficient than multiple calls to
-     * {@link #setCellStyleProperty(Cell, String, Object)}
+     * {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
      * if adding multiple cell styles.</p>
      *
      * <p>For performance reasons, if this is the only cell in a workbook that uses a cell style,
@@ -380,32 +346,32 @@ public final class CellUtil {
      * [@link #removeStyleFromWorkbookIfUnused(CellStyle, Workbook)]. -->
      * </p>
      *
-     * @param cell The cell to change the style of
-     * @param properties The properties to be added to a cell style, as {propertyName: propertyValue}.
+     * @param cell       The cell to change the style of
+     * @param properties The properties to be added to a cell style, as {property: propertyValue}.
      * @since POI 3.14 beta 2
      */
-    public static void setCellStyleProperties(Cell cell, Map<String, Object> properties) {
+    public static void setCellStyleProperties(Cell cell, Map<CellPropertyType, Object> properties) {
         setCellStyleProperties(cell, properties, false);
     }
 
-    private static void setCellStyleProperties(final Cell cell, final Map<String, Object> properties,
+    private static void setCellStyleProperties(final Cell cell, final Map<CellPropertyType, Object> properties,
                                                final boolean disableNullColorCheck) {
         Workbook workbook = cell.getSheet().getWorkbook();
         CellStyle originalStyle = cell.getCellStyle();
 
         CellStyle newStyle = null;
-        Map<String, Object> values = getFormatProperties(originalStyle);
-        if (properties.containsKey(FILL_FOREGROUND_COLOR_COLOR) && properties.get(FILL_FOREGROUND_COLOR_COLOR) == null) {
-            values.remove(FILL_FOREGROUND_COLOR);
+        Map<CellPropertyType, Object> values = getFormatProperties(originalStyle);
+        if (properties.containsKey(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR) && properties.get(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR) == null) {
+            values.remove(CellPropertyType.FILL_FOREGROUND_COLOR);
         }
-        if (properties.containsKey(FILL_FOREGROUND_COLOR) && !properties.containsKey(FILL_FOREGROUND_COLOR_COLOR)) {
-            values.remove(FILL_FOREGROUND_COLOR_COLOR);
+        if (properties.containsKey(CellPropertyType.FILL_FOREGROUND_COLOR) && !properties.containsKey(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR)) {
+            values.remove(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
         }
-        if (properties.containsKey(FILL_BACKGROUND_COLOR_COLOR) && properties.get(FILL_BACKGROUND_COLOR_COLOR) == null) {
-            values.remove(FILL_BACKGROUND_COLOR);
+        if (properties.containsKey(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR) && properties.get(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR) == null) {
+            values.remove(CellPropertyType.FILL_BACKGROUND_COLOR);
         }
-        if (properties.containsKey(FILL_BACKGROUND_COLOR) && !properties.containsKey(FILL_BACKGROUND_COLOR_COLOR)) {
-            values.remove(FILL_BACKGROUND_COLOR_COLOR);
+        if (properties.containsKey(CellPropertyType.FILL_BACKGROUND_COLOR) && !properties.containsKey(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR)) {
+            values.remove(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
         }
         putAll(properties, values);
 
@@ -415,7 +381,7 @@ public final class CellUtil {
 
         for (int i = 0; i < numberCellStyles; i++) {
             CellStyle wbStyle = workbook.getCellStyleAt(i);
-            Map<String, Object> wbStyleMap = getFormatProperties(wbStyle);
+            Map<CellPropertyType, Object> wbStyleMap = getFormatProperties(wbStyle);
 
             // the desired style already exists in the workbook. Use the existing style.
             if (styleMapsMatch(wbStyleMap, values, disableNullColorCheck)) {
@@ -433,14 +399,14 @@ public final class CellUtil {
         cell.setCellStyle(newStyle);
     }
 
-    private static boolean styleMapsMatch(final Map<String, Object> newProps,
-                                          final Map<String, Object> storedProps, final boolean disableNullColorCheck) {
-        final Map<String, Object> map1Copy = new HashMap<>(newProps);
-        final Map<String, Object> map2Copy = new HashMap<>(storedProps);
-        final Object backColor1 = map1Copy.remove(FILL_BACKGROUND_COLOR_COLOR);
-        final Object backColor2 = map2Copy.remove(FILL_BACKGROUND_COLOR_COLOR);
-        final Object foreColor1 = map1Copy.remove(FILL_FOREGROUND_COLOR_COLOR);
-        final Object foreColor2 = map2Copy.remove(FILL_FOREGROUND_COLOR_COLOR);
+    private static boolean styleMapsMatch(final Map<CellPropertyType, Object> newProps,
+                                          final Map<CellPropertyType, Object> storedProps, final boolean disableNullColorCheck) {
+        final Map<CellPropertyType, Object> map1Copy = new HashMap<>(newProps);
+        final Map<CellPropertyType, Object> map2Copy = new HashMap<>(storedProps);
+        final Object backColor1 = map1Copy.remove(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
+        final Object backColor2 = map2Copy.remove(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
+        final Object foreColor1 = map1Copy.remove(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
+        final Object foreColor2 = map2Copy.remove(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
         if (map1Copy.equals(map2Copy)) {
             final boolean backColorsMatch = (!disableNullColorCheck && backColor2 == null)
                     || Objects.equals(backColor1, backColor2);
@@ -464,25 +430,25 @@ public final class CellUtil {
      * {@link #setCellStyleProperties(Cell, Map)},
      * which is faster and does not add unnecessary intermediate CellStyles to the workbook.</p>
      *
-     * @param cell The cell that is to be changed.
-     * @param propertyName The name of the property that is to be changed.
+     * @param cell          The cell that is to be changed.
+     * @param property      The property that is to be changed.
      * @param propertyValue The value of the property that is to be changed.
      */
-    public static void setCellStyleProperty(Cell cell, String propertyName, Object propertyValue) {
+    public static void setCellStyleProperty(Cell cell, CellPropertyType property, Object propertyValue) {
         boolean disableNullColorCheck = false;
-        final Map<String, Object> propMap;
-        if (CellUtil.FILL_FOREGROUND_COLOR_COLOR.equals(propertyName) && propertyValue == null) {
+        final Map<CellPropertyType, Object> propMap;
+        if (CellPropertyType.FILL_FOREGROUND_COLOR_COLOR.equals(property) && propertyValue == null) {
             disableNullColorCheck = true;
             propMap = new HashMap<>();
-            propMap.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
-            propMap.put(CellUtil.FILL_FOREGROUND_COLOR, null);
-        } else if (CellUtil.FILL_BACKGROUND_COLOR_COLOR.equals(propertyName) && propertyValue == null) {
+            propMap.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
+            propMap.put(CellPropertyType.FILL_FOREGROUND_COLOR, null);
+        } else if (CellPropertyType.FILL_BACKGROUND_COLOR_COLOR.equals(property) && propertyValue == null) {
             disableNullColorCheck = true;
             propMap = new HashMap<>();
-            propMap.put(CellUtil.FILL_BACKGROUND_COLOR_COLOR, null);
-            propMap.put(CellUtil.FILL_BACKGROUND_COLOR, null);
+            propMap.put(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, null);
+            propMap.put(CellPropertyType.FILL_BACKGROUND_COLOR, null);
         } else {
-            propMap = Collections.singletonMap(propertyName, propertyValue);
+            propMap = Collections.singletonMap(property, propertyValue);
         }
         setCellStyleProperties(cell, propMap, disableNullColorCheck);
     }
@@ -494,37 +460,37 @@ public final class CellUtil {
      * map will not modify the cell style. The returned map is mutable.
      *
      * @param style cell style
-     * @return map of format properties (String -> Object)
+     * @return map of format properties (CellPropertyType -> Object)
      * @see #setFormatProperties(CellStyle, Workbook, Map)
      */
-    private static Map<String, Object> getFormatProperties(CellStyle style) {
-        Map<String, Object> properties = new HashMap<>();
-        put(properties, ALIGNMENT, style.getAlignment());
-        put(properties, VERTICAL_ALIGNMENT, style.getVerticalAlignment());
-        put(properties, BORDER_BOTTOM, style.getBorderBottom());
-        put(properties, BORDER_LEFT, style.getBorderLeft());
-        put(properties, BORDER_RIGHT, style.getBorderRight());
-        put(properties, BORDER_TOP, style.getBorderTop());
-        put(properties, BOTTOM_BORDER_COLOR, style.getBottomBorderColor());
-        put(properties, DATA_FORMAT, style.getDataFormat());
-        put(properties, FILL_PATTERN, style.getFillPattern());
-        
-        put(properties, FILL_FOREGROUND_COLOR, style.getFillForegroundColor());
-        put(properties, FILL_BACKGROUND_COLOR, style.getFillBackgroundColor());
-        put(properties, FILL_FOREGROUND_COLOR_COLOR, style.getFillForegroundColorColor());
-        put(properties, FILL_BACKGROUND_COLOR_COLOR, style.getFillBackgroundColorColor());
+    private static Map<CellPropertyType, Object> getFormatProperties(CellStyle style) {
+        Map<CellPropertyType, Object> properties = new HashMap<>();
+        put(properties, CellPropertyType.ALIGNMENT, style.getAlignment());
+        put(properties, CellPropertyType.VERTICAL_ALIGNMENT, style.getVerticalAlignment());
+        put(properties, CellPropertyType.BORDER_BOTTOM, style.getBorderBottom());
+        put(properties, CellPropertyType.BORDER_LEFT, style.getBorderLeft());
+        put(properties, CellPropertyType.BORDER_RIGHT, style.getBorderRight());
+        put(properties, CellPropertyType.BORDER_TOP, style.getBorderTop());
+        put(properties, CellPropertyType.BOTTOM_BORDER_COLOR, style.getBottomBorderColor());
+        put(properties, CellPropertyType.DATA_FORMAT, style.getDataFormat());
+        put(properties, CellPropertyType.FILL_PATTERN, style.getFillPattern());
 
-        put(properties, FONT, style.getFontIndex());
-        put(properties, HIDDEN, style.getHidden());
-        put(properties, INDENTION, style.getIndention());
-        put(properties, LEFT_BORDER_COLOR, style.getLeftBorderColor());
-        put(properties, LOCKED, style.getLocked());
-        put(properties, RIGHT_BORDER_COLOR, style.getRightBorderColor());
-        put(properties, ROTATION, style.getRotation());
-        put(properties, TOP_BORDER_COLOR, style.getTopBorderColor());
-        put(properties, WRAP_TEXT, style.getWrapText());
-        put(properties, SHRINK_TO_FIT, style.getShrinkToFit());
-        put(properties, QUOTE_PREFIXED, style.getQuotePrefixed());
+        put(properties, CellPropertyType.FILL_FOREGROUND_COLOR, style.getFillForegroundColor());
+        put(properties, CellPropertyType.FILL_BACKGROUND_COLOR, style.getFillBackgroundColor());
+        put(properties, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, style.getFillForegroundColorColor());
+        put(properties, CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, style.getFillBackgroundColorColor());
+
+        put(properties, CellPropertyType.FONT, style.getFontIndex());
+        put(properties, CellPropertyType.HIDDEN, style.getHidden());
+        put(properties, CellPropertyType.INDENTION, style.getIndention());
+        put(properties, CellPropertyType.LEFT_BORDER_COLOR, style.getLeftBorderColor());
+        put(properties, CellPropertyType.LOCKED, style.getLocked());
+        put(properties, CellPropertyType.RIGHT_BORDER_COLOR, style.getRightBorderColor());
+        put(properties, CellPropertyType.ROTATION, style.getRotation());
+        put(properties, CellPropertyType.TOP_BORDER_COLOR, style.getTopBorderColor());
+        put(properties, CellPropertyType.WRAP_TEXT, style.getWrapText());
+        put(properties, CellPropertyType.SHRINK_TO_FIT, style.getShrinkToFit());
+        put(properties, CellPropertyType.QUOTE_PREFIXED, style.getQuotePrefixed());
         return properties;
     }
 
@@ -532,27 +498,27 @@ public final class CellUtil {
      * Copies the entries in src to dest, using the preferential data type
      * so that maps can be compared for equality
      *
-     * @param src the property map to copy from (read-only)
+     * @param src  the property map to copy from (read-only)
      * @param dest the property map to copy into
      * @since POI 3.15 beta 3
      */
-    private static void putAll(final Map<String, Object> src, Map<String, Object> dest) {
-        for (final String key : src.keySet()) {
-            if (shortValues.contains(key)) {
+    private static void putAll(final Map<CellPropertyType, Object> src, Map<CellPropertyType, Object> dest) {
+        for (final CellPropertyType key : src.keySet()) {
+            if (SHORT_VALUES.contains(key)) {
                 dest.put(key, nullableShort(src, key));
-            } else if (colorValues.contains(key)) {
+            } else if (COLOR_VALUES.contains(key)) {
                 dest.put(key, getColor(src, key));
-            } else if (intValues.contains(key)) {
+            } else if (INT_VALUES.contains(key)) {
                 dest.put(key, getInt(src, key));
-            } else if (booleanValues.contains(key)) {
+            } else if (BOOLEAN_VALUES.contains(key)) {
                 dest.put(key, getBoolean(src, key));
-            } else if (borderTypeValues.contains(key)) {
+            } else if (BORDER_TYPE_VALUES.contains(key)) {
                 dest.put(key, getBorderStyle(src, key));
-            } else if (ALIGNMENT.equals(key)) {
+            } else if (CellPropertyType.ALIGNMENT.equals(key)) {
                 dest.put(key, getHorizontalAlignment(src, key));
-            } else if (VERTICAL_ALIGNMENT.equals(key)) {
+            } else if (CellPropertyType.VERTICAL_ALIGNMENT.equals(key)) {
                 dest.put(key, getVerticalAlignment(src, key));
-            } else if (FILL_PATTERN.equals(key)) {
+            } else if (CellPropertyType.FILL_PATTERN.equals(key)) {
                 dest.put(key, getFillPattern(src, key));
             } else {
                 LOGGER.atInfo().log("Ignoring unrecognized CellUtil format properties key: {}", key);
@@ -563,33 +529,33 @@ public final class CellUtil {
     /**
      * Sets the format properties of the given style based on the given map.
      *
-     * @param style cell style
-     * @param workbook parent workbook
-     * @param properties map of format properties (String -> Object)
+     * @param style      cell style
+     * @param workbook   parent workbook
+     * @param properties map of format properties (CellPropertyType -> Object)
      * @see #getFormatProperties(CellStyle)
      */
-    private static void setFormatProperties(CellStyle style, Workbook workbook, Map<String, Object> properties) {
-        style.setAlignment(getHorizontalAlignment(properties, ALIGNMENT));
-        style.setVerticalAlignment(getVerticalAlignment(properties, VERTICAL_ALIGNMENT));
-        style.setBorderBottom(getBorderStyle(properties, BORDER_BOTTOM));
-        style.setBorderLeft(getBorderStyle(properties, BORDER_LEFT));
-        style.setBorderRight(getBorderStyle(properties, BORDER_RIGHT));
-        style.setBorderTop(getBorderStyle(properties, BORDER_TOP));
-        style.setBottomBorderColor(getShort(properties, BOTTOM_BORDER_COLOR));
-        style.setDataFormat(getShort(properties, DATA_FORMAT));
-        style.setFillPattern(getFillPattern(properties, FILL_PATTERN));
+    private static void setFormatProperties(CellStyle style, Workbook workbook, Map<CellPropertyType, Object> properties) {
+        style.setAlignment(getHorizontalAlignment(properties, CellPropertyType.ALIGNMENT));
+        style.setVerticalAlignment(getVerticalAlignment(properties, CellPropertyType.VERTICAL_ALIGNMENT));
+        style.setBorderBottom(getBorderStyle(properties, CellPropertyType.BORDER_BOTTOM));
+        style.setBorderLeft(getBorderStyle(properties, CellPropertyType.BORDER_LEFT));
+        style.setBorderRight(getBorderStyle(properties, CellPropertyType.BORDER_RIGHT));
+        style.setBorderTop(getBorderStyle(properties, CellPropertyType.BORDER_TOP));
+        style.setBottomBorderColor(getShort(properties, CellPropertyType.BOTTOM_BORDER_COLOR));
+        style.setDataFormat(getShort(properties, CellPropertyType.DATA_FORMAT));
+        style.setFillPattern(getFillPattern(properties, CellPropertyType.FILL_PATTERN));
 
-        Short fillForeColorShort = nullableShort(properties, FILL_FOREGROUND_COLOR);
+        Short fillForeColorShort = nullableShort(properties, CellPropertyType.FILL_FOREGROUND_COLOR);
         if (fillForeColorShort != null) {
             style.setFillForegroundColor(fillForeColorShort);
         }
-        Short fillBackColorShort = nullableShort(properties, FILL_BACKGROUND_COLOR);
+        Short fillBackColorShort = nullableShort(properties, CellPropertyType.FILL_BACKGROUND_COLOR);
         if (fillBackColorShort != null) {
             style.setFillBackgroundColor(fillBackColorShort);
         }
 
-        Color foregroundFillColor = getColor(properties, FILL_FOREGROUND_COLOR_COLOR);
-        Color backgroundFillColor = getColor(properties, FILL_BACKGROUND_COLOR_COLOR);
+        Color foregroundFillColor = getColor(properties, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
+        Color backgroundFillColor = getColor(properties, CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
 
         if (foregroundFillColor != null) {
             try {
@@ -606,37 +572,37 @@ public final class CellUtil {
             }
         }
 
-        style.setFont(workbook.getFontAt(getInt(properties, FONT)));
-        style.setHidden(getBoolean(properties, HIDDEN));
-        style.setIndention(getShort(properties, INDENTION));
-        style.setLeftBorderColor(getShort(properties, LEFT_BORDER_COLOR));
-        style.setLocked(getBoolean(properties, LOCKED));
-        style.setRightBorderColor(getShort(properties, RIGHT_BORDER_COLOR));
-        style.setRotation(getShort(properties, ROTATION));
-        style.setTopBorderColor(getShort(properties, TOP_BORDER_COLOR));
-        style.setWrapText(getBoolean(properties, WRAP_TEXT));
-        style.setShrinkToFit(getBoolean(properties, SHRINK_TO_FIT));
-        style.setQuotePrefixed(getBoolean(properties, QUOTE_PREFIXED));
+        style.setFont(workbook.getFontAt(getInt(properties, CellPropertyType.FONT)));
+        style.setHidden(getBoolean(properties, CellPropertyType.HIDDEN));
+        style.setIndention(getShort(properties, CellPropertyType.INDENTION));
+        style.setLeftBorderColor(getShort(properties, CellPropertyType.LEFT_BORDER_COLOR));
+        style.setLocked(getBoolean(properties, CellPropertyType.LOCKED));
+        style.setRightBorderColor(getShort(properties, CellPropertyType.RIGHT_BORDER_COLOR));
+        style.setRotation(getShort(properties, CellPropertyType.ROTATION));
+        style.setTopBorderColor(getShort(properties, CellPropertyType.TOP_BORDER_COLOR));
+        style.setWrapText(getBoolean(properties, CellPropertyType.WRAP_TEXT));
+        style.setShrinkToFit(getBoolean(properties, CellPropertyType.SHRINK_TO_FIT));
+        style.setQuotePrefixed(getBoolean(properties, CellPropertyType.QUOTE_PREFIXED));
     }
 
     /**
      * Utility method that returns the named short value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return zero if the property does not exist, or is not a {@link Short}
-     *         otherwise the property value
+     * otherwise the property value
      */
-    private static short getShort(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static short getShort(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Number) {
             return ((Number) value).shortValue();
         }
         return 0;
     }
 
-    private static Short nullableShort(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static Short nullableShort(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Short) {
             return (Short) value;
         }
@@ -645,17 +611,17 @@ public final class CellUtil {
         }
         return null;
     }
-    
+
     /**
      * Utility method that returns the named Color value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return null if the property does not exist, or is not a {@link Color}
-     *         otherwise the property value
+     * otherwise the property value
      */
-    private static Color getColor(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static Color getColor(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Color) {
             return (Color) value;
         }
@@ -666,13 +632,13 @@ public final class CellUtil {
     /**
      * Utility method that returns the named int value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return zero if the property does not exist, or is not a {@link Integer}
-     *         otherwise the property value
+     * otherwise the property value
      */
-    private static int getInt(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static int getInt(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Number) {
             return ((Number) value).intValue();
         }
@@ -682,26 +648,24 @@ public final class CellUtil {
     /**
      * Utility method that returns the named BorderStyle value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return Border style if set, otherwise {@link BorderStyle#NONE}
      */
-    private static BorderStyle getBorderStyle(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static BorderStyle getBorderStyle(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         BorderStyle border;
         if (value instanceof BorderStyle) {
             border = (BorderStyle) value;
         }
         // @deprecated 3.15 beta 2. getBorderStyle will only work on BorderStyle enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use BorderStyle enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use BorderStyle enums instead.", property);
             short code = (Short) value;
             border = BorderStyle.valueOf(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             border = BorderStyle.NONE;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected border style class. Must be BorderStyle or Short (deprecated).");
         }
         return border;
@@ -710,27 +674,25 @@ public final class CellUtil {
     /**
      * Utility method that returns the named FillPatternType value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return FillPatternType style if set, otherwise {@link FillPatternType#NO_FILL}
      * @since POI 3.15 beta 3
      */
-    private static FillPatternType getFillPattern(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static FillPatternType getFillPattern(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         FillPatternType pattern;
         if (value instanceof FillPatternType) {
             pattern = (FillPatternType) value;
         }
         // @deprecated 3.15 beta 2. getFillPattern will only work on FillPatternType enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use FillPatternType enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use FillPatternType enums instead.", property);
             short code = (Short) value;
             pattern = FillPatternType.forInt(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             pattern = FillPatternType.NO_FILL;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected fill pattern style class. Must be FillPatternType or Short (deprecated).");
         }
         return pattern;
@@ -739,27 +701,25 @@ public final class CellUtil {
     /**
      * Utility method that returns the named HorizontalAlignment value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return HorizontalAlignment style if set, otherwise {@link HorizontalAlignment#GENERAL}
      * @since POI 3.15 beta 3
      */
-    private static HorizontalAlignment getHorizontalAlignment(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static HorizontalAlignment getHorizontalAlignment(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         HorizontalAlignment align;
         if (value instanceof HorizontalAlignment) {
             align = (HorizontalAlignment) value;
         }
         // @deprecated 3.15 beta 2. getHorizontalAlignment will only work on HorizontalAlignment enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use HorizontalAlignment enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use HorizontalAlignment enums instead.", property);
             short code = (Short) value;
             align = HorizontalAlignment.forInt(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             align = HorizontalAlignment.GENERAL;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected horizontal alignment style class. Must be HorizontalAlignment or Short (deprecated).");
         }
         return align;
@@ -768,27 +728,25 @@ public final class CellUtil {
     /**
      * Utility method that returns the named VerticalAlignment value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return VerticalAlignment style if set, otherwise {@link VerticalAlignment#BOTTOM}
      * @since POI 3.15 beta 3
      */
-    private static VerticalAlignment getVerticalAlignment(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static VerticalAlignment getVerticalAlignment(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         VerticalAlignment align;
         if (value instanceof VerticalAlignment) {
             align = (VerticalAlignment) value;
         }
         // @deprecated 3.15 beta 2. getVerticalAlignment will only work on VerticalAlignment enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use VerticalAlignment enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use VerticalAlignment enums instead.", property);
             short code = (Short) value;
             align = VerticalAlignment.forInt(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             align = VerticalAlignment.BOTTOM;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected vertical alignment style class. Must be VerticalAlignment or Short (deprecated).");
         }
         return align;
@@ -797,13 +755,13 @@ public final class CellUtil {
     /**
      * Utility method that returns the named boolean value from the given map.
      *
-     * @param properties map of properties (String -> Object)
-     * @param name property name
+     * @param properties map of properties (CellPropertyType -> Object)
+     * @param property   property
      * @return false if the property does not exist, or is not a {@link Boolean},
-     *         true otherwise
+     * true otherwise
      */
-    private static boolean getBoolean(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static boolean getBoolean(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         //noinspection SimplifiableIfStatement
         if (value instanceof Boolean) {
             return (Boolean) value;
@@ -815,19 +773,19 @@ public final class CellUtil {
      * Utility method that puts the given value to the given map.
      *
      * @param properties map of properties (String -> Object)
-     * @param name property name
-     * @param value property value
+     * @param property   property
+     * @param value      property value
      */
-    private static void put(Map<String, Object> properties, String name, Object value) {
-        properties.put(name, value);
+    private static void put(Map<CellPropertyType, Object> properties, CellPropertyType property, Object value) {
+        properties.put(property, value);
     }
 
     /**
-     *  Looks for text in the cell that should be unicode, like &alpha; and provides the
-     *  unicode version of it.
+     * Looks for text in the cell that should be unicode, like &alpha; and provides the
+     * unicode version of it.
      *
-     *@param  cell  The cell to check for unicode values
-     *@return       translated to unicode
+     * @param cell The cell to check for unicode values
+     * @return translated to unicode
      */
     public static Cell translateUnicodeValues(Cell cell) {
 
@@ -850,22 +808,22 @@ public final class CellUtil {
     }
 
     static {
-        unicodeMappings = new UnicodeMapping[] {
-            um("alpha",   "\u03B1" ),
-            um("beta",    "\u03B2" ),
-            um("gamma",   "\u03B3" ),
-            um("delta",   "\u03B4" ),
-            um("epsilon", "\u03B5" ),
-            um("zeta",    "\u03B6" ),
-            um("eta",     "\u03B7" ),
-            um("theta",   "\u03B8" ),
-            um("iota",    "\u03B9" ),
-            um("kappa",   "\u03BA" ),
-            um("lambda",  "\u03BB" ),
-            um("mu",      "\u03BC" ),
-            um("nu",      "\u03BD" ),
-            um("xi",      "\u03BE" ),
-            um("omicron", "\u03BF" ),
+        unicodeMappings = new UnicodeMapping[]{
+                um("alpha", "\u03B1"),
+                um("beta", "\u03B2"),
+                um("gamma", "\u03B3"),
+                um("delta", "\u03B4"),
+                um("epsilon", "\u03B5"),
+                um("zeta", "\u03B6"),
+                um("eta", "\u03B7"),
+                um("theta", "\u03B8"),
+                um("iota", "\u03B9"),
+                um("kappa", "\u03BA"),
+                um("lambda", "\u03BB"),
+                um("mu", "\u03BC"),
+                um("nu", "\u03BD"),
+                um("xi", "\u03BE"),
+                um("omicron", "\u03BF"),
         };
     }
 

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -20,10 +20,31 @@ package org.apache.poi.ss.util;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.common.Duplicatable;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellCopyContext;
+import org.apache.poi.ss.usermodel.CellCopyPolicy;
+import org.apache.poi.ss.usermodel.CellPropertyCategory;
+import org.apache.poi.ss.usermodel.CellPropertyType;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Color;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
+import org.apache.poi.ss.usermodel.Hyperlink;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.VerticalAlignment;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.util.Beta;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Various utility functions that make working with a cells and rows easier. The various methods

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -58,145 +58,145 @@ public final class CellUtil {
     private static final Logger LOGGER = LogManager.getLogger(CellUtil.class);
 
     /**
-     * @deprecated Use {@link CellPropertyType#ALIGNMENT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#ALIGNMENT} instead.
      */
     @Deprecated
     public static final String ALIGNMENT = "alignment";
 
     /**
-     * @deprecated Use {@link CellPropertyType#BORDER_BOTTOM} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#BORDER_BOTTOM} instead.
      */
     @Deprecated
     public static final String BORDER_BOTTOM = "borderBottom";
 
     /**
-     * @deprecated Use {@link CellPropertyType#BORDER_LEFT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#BORDER_LEFT} instead.
      */
     @Deprecated
     public static final String BORDER_LEFT = "borderLeft";
 
     /**
-     * @deprecated Use {@link CellPropertyType#BORDER_RIGHT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#BORDER_RIGHT} instead.
      */
     @Deprecated
     public static final String BORDER_RIGHT = "borderRight";
 
     /**
-     * @deprecated Use {@link CellPropertyType#BORDER_TOP} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#BORDER_TOP} instead.
      */
     @Deprecated
     public static final String BORDER_TOP = "borderTop";
 
     /**
-     * @deprecated Use {@link CellPropertyType#BORDER_BOTTOM} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#BORDER_BOTTOM} instead.
      */
     @Deprecated
     public static final String BOTTOM_BORDER_COLOR = "bottomBorderColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#BOTTOM_BORDER_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#BOTTOM_BORDER_COLOR} instead.
      */
     @Deprecated
     public static final String LEFT_BORDER_COLOR = "leftBorderColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#RIGHT_BORDER_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#RIGHT_BORDER_COLOR} instead.
      */
     @Deprecated
     public static final String RIGHT_BORDER_COLOR = "rightBorderColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#TOP_BORDER_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#TOP_BORDER_COLOR} instead.
      */
     @Deprecated
     public static final String TOP_BORDER_COLOR = "topBorderColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#DATA_FORMAT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#DATA_FORMAT} instead.
      */
     @Deprecated
     public static final String DATA_FORMAT = "dataFormat";
 
     /**
-     * @deprecated Use {@link CellPropertyType#FILL_BACKGROUND_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#FILL_BACKGROUND_COLOR} instead.
      */
     @Deprecated
     public static final String FILL_BACKGROUND_COLOR = "fillBackgroundColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#FILL_FOREGROUND_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#FILL_FOREGROUND_COLOR} instead.
      */
     @Deprecated
     public static final String FILL_FOREGROUND_COLOR = "fillForegroundColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#FILL_BACKGROUND_COLOR_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#FILL_BACKGROUND_COLOR_COLOR} instead.
      */
     @Deprecated
     public static final String FILL_BACKGROUND_COLOR_COLOR = "fillBackgroundColorColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#FILL_FOREGROUND_COLOR_COLOR} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#FILL_FOREGROUND_COLOR_COLOR} instead.
      */
     @Deprecated
     public static final String FILL_FOREGROUND_COLOR_COLOR = "fillForegroundColorColor";
 
     /**
-     * @deprecated Use {@link CellPropertyType#FILL_PATTERN} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#FILL_PATTERN} instead.
      */
     @Deprecated
     public static final String FILL_PATTERN = "fillPattern";
 
     /**
-     * @deprecated Use {@link CellPropertyType#FONT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#FONT} instead.
      */
     @Deprecated
     public static final String FONT = "font";
 
     /**
-     * @deprecated Use {@link CellPropertyType#HIDDEN} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#HIDDEN} instead.
      */
     @Deprecated
     public static final String HIDDEN = "hidden";
 
     /**
-     * @deprecated Use {@link CellPropertyType#INDENTION} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#INDENTION} instead.
      */
     @Deprecated
     public static final String INDENTION = "indention";
 
     /**
-     * @deprecated Use {@link CellPropertyType#LOCKED} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#LOCKED} instead.
      */
     @Deprecated
     public static final String LOCKED = "locked";
 
     /**
-     * @deprecated Use {@link CellPropertyType#ROTATION} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#ROTATION} instead.
      */
     @Deprecated
     public static final String ROTATION = "rotation";
 
     /**
-     * @deprecated Use {@link CellPropertyType#VERTICAL_ALIGNMENT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#VERTICAL_ALIGNMENT} instead.
      */
     @Deprecated
     public static final String VERTICAL_ALIGNMENT = "verticalAlignment";
 
     /**
-     * @deprecated Use {@link CellPropertyType#WRAP_TEXT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#WRAP_TEXT} instead.
      */
     @Deprecated
     public static final String WRAP_TEXT = "wrapText";
 
     /**
-     * @deprecated Use {@link CellPropertyType#SHRINK_TO_FIT} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#SHRINK_TO_FIT} instead.
      */
     @Deprecated
     public static final String SHRINK_TO_FIT = "shrinkToFit";
 
     /**
-     * @deprecated Use {@link CellPropertyType#QUOTE_PREFIXED} instead.
+     * @deprecated as of POI 5.3.1. Use {@link CellPropertyType#QUOTE_PREFIXED} instead.
      */
     @Deprecated
     public static final String QUOTE_PREFIXED = "quotePrefixed";
@@ -500,7 +500,7 @@ public final class CellUtil {
      * @param cell The cell to change the style of
      * @param properties The properties to be added to a cell style, as {property: propertyValue}.
      * @since POI 3.14 beta 2
-     * @deprecated See {@link #setCellStylePropertiesEnum(Cell, Map)}
+     * @deprecated as of POI 5.3.1. See {@link #setCellStylePropertiesEnum(Cell, Map)}
      */
     @Deprecated
     public static void setCellStyleProperties(Cell cell, Map<String, Object> properties) {
@@ -532,7 +532,7 @@ public final class CellUtil {
      *
      * @param cell       The cell to change the style of
      * @param properties The properties to be added to a cell style, as {property: propertyValue}.
-     * @since POI 3.14 beta 2
+     * @since POI 5.3.1
      */
     public static void setCellStylePropertiesEnum(Cell cell, Map<CellPropertyType, Object> properties) {
         setCellStyleProperties(cell, properties, false);
@@ -617,6 +617,8 @@ public final class CellUtil {
      * @param cell The cell that is to be changed.
      * @param property The name of the property that is to be changed.
      * @param propertyValue The value of the property that is to be changed.
+     *
+     * @since POI 5.3.1
      */
     public static void setCellStyleProperty(Cell cell, CellPropertyType property, Object propertyValue) {
         boolean disableNullColorCheck = false;
@@ -653,7 +655,7 @@ public final class CellUtil {
      * @param cell The cell that is to be changed.
      * @param propertyName The name of the property that is to be changed.
      * @param propertyValue The value of the property that is to be changed.
-     * @deprecated see {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
+     * @deprecated as of POI 5.3.1. See {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
      */
     @Deprecated
     public static void setCellStyleProperty(Cell cell, String propertyName, Object propertyValue) {

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -36,6 +36,178 @@ public final class CellUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(CellUtil.class);
 
+    /**
+     * @deprecated Use {@link CellPropertyType#ALIGNMENT} instead.
+     */
+    @Deprecated
+    public static final String ALIGNMENT = "alignment";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#BORDER_BOTTOM} instead.
+     */
+    @Deprecated
+    public static final String BORDER_BOTTOM = "borderBottom";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#BORDER_LEFT} instead.
+     */
+    @Deprecated
+    public static final String BORDER_LEFT = "borderLeft";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#BORDER_RIGHT} instead.
+     */
+    @Deprecated
+    public static final String BORDER_RIGHT = "borderRight";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#BORDER_TOP} instead.
+     */
+    @Deprecated
+    public static final String BORDER_TOP = "borderTop";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#BORDER_BOTTOM} instead.
+     */
+    @Deprecated
+    public static final String BOTTOM_BORDER_COLOR = "bottomBorderColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#BOTTOM_BORDER_COLOR} instead.
+     */
+    @Deprecated
+    public static final String LEFT_BORDER_COLOR = "leftBorderColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#RIGHT_BORDER_COLOR} instead.
+     */
+    @Deprecated
+    public static final String RIGHT_BORDER_COLOR = "rightBorderColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#TOP_BORDER_COLOR} instead.
+     */
+    @Deprecated
+    public static final String TOP_BORDER_COLOR = "topBorderColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#DATA_FORMAT} instead.
+     */
+    @Deprecated
+    public static final String DATA_FORMAT = "dataFormat";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#FILL_BACKGROUND_COLOR} instead.
+     */
+    @Deprecated
+    public static final String FILL_BACKGROUND_COLOR = "fillBackgroundColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#FILL_FOREGROUND_COLOR} instead.
+     */
+    @Deprecated
+    public static final String FILL_FOREGROUND_COLOR = "fillForegroundColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#FILL_BACKGROUND_COLOR_COLOR} instead.
+     */
+    @Deprecated
+    public static final String FILL_BACKGROUND_COLOR_COLOR = "fillBackgroundColorColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#FILL_FOREGROUND_COLOR_COLOR} instead.
+     */
+    @Deprecated
+    public static final String FILL_FOREGROUND_COLOR_COLOR = "fillForegroundColorColor";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#FILL_PATTERN} instead.
+     */
+    @Deprecated
+    public static final String FILL_PATTERN = "fillPattern";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#FONT} instead.
+     */
+    @Deprecated
+    public static final String FONT = "font";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#HIDDEN} instead.
+     */
+    @Deprecated
+    public static final String HIDDEN = "hidden";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#INDENTION} instead.
+     */
+    @Deprecated
+    public static final String INDENTION = "indention";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#LOCKED} instead.
+     */
+    @Deprecated
+    public static final String LOCKED = "locked";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#ROTATION} instead.
+     */
+    @Deprecated
+    public static final String ROTATION = "rotation";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#VERTICAL_ALIGNMENT} instead.
+     */
+    @Deprecated
+    public static final String VERTICAL_ALIGNMENT = "verticalAlignment";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#WRAP_TEXT} instead.
+     */
+    @Deprecated
+    public static final String WRAP_TEXT = "wrapText";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#SHRINK_TO_FIT} instead.
+     */
+    @Deprecated
+    public static final String SHRINK_TO_FIT = "shrinkToFit";
+
+    /**
+     * @deprecated Use {@link CellPropertyType#QUOTE_PREFIXED} instead.
+     */
+    @Deprecated
+    public static final String QUOTE_PREFIXED = "quotePrefixed";
+
+    // FIXME Must be deleted along with string constants
+    static final Map<String, CellPropertyType> namePropertyMap = new HashMap<>();
+
+    static {
+        namePropertyMap.put(ALIGNMENT, CellPropertyType.ALIGNMENT);
+        namePropertyMap.put(BORDER_BOTTOM, CellPropertyType.BORDER_BOTTOM);
+        namePropertyMap.put(BORDER_LEFT, CellPropertyType.BORDER_LEFT);
+        namePropertyMap.put(BORDER_RIGHT, CellPropertyType.BORDER_RIGHT);
+        namePropertyMap.put(BORDER_TOP, CellPropertyType.BORDER_TOP);
+        namePropertyMap.put(BOTTOM_BORDER_COLOR, CellPropertyType.BOTTOM_BORDER_COLOR);
+        namePropertyMap.put(LEFT_BORDER_COLOR, CellPropertyType.LEFT_BORDER_COLOR);
+        namePropertyMap.put(RIGHT_BORDER_COLOR, CellPropertyType.RIGHT_BORDER_COLOR);
+        namePropertyMap.put(TOP_BORDER_COLOR, CellPropertyType.TOP_BORDER_COLOR);
+        namePropertyMap.put(FILL_BACKGROUND_COLOR, CellPropertyType.FILL_BACKGROUND_COLOR);
+        namePropertyMap.put(FILL_FOREGROUND_COLOR, CellPropertyType.FILL_FOREGROUND_COLOR);
+        namePropertyMap.put(FILL_BACKGROUND_COLOR_COLOR, CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
+        namePropertyMap.put(FILL_FOREGROUND_COLOR_COLOR, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
+        namePropertyMap.put(FILL_PATTERN, CellPropertyType.FILL_PATTERN);
+        namePropertyMap.put(FONT, CellPropertyType.FONT);
+        namePropertyMap.put(HIDDEN, CellPropertyType.HIDDEN);
+        namePropertyMap.put(INDENTION, CellPropertyType.INDENTION);
+        namePropertyMap.put(LOCKED, CellPropertyType.LOCKED);
+        namePropertyMap.put(ROTATION, CellPropertyType.ROTATION);
+        namePropertyMap.put(VERTICAL_ALIGNMENT, CellPropertyType.VERTICAL_ALIGNMENT);
+        namePropertyMap.put(SHRINK_TO_FIT, CellPropertyType.SHRINK_TO_FIT);
+        namePropertyMap.put(QUOTE_PREFIXED, CellPropertyType.QUOTE_PREFIXED);
+    }
+
     private static final UnicodeMapping[] unicodeMappings;
 
     private static final class UnicodeMapping {
@@ -303,10 +475,43 @@ public final class CellUtil {
      * </p>
      *
      * @param cell       The cell to change the style of
+     * @param properties The properties to be added to a cell style, as {property (String, CellPropertyType): propertyValue}.
+     * @since POI 3.14 beta 2
+     * @deprecated See {@link #setCellStylePropertiesEnum(Cell, Map)}
+     */
+    @Deprecated
+    public static void setCellStyleProperties(Cell cell, Map<String, Object> properties) {
+        Map<CellPropertyType, Object> strPropMap = new HashMap<>(properties.size());
+        properties.forEach((k, v) -> strPropMap.put(namePropertyMap.get(k), v));
+        setCellStyleProperties(cell, strPropMap, false);
+    }
+
+    /**
+     * <p>This method attempts to find an existing CellStyle that matches the {@code cell}'s
+     * current style plus styles properties in {@code properties}. A new style is created if the
+     * workbook does not contain a matching style.</p>
+     *
+     * <p>Modifies the cell style of {@code cell} without affecting other cells that use the
+     * same style.</p>
+     *
+     * <p>This is necessary because Excel has an upper limit on the number of styles that it supports.</p>
+     *
+     * <p>This function is more efficient than multiple calls to
+     * {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
+     * if adding multiple cell styles.</p>
+     *
+     * <p>For performance reasons, if this is the only cell in a workbook that uses a cell style,
+     * this method does NOT remove the old style from the workbook.
+     * <!-- NOT IMPLEMENTED: Unused styles should be
+     * pruned from the workbook with [@link #removeUnusedCellStyles(Workbook)] or
+     * [@link #removeStyleFromWorkbookIfUnused(CellStyle, Workbook)]. -->
+     * </p>
+     *
+     * @param cell       The cell to change the style of
      * @param properties The properties to be added to a cell style, as {property: propertyValue}.
      * @since POI 3.14 beta 2
      */
-    public static void setCellStyleProperties(Cell cell, Map<CellPropertyType, Object> properties) {
+    public static void setCellStylePropertiesEnum(Cell cell, Map<CellPropertyType, Object> properties) {
         setCellStyleProperties(cell, properties, false);
     }
 
@@ -383,7 +588,7 @@ public final class CellUtil {
      * same style.</p>
      *
      * <p>If setting more than one cell style property on a cell, use
-     * {@link #setCellStyleProperties(Cell, Map)},
+     * {@link #setCellStylePropertiesEnum(Cell, Map)},
      * which is faster and does not add unnecessary intermediate CellStyles to the workbook.</p>
      *
      * @param cell          The cell that is to be changed.
@@ -407,6 +612,29 @@ public final class CellUtil {
             propMap = Collections.singletonMap(property, propertyValue);
         }
         setCellStyleProperties(cell, propMap, disableNullColorCheck);
+    }
+
+    /**
+     * <p>This method attempts to find an existing CellStyle that matches the {@code cell}'s
+     * current style plus a single style property {@code propertyName} with value
+     * {@code propertyValue}.
+     * A new style is created if the workbook does not contain a matching style.</p>
+     *
+     * <p>Modifies the cell style of {@code cell} without affecting other cells that use the
+     * same style.</p>
+     *
+     * <p>If setting more than one cell style property on a cell, use
+     * {@link #setCellStylePropertiesEnum(Cell, Map)},
+     * which is faster and does not add unnecessary intermediate CellStyles to the workbook.</p>
+     *
+     * @param cell          The cell that is to be changed.
+     * @param propertyName  The name of the property that is to be changed.
+     * @param propertyValue The value of the property that is to be changed.
+     * @deprecated see {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
+     */
+    @Deprecated
+    public static void setCellStyleProperty(Cell cell, String propertyName, Object propertyValue) {
+        setCellStyleProperty(cell, namePropertyMap.get(propertyName), propertyValue);
     }
 
     /**
@@ -488,8 +716,8 @@ public final class CellUtil {
     /**
      * Puts the value associated with the given key from the source map into the destination map based on the key type.
      *
-     * @param key The type of the key.
-     * @param src The source map of properties.
+     * @param key  The type of the key.
+     * @param src  The source map of properties.
      * @param dest The destination map of properties.
      */
     private static void putByType(CellPropertyType key, final Map<CellPropertyType, Object> src, Map<CellPropertyType, Object> dest) {

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -425,7 +425,7 @@ public final class CellUtil {
      * by multiple cells. Instead, this method will search for existing CellStyles
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
-     *
+     * </p>
      * @param cell the cell to set the alignment for
      * @param align the horizontal alignment to use.
      *

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -250,7 +250,7 @@ public final class CellUtil {
      * Get a row from the spreadsheet, and create it if it doesn't exist.
      *
      * @param rowIndex The 0 based row number
-     * @param sheet    The sheet that the row is part of.
+     * @param sheet The sheet that the row is part of.
      * @return The row indicated by the rowCounter
      */
     public static Row getRow(int rowIndex, Sheet sheet) {
@@ -265,7 +265,7 @@ public final class CellUtil {
     /**
      * Get a specific cell from a row. If the cell doesn't exist, then create it.
      *
-     * @param row         The row that the cell is part of
+     * @param row The row that the cell is part of
      * @param columnIndex The column index that the cell is in.
      * @return The cell indicated by the column.
      */
@@ -282,11 +282,11 @@ public final class CellUtil {
     /**
      * Creates a cell, gives it a value, and applies a style if provided
      *
-     * @param row    the row to create the cell in
-     * @param column the column index to create the cell in
-     * @param value  The value of the cell
-     * @param style  If the style is not null, then set
-     * @return A new Cell
+     * @param  row     the row to create the cell in
+     * @param  column  the column index to create the cell in
+     * @param  value   The value of the cell
+     * @param  style   If the style is not null, then set
+     * @return         A new Cell
      */
     public static Cell createCell(Row row, int column, String value, CellStyle style) {
         Cell cell = getCell(row, column);
@@ -303,10 +303,10 @@ public final class CellUtil {
     /**
      * Create a cell, and give it a value.
      *
-     * @param row    the row to create the cell in
-     * @param column the column index to create the cell in
-     * @param value  The value of the cell
-     * @return A new Cell.
+     *@param  row     the row to create the cell in
+     *@param  column  the column index to create the cell in
+     *@param  value   The value of the cell
+     *@return         A new Cell.
      */
     public static Cell createCell(Row row, int column, String value) {
         return createCell(row, column, value, null);
@@ -315,19 +315,19 @@ public final class CellUtil {
     /**
      * Copy cell value, formula and style, from srcCell per cell copy policy
      * If srcCell is null, clears the cell value and cell style per cell copy policy.
-     * <p>
+     *
      * Note that if you are copying from a source cell from a different type of then you may need to disable style copying
      * in the {@link CellCopyPolicy} (HSSF styles are not compatible with XSSF styles, for instance).
-     * <p>
+     *
      * This does not shift references in formulas. The <code>copyRowFrom</code> method on <code>XSSFRow</code>
      * and <code>HSSFRow</code> does attempt to shift references in formulas.
      *
-     * @param srcCell  The cell to take value, formula and style from
+     * @param srcCell The cell to take value, formula and style from
      * @param destCell The cell to copy to
-     * @param policy   The policy for copying the information, see {@link CellCopyPolicy}
-     * @param context  The context for copying, see {@link CellCopyContext}
+     * @param policy The policy for copying the information, see {@link CellCopyPolicy}
+     * @param context The context for copying, see {@link CellCopyContext}
      * @throws IllegalArgumentException if copy cell style and srcCell is from a different workbook
-     * @throws IllegalStateException    if srcCell hyperlink is not an instance of {@link Duplicatable}
+     * @throws IllegalStateException if srcCell hyperlink is not an instance of {@link Duplicatable}
      * @since POI 5.2.0
      */
     @Beta
@@ -426,8 +426,9 @@ public final class CellUtil {
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
      *
-     * @param cell  the cell to set the alignment for
+     * @param cell the cell to set the alignment for
      * @param align the horizontal alignment to use.
+     *
      * @see HorizontalAlignment for alignment options
      * @since POI 3.15 beta 3
      */
@@ -437,15 +438,16 @@ public final class CellUtil {
 
     /**
      * Take a cell, and vertically align it.
-     * <p>
+     *
      * This is superior to cell.getCellStyle().setVerticalAlignment(align) because
      * this method will not modify the CellStyle object that may be referenced
      * by multiple cells. Instead, this method will search for existing CellStyles
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
      *
-     * @param cell  the cell to set the alignment for
+     * @param cell the cell to set the alignment for
      * @param align the vertical alignment to use.
+     *
      * @see VerticalAlignment for alignment options
      * @since POI 3.15 beta 3
      */
@@ -495,8 +497,8 @@ public final class CellUtil {
      * [@link #removeStyleFromWorkbookIfUnused(CellStyle, Workbook)]. -->
      * </p>
      *
-     * @param cell       The cell to change the style of
-     * @param properties The properties to be added to a cell style, as {property (String, CellPropertyType): propertyValue}.
+     * @param cell The cell to change the style of
+     * @param properties The properties to be added to a cell style, as {property: propertyValue}.
      * @since POI 3.14 beta 2
      * @deprecated See {@link #setCellStylePropertiesEnum(Cell, Map)}
      */
@@ -612,8 +614,8 @@ public final class CellUtil {
      * {@link #setCellStylePropertiesEnum(Cell, Map)},
      * which is faster and does not add unnecessary intermediate CellStyles to the workbook.</p>
      *
-     * @param cell          The cell that is to be changed.
-     * @param property      The property that is to be changed.
+     * @param cell The cell that is to be changed.
+     * @param property The name of the property that is to be changed.
      * @param propertyValue The value of the property that is to be changed.
      */
     public static void setCellStyleProperty(Cell cell, CellPropertyType property, Object propertyValue) {
@@ -648,8 +650,8 @@ public final class CellUtil {
      * {@link #setCellStylePropertiesEnum(Cell, Map)},
      * which is faster and does not add unnecessary intermediate CellStyles to the workbook.</p>
      *
-     * @param cell          The cell that is to be changed.
-     * @param propertyName  The name of the property that is to be changed.
+     * @param cell The cell that is to be changed.
+     * @param propertyName The name of the property that is to be changed.
      * @param propertyValue The value of the property that is to be changed.
      * @deprecated see {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
      */
@@ -703,7 +705,7 @@ public final class CellUtil {
      * Copies the entries in src to dest, using the preferential data type
      * so that maps can be compared for equality
      *
-     * @param src  the property map to copy from (read-only)
+     * @param src the property map to copy from (read-only)
      * @param dest the property map to copy into
      * @since POI 3.15 beta 3
      */
@@ -761,8 +763,8 @@ public final class CellUtil {
     /**
      * Sets the format properties of the given style based on the given map.
      *
-     * @param style      cell style
-     * @param workbook   parent workbook
+     * @param style cell style
+     * @param workbook parent workbook
      * @param properties map of format properties (CellPropertyType -> Object)
      * @see #getFormatProperties(CellStyle)
      */
@@ -821,9 +823,9 @@ public final class CellUtil {
      * Utility method that returns the named short value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return zero if the property does not exist, or is not a {@link Short}
-     * otherwise the property value
+     *         otherwise the property value
      */
     private static short getShort(Map<CellPropertyType, Object> properties, CellPropertyType property) {
         Object value = properties.get(property);
@@ -848,9 +850,9 @@ public final class CellUtil {
      * Utility method that returns the named Color value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return null if the property does not exist, or is not a {@link Color}
-     * otherwise the property value
+     *         otherwise the property value
      */
     private static Color getColor(Map<CellPropertyType, Object> properties, CellPropertyType property) {
         Object value = properties.get(property);
@@ -865,9 +867,9 @@ public final class CellUtil {
      * Utility method that returns the named int value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return zero if the property does not exist, or is not a {@link Integer}
-     * otherwise the property value
+     *         otherwise the property value
      */
     private static int getInt(Map<CellPropertyType, Object> properties, CellPropertyType property) {
         Object value = properties.get(property);
@@ -881,7 +883,7 @@ public final class CellUtil {
      * Utility method that returns the named BorderStyle value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return Border style if set, otherwise {@link BorderStyle#NONE}
      */
     private static BorderStyle getBorderStyle(Map<CellPropertyType, Object> properties, CellPropertyType property) {
@@ -907,7 +909,7 @@ public final class CellUtil {
      * Utility method that returns the named FillPatternType value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return FillPatternType style if set, otherwise {@link FillPatternType#NO_FILL}
      * @since POI 3.15 beta 3
      */
@@ -934,7 +936,7 @@ public final class CellUtil {
      * Utility method that returns the named HorizontalAlignment value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return HorizontalAlignment style if set, otherwise {@link HorizontalAlignment#GENERAL}
      * @since POI 3.15 beta 3
      */
@@ -961,7 +963,7 @@ public final class CellUtil {
      * Utility method that returns the named VerticalAlignment value from the given map.
      *
      * @param properties map of named properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return VerticalAlignment style if set, otherwise {@link VerticalAlignment#BOTTOM}
      * @since POI 3.15 beta 3
      */
@@ -988,9 +990,9 @@ public final class CellUtil {
      * Utility method that returns the named boolean value from the given map.
      *
      * @param properties map of properties (CellPropertyType -> Object)
-     * @param property   property
+     * @param property property
      * @return false if the property does not exist, or is not a {@link Boolean},
-     * true otherwise
+     *         true otherwise
      */
     private static boolean getBoolean(Map<CellPropertyType, Object> properties, CellPropertyType property) {
         Object value = properties.get(property);
@@ -1004,20 +1006,20 @@ public final class CellUtil {
     /**
      * Utility method that puts the given value to the given map.
      *
-     * @param properties map of properties (String -> Object)
-     * @param property   property
-     * @param value      property value
+     * @param properties map of properties (CellPropertyType -> Object)
+     * @param property property
+     * @param value property value
      */
     private static void put(Map<CellPropertyType, Object> properties, CellPropertyType property, Object value) {
         properties.put(property, value);
     }
 
     /**
-     * Looks for text in the cell that should be unicode, like &alpha; and provides the
-     * unicode version of it.
+     *  Looks for text in the cell that should be unicode, like &alpha; and provides the
+     *  unicode version of it.
      *
-     * @param cell The cell to check for unicode values
-     * @return translated to unicode
+     *@param  cell  The cell to check for unicode values
+     *@return       translated to unicode
      */
     public static Cell translateUnicodeValues(Cell cell) {
 
@@ -1040,24 +1042,25 @@ public final class CellUtil {
     }
 
     static {
-        unicodeMappings = new UnicodeMapping[]{
-                um("alpha", "\u03B1"),
-                um("beta", "\u03B2"),
-                um("gamma", "\u03B3"),
-                um("delta", "\u03B4"),
-                um("epsilon", "\u03B5"),
-                um("zeta", "\u03B6"),
-                um("eta", "\u03B7"),
-                um("theta", "\u03B8"),
-                um("iota", "\u03B9"),
-                um("kappa", "\u03BA"),
-                um("lambda", "\u03BB"),
-                um("mu", "\u03BC"),
-                um("nu", "\u03BD"),
-                um("xi", "\u03BE"),
-                um("omicron", "\u03BF"),
+        unicodeMappings = new UnicodeMapping[] {
+                um("alpha",   "\u03B1" ),
+                um("beta",    "\u03B2" ),
+                um("gamma",   "\u03B3" ),
+                um("delta",   "\u03B4" ),
+                um("epsilon", "\u03B5" ),
+                um("zeta",    "\u03B6" ),
+                um("eta",     "\u03B7" ),
+                um("theta",   "\u03B8" ),
+                um("iota",    "\u03B9" ),
+                um("kappa",   "\u03BA" ),
+                um("lambda",  "\u03BB" ),
+                um("mu",      "\u03BC" ),
+                um("nu",      "\u03BD" ),
+                um("xi",      "\u03BE" ),
+                um("omicron", "\u03BF" ),
         };
     }
+
 
     private static UnicodeMapping um(String entityName, String resolvedValue) {
         return new UnicodeMapping(entityName, resolvedValue);

--- a/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellUtil.java
@@ -17,20 +17,13 @@
 
 package org.apache.poi.ss.util;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.common.Duplicatable;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.util.Beta;
+
+import java.util.*;
 
 /**
  * Various utility functions that make working with a cells and rows easier. The various methods
@@ -42,74 +35,6 @@ import org.apache.poi.util.Beta;
 public final class CellUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(CellUtil.class);
-
-    // FIXME: Move these constants into an enum
-    public static final String ALIGNMENT = "alignment";
-    public static final String BORDER_BOTTOM = "borderBottom";
-    public static final String BORDER_LEFT = "borderLeft";
-    public static final String BORDER_RIGHT = "borderRight";
-    public static final String BORDER_TOP = "borderTop";
-    public static final String BOTTOM_BORDER_COLOR = "bottomBorderColor";
-    public static final String LEFT_BORDER_COLOR = "leftBorderColor";
-    public static final String RIGHT_BORDER_COLOR = "rightBorderColor";
-    public static final String TOP_BORDER_COLOR = "topBorderColor";
-    public static final String DATA_FORMAT = "dataFormat";
-    public static final String FILL_BACKGROUND_COLOR = "fillBackgroundColor";
-    public static final String FILL_FOREGROUND_COLOR = "fillForegroundColor";
-    
-    public static final String FILL_BACKGROUND_COLOR_COLOR = "fillBackgroundColorColor";
-    public static final String FILL_FOREGROUND_COLOR_COLOR = "fillForegroundColorColor";
-
-    public static final String FILL_PATTERN = "fillPattern";
-    public static final String FONT = "font";
-    public static final String HIDDEN = "hidden";
-    public static final String INDENTION = "indention";
-    public static final String LOCKED = "locked";
-    public static final String ROTATION = "rotation";
-    public static final String VERTICAL_ALIGNMENT = "verticalAlignment";
-    public static final String WRAP_TEXT = "wrapText";
-    public static final String SHRINK_TO_FIT = "shrinkToFit";
-    public static final String QUOTE_PREFIXED = "quotePrefixed";
-
-    private static final Set<String> shortValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    BOTTOM_BORDER_COLOR,
-                    LEFT_BORDER_COLOR,
-                    RIGHT_BORDER_COLOR,
-                    TOP_BORDER_COLOR,
-                    FILL_FOREGROUND_COLOR,
-                    FILL_BACKGROUND_COLOR,
-                    INDENTION,
-                    DATA_FORMAT,
-                    ROTATION
-            )));
-            
-    private static final Set<String> colorValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    FILL_FOREGROUND_COLOR_COLOR,
-                    FILL_BACKGROUND_COLOR_COLOR
-            )));
-
-    private static final Set<String> intValues = Collections.unmodifiableSet(
-            new HashSet<>(Collections.singletonList(
-                FONT
-            )));
-    private static final Set<String> booleanValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    LOCKED,
-                    HIDDEN,
-                    WRAP_TEXT,
-                    SHRINK_TO_FIT,
-                    QUOTE_PREFIXED
-            )));
-    private static final Set<String> borderTypeValues = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
-                    BORDER_BOTTOM,
-                    BORDER_LEFT,
-                    BORDER_RIGHT,
-                    BORDER_TOP
-            )));
-
 
     private static final UnicodeMapping[] unicodeMappings;
 
@@ -132,7 +57,7 @@ public final class CellUtil {
      * Get a row from the spreadsheet, and create it if it doesn't exist.
      *
      * @param rowIndex The 0 based row number
-     * @param sheet The sheet that the row is part of.
+     * @param sheet    The sheet that the row is part of.
      * @return The row indicated by the rowCounter
      */
     public static Row getRow(int rowIndex, Sheet sheet) {
@@ -147,7 +72,7 @@ public final class CellUtil {
     /**
      * Get a specific cell from a row. If the cell doesn't exist, then create it.
      *
-     * @param row The row that the cell is part of
+     * @param row         The row that the cell is part of
      * @param columnIndex The column index that the cell is in.
      * @return The cell indicated by the column.
      */
@@ -164,11 +89,11 @@ public final class CellUtil {
     /**
      * Creates a cell, gives it a value, and applies a style if provided
      *
-     * @param  row     the row to create the cell in
-     * @param  column  the column index to create the cell in
-     * @param  value   The value of the cell
-     * @param  style   If the style is not null, then set
-     * @return         A new Cell
+     * @param row    the row to create the cell in
+     * @param column the column index to create the cell in
+     * @param value  The value of the cell
+     * @param style  If the style is not null, then set
+     * @return A new Cell
      */
     public static Cell createCell(Row row, int column, String value, CellStyle style) {
         Cell cell = getCell(row, column);
@@ -185,10 +110,10 @@ public final class CellUtil {
     /**
      * Create a cell, and give it a value.
      *
-     *@param  row     the row to create the cell in
-     *@param  column  the column index to create the cell in
-     *@param  value   The value of the cell
-     *@return         A new Cell.
+     * @param row    the row to create the cell in
+     * @param column the column index to create the cell in
+     * @param value  The value of the cell
+     * @return A new Cell.
      */
     public static Cell createCell(Row row, int column, String value) {
         return createCell(row, column, value, null);
@@ -197,19 +122,19 @@ public final class CellUtil {
     /**
      * Copy cell value, formula and style, from srcCell per cell copy policy
      * If srcCell is null, clears the cell value and cell style per cell copy policy.
-     *
+     * <p>
      * Note that if you are copying from a source cell from a different type of then you may need to disable style copying
      * in the {@link CellCopyPolicy} (HSSF styles are not compatible with XSSF styles, for instance).
-     *
+     * <p>
      * This does not shift references in formulas. The <code>copyRowFrom</code> method on <code>XSSFRow</code>
      * and <code>HSSFRow</code> does attempt to shift references in formulas.
      *
-     * @param srcCell The cell to take value, formula and style from
+     * @param srcCell  The cell to take value, formula and style from
      * @param destCell The cell to copy to
-     * @param policy The policy for copying the information, see {@link CellCopyPolicy}
-     * @param context The context for copying, see {@link CellCopyContext}
+     * @param policy   The policy for copying the information, see {@link CellCopyPolicy}
+     * @param context  The context for copying, see {@link CellCopyContext}
      * @throws IllegalArgumentException if copy cell style and srcCell is from a different workbook
-     * @throws IllegalStateException if srcCell hyperlink is not an instance of {@link Duplicatable}
+     * @throws IllegalStateException    if srcCell hyperlink is not an instance of {@link Duplicatable}
      * @since POI 5.2.0
      */
     @Beta
@@ -228,8 +153,7 @@ public final class CellUtil {
                         // DataFormat is not copied unless policy.isCopyCellStyle is true
                         if (DateUtil.isCellDateFormatted(srcCell)) {
                             destCell.setCellValue(srcCell.getDateCellValue());
-                        }
-                        else {
+                        } else {
                             destCell.setCellValue(srcCell.getNumericCellValue());
                         }
                         break;
@@ -280,7 +204,7 @@ public final class CellUtil {
             // if srcCell doesn't have a hyperlink and destCell has a hyperlink, don't clear destCell's hyperlink
             if (srcHyperlink != null) {
                 if (srcHyperlink instanceof Duplicatable) {
-                    Hyperlink newHyperlink = (Hyperlink)((Duplicatable)srcHyperlink).copy();
+                    Hyperlink newHyperlink = (Hyperlink) ((Duplicatable) srcHyperlink).copy();
                     destCell.setHyperlink(newHyperlink);
                 } else {
                     throw new IllegalStateException("srcCell hyperlink is not an instance of Duplicatable");
@@ -292,7 +216,7 @@ public final class CellUtil {
             if (srcHyperlink == null) {
                 destCell.setHyperlink(null);
             } else if (srcHyperlink instanceof Duplicatable) {
-                Hyperlink newHyperlink = (Hyperlink)((Duplicatable)srcHyperlink).copy();
+                Hyperlink newHyperlink = (Hyperlink) ((Duplicatable) srcHyperlink).copy();
                 destCell.setHyperlink(newHyperlink);
             } else {
                 throw new IllegalStateException("srcCell hyperlink is not an instance of Duplicatable");
@@ -302,40 +226,38 @@ public final class CellUtil {
 
     /**
      * Take a cell, and align it.
-     *
+     * <p>
      * This is superior to cell.getCellStyle().setAlignment(align) because
      * this method will not modify the CellStyle object that may be referenced
      * by multiple cells. Instead, this method will search for existing CellStyles
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
      *
-     * @param cell the cell to set the alignment for
+     * @param cell  the cell to set the alignment for
      * @param align the horizontal alignment to use.
-     *
      * @see HorizontalAlignment for alignment options
      * @since POI 3.15 beta 3
      */
     public static void setAlignment(Cell cell, HorizontalAlignment align) {
-        setCellStyleProperty(cell, ALIGNMENT, align);
+        setCellStyleProperty(cell, CellPropertyType.ALIGNMENT, align);
     }
 
     /**
      * Take a cell, and vertically align it.
-     *
+     * <p>
      * This is superior to cell.getCellStyle().setVerticalAlignment(align) because
      * this method will not modify the CellStyle object that may be referenced
      * by multiple cells. Instead, this method will search for existing CellStyles
      * that match the desired CellStyle, creating a new CellStyle with the desired
      * style if no match exists.
      *
-     * @param cell the cell to set the alignment for
+     * @param cell  the cell to set the alignment for
      * @param align the vertical alignment to use.
-     *
      * @see VerticalAlignment for alignment options
      * @since POI 3.15 beta 3
      */
     public static void setVerticalAlignment(Cell cell, VerticalAlignment align) {
-        setCellStyleProperty(cell, VERTICAL_ALIGNMENT, align);
+        setCellStyleProperty(cell, CellPropertyType.VERTICAL_ALIGNMENT, align);
     }
 
     /**
@@ -356,7 +278,7 @@ public final class CellUtil {
         // Check if cell belongs to workbook
         // (checked in setCellStyleProperty)
 
-        setCellStyleProperty(cell, FONT, fontIndex);
+        setCellStyleProperty(cell, CellPropertyType.FONT, fontIndex);
     }
 
     /**
@@ -370,7 +292,7 @@ public final class CellUtil {
      * <p>This is necessary because Excel has an upper limit on the number of styles that it supports.</p>
      *
      * <p>This function is more efficient than multiple calls to
-     * {@link #setCellStyleProperty(Cell, String, Object)}
+     * {@link #setCellStyleProperty(Cell, CellPropertyType, Object)}
      * if adding multiple cell styles.</p>
      *
      * <p>For performance reasons, if this is the only cell in a workbook that uses a cell style,
@@ -380,32 +302,32 @@ public final class CellUtil {
      * [@link #removeStyleFromWorkbookIfUnused(CellStyle, Workbook)]. -->
      * </p>
      *
-     * @param cell The cell to change the style of
-     * @param properties The properties to be added to a cell style, as {propertyName: propertyValue}.
+     * @param cell       The cell to change the style of
+     * @param properties The properties to be added to a cell style, as {property: propertyValue}.
      * @since POI 3.14 beta 2
      */
-    public static void setCellStyleProperties(Cell cell, Map<String, Object> properties) {
+    public static void setCellStyleProperties(Cell cell, Map<CellPropertyType, Object> properties) {
         setCellStyleProperties(cell, properties, false);
     }
 
-    private static void setCellStyleProperties(final Cell cell, final Map<String, Object> properties,
+    private static void setCellStyleProperties(final Cell cell, final Map<CellPropertyType, Object> properties,
                                                final boolean disableNullColorCheck) {
         Workbook workbook = cell.getSheet().getWorkbook();
         CellStyle originalStyle = cell.getCellStyle();
 
         CellStyle newStyle = null;
-        Map<String, Object> values = getFormatProperties(originalStyle);
-        if (properties.containsKey(FILL_FOREGROUND_COLOR_COLOR) && properties.get(FILL_FOREGROUND_COLOR_COLOR) == null) {
-            values.remove(FILL_FOREGROUND_COLOR);
+        Map<CellPropertyType, Object> values = getFormatProperties(originalStyle);
+        if (properties.containsKey(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR) && properties.get(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR) == null) {
+            values.remove(CellPropertyType.FILL_FOREGROUND_COLOR);
         }
-        if (properties.containsKey(FILL_FOREGROUND_COLOR) && !properties.containsKey(FILL_FOREGROUND_COLOR_COLOR)) {
-            values.remove(FILL_FOREGROUND_COLOR_COLOR);
+        if (properties.containsKey(CellPropertyType.FILL_FOREGROUND_COLOR) && !properties.containsKey(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR)) {
+            values.remove(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
         }
-        if (properties.containsKey(FILL_BACKGROUND_COLOR_COLOR) && properties.get(FILL_BACKGROUND_COLOR_COLOR) == null) {
-            values.remove(FILL_BACKGROUND_COLOR);
+        if (properties.containsKey(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR) && properties.get(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR) == null) {
+            values.remove(CellPropertyType.FILL_BACKGROUND_COLOR);
         }
-        if (properties.containsKey(FILL_BACKGROUND_COLOR) && !properties.containsKey(FILL_BACKGROUND_COLOR_COLOR)) {
-            values.remove(FILL_BACKGROUND_COLOR_COLOR);
+        if (properties.containsKey(CellPropertyType.FILL_BACKGROUND_COLOR) && !properties.containsKey(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR)) {
+            values.remove(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
         }
         putAll(properties, values);
 
@@ -415,7 +337,7 @@ public final class CellUtil {
 
         for (int i = 0; i < numberCellStyles; i++) {
             CellStyle wbStyle = workbook.getCellStyleAt(i);
-            Map<String, Object> wbStyleMap = getFormatProperties(wbStyle);
+            Map<CellPropertyType, Object> wbStyleMap = getFormatProperties(wbStyle);
 
             // the desired style already exists in the workbook. Use the existing style.
             if (styleMapsMatch(wbStyleMap, values, disableNullColorCheck)) {
@@ -433,14 +355,14 @@ public final class CellUtil {
         cell.setCellStyle(newStyle);
     }
 
-    private static boolean styleMapsMatch(final Map<String, Object> newProps,
-                                          final Map<String, Object> storedProps, final boolean disableNullColorCheck) {
-        final Map<String, Object> map1Copy = new HashMap<>(newProps);
-        final Map<String, Object> map2Copy = new HashMap<>(storedProps);
-        final Object backColor1 = map1Copy.remove(FILL_BACKGROUND_COLOR_COLOR);
-        final Object backColor2 = map2Copy.remove(FILL_BACKGROUND_COLOR_COLOR);
-        final Object foreColor1 = map1Copy.remove(FILL_FOREGROUND_COLOR_COLOR);
-        final Object foreColor2 = map2Copy.remove(FILL_FOREGROUND_COLOR_COLOR);
+    private static boolean styleMapsMatch(final Map<CellPropertyType, Object> newProps,
+                                          final Map<CellPropertyType, Object> storedProps, final boolean disableNullColorCheck) {
+        final Map<CellPropertyType, Object> map1Copy = new HashMap<>(newProps);
+        final Map<CellPropertyType, Object> map2Copy = new HashMap<>(storedProps);
+        final Object backColor1 = map1Copy.remove(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
+        final Object backColor2 = map2Copy.remove(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
+        final Object foreColor1 = map1Copy.remove(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
+        final Object foreColor2 = map2Copy.remove(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
         if (map1Copy.equals(map2Copy)) {
             final boolean backColorsMatch = (!disableNullColorCheck && backColor2 == null)
                     || Objects.equals(backColor1, backColor2);
@@ -464,25 +386,25 @@ public final class CellUtil {
      * {@link #setCellStyleProperties(Cell, Map)},
      * which is faster and does not add unnecessary intermediate CellStyles to the workbook.</p>
      *
-     * @param cell The cell that is to be changed.
-     * @param propertyName The name of the property that is to be changed.
+     * @param cell          The cell that is to be changed.
+     * @param property      The property that is to be changed.
      * @param propertyValue The value of the property that is to be changed.
      */
-    public static void setCellStyleProperty(Cell cell, String propertyName, Object propertyValue) {
+    public static void setCellStyleProperty(Cell cell, CellPropertyType property, Object propertyValue) {
         boolean disableNullColorCheck = false;
-        final Map<String, Object> propMap;
-        if (CellUtil.FILL_FOREGROUND_COLOR_COLOR.equals(propertyName) && propertyValue == null) {
+        final Map<CellPropertyType, Object> propMap;
+        if (CellPropertyType.FILL_FOREGROUND_COLOR_COLOR.equals(property) && propertyValue == null) {
             disableNullColorCheck = true;
             propMap = new HashMap<>();
-            propMap.put(CellUtil.FILL_FOREGROUND_COLOR_COLOR, null);
-            propMap.put(CellUtil.FILL_FOREGROUND_COLOR, null);
-        } else if (CellUtil.FILL_BACKGROUND_COLOR_COLOR.equals(propertyName) && propertyValue == null) {
+            propMap.put(CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, null);
+            propMap.put(CellPropertyType.FILL_FOREGROUND_COLOR, null);
+        } else if (CellPropertyType.FILL_BACKGROUND_COLOR_COLOR.equals(property) && propertyValue == null) {
             disableNullColorCheck = true;
             propMap = new HashMap<>();
-            propMap.put(CellUtil.FILL_BACKGROUND_COLOR_COLOR, null);
-            propMap.put(CellUtil.FILL_BACKGROUND_COLOR, null);
+            propMap.put(CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, null);
+            propMap.put(CellPropertyType.FILL_BACKGROUND_COLOR, null);
         } else {
-            propMap = Collections.singletonMap(propertyName, propertyValue);
+            propMap = Collections.singletonMap(property, propertyValue);
         }
         setCellStyleProperties(cell, propMap, disableNullColorCheck);
     }
@@ -494,37 +416,37 @@ public final class CellUtil {
      * map will not modify the cell style. The returned map is mutable.
      *
      * @param style cell style
-     * @return map of format properties (String -> Object)
+     * @return map of format properties (CellPropertyType -> Object)
      * @see #setFormatProperties(CellStyle, Workbook, Map)
      */
-    private static Map<String, Object> getFormatProperties(CellStyle style) {
-        Map<String, Object> properties = new HashMap<>();
-        put(properties, ALIGNMENT, style.getAlignment());
-        put(properties, VERTICAL_ALIGNMENT, style.getVerticalAlignment());
-        put(properties, BORDER_BOTTOM, style.getBorderBottom());
-        put(properties, BORDER_LEFT, style.getBorderLeft());
-        put(properties, BORDER_RIGHT, style.getBorderRight());
-        put(properties, BORDER_TOP, style.getBorderTop());
-        put(properties, BOTTOM_BORDER_COLOR, style.getBottomBorderColor());
-        put(properties, DATA_FORMAT, style.getDataFormat());
-        put(properties, FILL_PATTERN, style.getFillPattern());
-        
-        put(properties, FILL_FOREGROUND_COLOR, style.getFillForegroundColor());
-        put(properties, FILL_BACKGROUND_COLOR, style.getFillBackgroundColor());
-        put(properties, FILL_FOREGROUND_COLOR_COLOR, style.getFillForegroundColorColor());
-        put(properties, FILL_BACKGROUND_COLOR_COLOR, style.getFillBackgroundColorColor());
+    private static Map<CellPropertyType, Object> getFormatProperties(CellStyle style) {
+        Map<CellPropertyType, Object> properties = new HashMap<>();
+        put(properties, CellPropertyType.ALIGNMENT, style.getAlignment());
+        put(properties, CellPropertyType.VERTICAL_ALIGNMENT, style.getVerticalAlignment());
+        put(properties, CellPropertyType.BORDER_BOTTOM, style.getBorderBottom());
+        put(properties, CellPropertyType.BORDER_LEFT, style.getBorderLeft());
+        put(properties, CellPropertyType.BORDER_RIGHT, style.getBorderRight());
+        put(properties, CellPropertyType.BORDER_TOP, style.getBorderTop());
+        put(properties, CellPropertyType.BOTTOM_BORDER_COLOR, style.getBottomBorderColor());
+        put(properties, CellPropertyType.DATA_FORMAT, style.getDataFormat());
+        put(properties, CellPropertyType.FILL_PATTERN, style.getFillPattern());
 
-        put(properties, FONT, style.getFontIndex());
-        put(properties, HIDDEN, style.getHidden());
-        put(properties, INDENTION, style.getIndention());
-        put(properties, LEFT_BORDER_COLOR, style.getLeftBorderColor());
-        put(properties, LOCKED, style.getLocked());
-        put(properties, RIGHT_BORDER_COLOR, style.getRightBorderColor());
-        put(properties, ROTATION, style.getRotation());
-        put(properties, TOP_BORDER_COLOR, style.getTopBorderColor());
-        put(properties, WRAP_TEXT, style.getWrapText());
-        put(properties, SHRINK_TO_FIT, style.getShrinkToFit());
-        put(properties, QUOTE_PREFIXED, style.getQuotePrefixed());
+        put(properties, CellPropertyType.FILL_FOREGROUND_COLOR, style.getFillForegroundColor());
+        put(properties, CellPropertyType.FILL_BACKGROUND_COLOR, style.getFillBackgroundColor());
+        put(properties, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR, style.getFillForegroundColorColor());
+        put(properties, CellPropertyType.FILL_BACKGROUND_COLOR_COLOR, style.getFillBackgroundColorColor());
+
+        put(properties, CellPropertyType.FONT, style.getFontIndex());
+        put(properties, CellPropertyType.HIDDEN, style.getHidden());
+        put(properties, CellPropertyType.INDENTION, style.getIndention());
+        put(properties, CellPropertyType.LEFT_BORDER_COLOR, style.getLeftBorderColor());
+        put(properties, CellPropertyType.LOCKED, style.getLocked());
+        put(properties, CellPropertyType.RIGHT_BORDER_COLOR, style.getRightBorderColor());
+        put(properties, CellPropertyType.ROTATION, style.getRotation());
+        put(properties, CellPropertyType.TOP_BORDER_COLOR, style.getTopBorderColor());
+        put(properties, CellPropertyType.WRAP_TEXT, style.getWrapText());
+        put(properties, CellPropertyType.SHRINK_TO_FIT, style.getShrinkToFit());
+        put(properties, CellPropertyType.QUOTE_PREFIXED, style.getQuotePrefixed());
         return properties;
     }
 
@@ -532,64 +454,91 @@ public final class CellUtil {
      * Copies the entries in src to dest, using the preferential data type
      * so that maps can be compared for equality
      *
-     * @param src the property map to copy from (read-only)
+     * @param src  the property map to copy from (read-only)
      * @param dest the property map to copy into
      * @since POI 3.15 beta 3
      */
-    private static void putAll(final Map<String, Object> src, Map<String, Object> dest) {
-        for (final String key : src.keySet()) {
-            if (shortValues.contains(key)) {
-                dest.put(key, nullableShort(src, key));
-            } else if (colorValues.contains(key)) {
-                dest.put(key, getColor(src, key));
-            } else if (intValues.contains(key)) {
-                dest.put(key, getInt(src, key));
-            } else if (booleanValues.contains(key)) {
-                dest.put(key, getBoolean(src, key));
-            } else if (borderTypeValues.contains(key)) {
-                dest.put(key, getBorderStyle(src, key));
-            } else if (ALIGNMENT.equals(key)) {
-                dest.put(key, getHorizontalAlignment(src, key));
-            } else if (VERTICAL_ALIGNMENT.equals(key)) {
-                dest.put(key, getVerticalAlignment(src, key));
-            } else if (FILL_PATTERN.equals(key)) {
-                dest.put(key, getFillPattern(src, key));
-            } else {
-                LOGGER.atInfo().log("Ignoring unrecognized CellUtil format properties key: {}", key);
+    private static void putAll(final Map<CellPropertyType, Object> src, Map<CellPropertyType, Object> dest) {
+        for (final CellPropertyType key : src.keySet()) {
+            CellPropertyCategory category = key.getCategory();
+
+            switch (category) {
+                case INT:
+                    dest.put(key, getInt(src, key));
+                    break;
+                case BOOL:
+                    dest.put(key, getBoolean(src, key));
+                    break;
+                case SHORT:
+                    dest.put(key, nullableShort(src, key));
+                    break;
+                case COLOR:
+                    dest.put(key, getColor(src, key));
+                    break;
+                case BORDER_TYPE:
+                    dest.put(key, getBorderStyle(src, key));
+                    break;
+                default:
+                    putByType(key, src, dest);
+                    break;
             }
+        }
+    }
+
+    /**
+     * Puts the value associated with the given key from the source map into the destination map based on the key type.
+     *
+     * @param key The type of the key.
+     * @param src The source map of properties.
+     * @param dest The destination map of properties.
+     */
+    private static void putByType(CellPropertyType key, final Map<CellPropertyType, Object> src, Map<CellPropertyType, Object> dest) {
+        switch (key) {
+            case ALIGNMENT:
+                dest.put(key, getHorizontalAlignment(src, key));
+                break;
+            case VERTICAL_ALIGNMENT:
+                dest.put(key, getVerticalAlignment(src, key));
+                break;
+            case FILL_PATTERN:
+                dest.put(key, getFillPattern(src, key));
+                break;
+            default:
+                LOGGER.atInfo().log("Ignoring unrecognized CellPropertyType in putByType method: {}", key);
+                break;
         }
     }
 
     /**
      * Sets the format properties of the given style based on the given map.
      *
-     * @param style cell style
-     * @param workbook parent workbook
-     * @param properties map of format properties (String -> Object)
+     * @param style      cell style
+     * @param workbook   parent workbook
+     * @param properties map of format properties (CellPropertyType -> Object)
      * @see #getFormatProperties(CellStyle)
      */
-    private static void setFormatProperties(CellStyle style, Workbook workbook, Map<String, Object> properties) {
-        style.setAlignment(getHorizontalAlignment(properties, ALIGNMENT));
-        style.setVerticalAlignment(getVerticalAlignment(properties, VERTICAL_ALIGNMENT));
-        style.setBorderBottom(getBorderStyle(properties, BORDER_BOTTOM));
-        style.setBorderLeft(getBorderStyle(properties, BORDER_LEFT));
-        style.setBorderRight(getBorderStyle(properties, BORDER_RIGHT));
-        style.setBorderTop(getBorderStyle(properties, BORDER_TOP));
-        style.setBottomBorderColor(getShort(properties, BOTTOM_BORDER_COLOR));
-        style.setDataFormat(getShort(properties, DATA_FORMAT));
-        style.setFillPattern(getFillPattern(properties, FILL_PATTERN));
+    private static void setFormatProperties(CellStyle style, Workbook workbook, Map<CellPropertyType, Object> properties) {
+        style.setAlignment(getHorizontalAlignment(properties, CellPropertyType.ALIGNMENT));
+        style.setVerticalAlignment(getVerticalAlignment(properties, CellPropertyType.VERTICAL_ALIGNMENT));
+        style.setBorderBottom(getBorderStyle(properties, CellPropertyType.BORDER_BOTTOM));
+        style.setBorderLeft(getBorderStyle(properties, CellPropertyType.BORDER_LEFT));
+        style.setBorderRight(getBorderStyle(properties, CellPropertyType.BORDER_RIGHT));
+        style.setBorderTop(getBorderStyle(properties, CellPropertyType.BORDER_TOP));
+        style.setBottomBorderColor(getShort(properties, CellPropertyType.BOTTOM_BORDER_COLOR));
+        style.setDataFormat(getShort(properties, CellPropertyType.DATA_FORMAT));
+        style.setFillPattern(getFillPattern(properties, CellPropertyType.FILL_PATTERN));
 
-        Short fillForeColorShort = nullableShort(properties, FILL_FOREGROUND_COLOR);
+        Short fillForeColorShort = nullableShort(properties, CellPropertyType.FILL_FOREGROUND_COLOR);
         if (fillForeColorShort != null) {
             style.setFillForegroundColor(fillForeColorShort);
         }
-        Short fillBackColorShort = nullableShort(properties, FILL_BACKGROUND_COLOR);
+        Short fillBackColorShort = nullableShort(properties, CellPropertyType.FILL_BACKGROUND_COLOR);
         if (fillBackColorShort != null) {
             style.setFillBackgroundColor(fillBackColorShort);
         }
 
-        Color foregroundFillColor = getColor(properties, FILL_FOREGROUND_COLOR_COLOR);
-        Color backgroundFillColor = getColor(properties, FILL_BACKGROUND_COLOR_COLOR);
+        Color foregroundFillColor = getColor(properties, CellPropertyType.FILL_FOREGROUND_COLOR_COLOR);
+        Color backgroundFillColor = getColor(properties, CellPropertyType.FILL_BACKGROUND_COLOR_COLOR);
 
         if (foregroundFillColor != null) {
             try {
@@ -606,37 +555,37 @@ public final class CellUtil {
             }
         }
 
-        style.setFont(workbook.getFontAt(getInt(properties, FONT)));
-        style.setHidden(getBoolean(properties, HIDDEN));
-        style.setIndention(getShort(properties, INDENTION));
-        style.setLeftBorderColor(getShort(properties, LEFT_BORDER_COLOR));
-        style.setLocked(getBoolean(properties, LOCKED));
-        style.setRightBorderColor(getShort(properties, RIGHT_BORDER_COLOR));
-        style.setRotation(getShort(properties, ROTATION));
-        style.setTopBorderColor(getShort(properties, TOP_BORDER_COLOR));
-        style.setWrapText(getBoolean(properties, WRAP_TEXT));
-        style.setShrinkToFit(getBoolean(properties, SHRINK_TO_FIT));
-        style.setQuotePrefixed(getBoolean(properties, QUOTE_PREFIXED));
+        style.setFont(workbook.getFontAt(getInt(properties, CellPropertyType.FONT)));
+        style.setHidden(getBoolean(properties, CellPropertyType.HIDDEN));
+        style.setIndention(getShort(properties, CellPropertyType.INDENTION));
+        style.setLeftBorderColor(getShort(properties, CellPropertyType.LEFT_BORDER_COLOR));
+        style.setLocked(getBoolean(properties, CellPropertyType.LOCKED));
+        style.setRightBorderColor(getShort(properties, CellPropertyType.RIGHT_BORDER_COLOR));
+        style.setRotation(getShort(properties, CellPropertyType.ROTATION));
+        style.setTopBorderColor(getShort(properties, CellPropertyType.TOP_BORDER_COLOR));
+        style.setWrapText(getBoolean(properties, CellPropertyType.WRAP_TEXT));
+        style.setShrinkToFit(getBoolean(properties, CellPropertyType.SHRINK_TO_FIT));
+        style.setQuotePrefixed(getBoolean(properties, CellPropertyType.QUOTE_PREFIXED));
     }
 
     /**
      * Utility method that returns the named short value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return zero if the property does not exist, or is not a {@link Short}
-     *         otherwise the property value
+     * otherwise the property value
      */
-    private static short getShort(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static short getShort(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Number) {
             return ((Number) value).shortValue();
         }
         return 0;
     }
 
-    private static Short nullableShort(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static Short nullableShort(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Short) {
             return (Short) value;
         }
@@ -645,17 +594,17 @@ public final class CellUtil {
         }
         return null;
     }
-    
+
     /**
      * Utility method that returns the named Color value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return null if the property does not exist, or is not a {@link Color}
-     *         otherwise the property value
+     * otherwise the property value
      */
-    private static Color getColor(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static Color getColor(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Color) {
             return (Color) value;
         }
@@ -666,13 +615,13 @@ public final class CellUtil {
     /**
      * Utility method that returns the named int value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return zero if the property does not exist, or is not a {@link Integer}
-     *         otherwise the property value
+     * otherwise the property value
      */
-    private static int getInt(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static int getInt(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         if (value instanceof Number) {
             return ((Number) value).intValue();
         }
@@ -682,26 +631,24 @@ public final class CellUtil {
     /**
      * Utility method that returns the named BorderStyle value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return Border style if set, otherwise {@link BorderStyle#NONE}
      */
-    private static BorderStyle getBorderStyle(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static BorderStyle getBorderStyle(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         BorderStyle border;
         if (value instanceof BorderStyle) {
             border = (BorderStyle) value;
         }
         // @deprecated 3.15 beta 2. getBorderStyle will only work on BorderStyle enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use BorderStyle enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use BorderStyle enums instead.", property);
             short code = (Short) value;
             border = BorderStyle.valueOf(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             border = BorderStyle.NONE;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected border style class. Must be BorderStyle or Short (deprecated).");
         }
         return border;
@@ -710,27 +657,25 @@ public final class CellUtil {
     /**
      * Utility method that returns the named FillPatternType value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return FillPatternType style if set, otherwise {@link FillPatternType#NO_FILL}
      * @since POI 3.15 beta 3
      */
-    private static FillPatternType getFillPattern(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static FillPatternType getFillPattern(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         FillPatternType pattern;
         if (value instanceof FillPatternType) {
             pattern = (FillPatternType) value;
         }
         // @deprecated 3.15 beta 2. getFillPattern will only work on FillPatternType enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use FillPatternType enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map uses Short values for {}. Should use FillPatternType enums instead.", property);
             short code = (Short) value;
             pattern = FillPatternType.forInt(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             pattern = FillPatternType.NO_FILL;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected fill pattern style class. Must be FillPatternType or Short (deprecated).");
         }
         return pattern;
@@ -739,27 +684,25 @@ public final class CellUtil {
     /**
      * Utility method that returns the named HorizontalAlignment value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return HorizontalAlignment style if set, otherwise {@link HorizontalAlignment#GENERAL}
      * @since POI 3.15 beta 3
      */
-    private static HorizontalAlignment getHorizontalAlignment(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static HorizontalAlignment getHorizontalAlignment(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         HorizontalAlignment align;
         if (value instanceof HorizontalAlignment) {
             align = (HorizontalAlignment) value;
         }
         // @deprecated 3.15 beta 2. getHorizontalAlignment will only work on HorizontalAlignment enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use HorizontalAlignment enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use HorizontalAlignment enums instead.", property);
             short code = (Short) value;
             align = HorizontalAlignment.forInt(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             align = HorizontalAlignment.GENERAL;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected horizontal alignment style class. Must be HorizontalAlignment or Short (deprecated).");
         }
         return align;
@@ -768,27 +711,25 @@ public final class CellUtil {
     /**
      * Utility method that returns the named VerticalAlignment value from the given map.
      *
-     * @param properties map of named properties (String -> Object)
-     * @param name property name
+     * @param properties map of named properties (CellPropertyType -> Object)
+     * @param property   property
      * @return VerticalAlignment style if set, otherwise {@link VerticalAlignment#BOTTOM}
      * @since POI 3.15 beta 3
      */
-    private static VerticalAlignment getVerticalAlignment(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static VerticalAlignment getVerticalAlignment(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         VerticalAlignment align;
         if (value instanceof VerticalAlignment) {
             align = (VerticalAlignment) value;
         }
         // @deprecated 3.15 beta 2. getVerticalAlignment will only work on VerticalAlignment enums instead of codes in the future.
         else if (value instanceof Short) {
-            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use VerticalAlignment enums instead.", name);
+            LOGGER.atWarn().log("Deprecation warning: CellUtil properties map used a Short value for {}. Should use VerticalAlignment enums instead.", property);
             short code = (Short) value;
             align = VerticalAlignment.forInt(code);
-        }
-        else if (value == null) {
+        } else if (value == null) {
             align = VerticalAlignment.BOTTOM;
-        }
-        else {
+        } else {
             throw new IllegalStateException("Unexpected vertical alignment style class. Must be VerticalAlignment or Short (deprecated).");
         }
         return align;
@@ -797,13 +738,13 @@ public final class CellUtil {
     /**
      * Utility method that returns the named boolean value from the given map.
      *
-     * @param properties map of properties (String -> Object)
-     * @param name property name
+     * @param properties map of properties (CellPropertyType -> Object)
+     * @param property   property
      * @return false if the property does not exist, or is not a {@link Boolean},
-     *         true otherwise
+     * true otherwise
      */
-    private static boolean getBoolean(Map<String, Object> properties, String name) {
-        Object value = properties.get(name);
+    private static boolean getBoolean(Map<CellPropertyType, Object> properties, CellPropertyType property) {
+        Object value = properties.get(property);
         //noinspection SimplifiableIfStatement
         if (value instanceof Boolean) {
             return (Boolean) value;
@@ -815,19 +756,19 @@ public final class CellUtil {
      * Utility method that puts the given value to the given map.
      *
      * @param properties map of properties (String -> Object)
-     * @param name property name
-     * @param value property value
+     * @param property   property
+     * @param value      property value
      */
-    private static void put(Map<String, Object> properties, String name, Object value) {
-        properties.put(name, value);
+    private static void put(Map<CellPropertyType, Object> properties, CellPropertyType property, Object value) {
+        properties.put(property, value);
     }
 
     /**
-     *  Looks for text in the cell that should be unicode, like &alpha; and provides the
-     *  unicode version of it.
+     * Looks for text in the cell that should be unicode, like &alpha; and provides the
+     * unicode version of it.
      *
-     *@param  cell  The cell to check for unicode values
-     *@return       translated to unicode
+     * @param cell The cell to check for unicode values
+     * @return translated to unicode
      */
     public static Cell translateUnicodeValues(Cell cell) {
 
@@ -850,22 +791,22 @@ public final class CellUtil {
     }
 
     static {
-        unicodeMappings = new UnicodeMapping[] {
-            um("alpha",   "\u03B1" ),
-            um("beta",    "\u03B2" ),
-            um("gamma",   "\u03B3" ),
-            um("delta",   "\u03B4" ),
-            um("epsilon", "\u03B5" ),
-            um("zeta",    "\u03B6" ),
-            um("eta",     "\u03B7" ),
-            um("theta",   "\u03B8" ),
-            um("iota",    "\u03B9" ),
-            um("kappa",   "\u03BA" ),
-            um("lambda",  "\u03BB" ),
-            um("mu",      "\u03BC" ),
-            um("nu",      "\u03BD" ),
-            um("xi",      "\u03BE" ),
-            um("omicron", "\u03BF" ),
+        unicodeMappings = new UnicodeMapping[]{
+                um("alpha", "\u03B1"),
+                um("beta", "\u03B2"),
+                um("gamma", "\u03B3"),
+                um("delta", "\u03B4"),
+                um("epsilon", "\u03B5"),
+                um("zeta", "\u03B6"),
+                um("eta", "\u03B7"),
+                um("theta", "\u03B8"),
+                um("iota", "\u03B9"),
+                um("kappa", "\u03BA"),
+                um("lambda", "\u03BB"),
+                um("mu", "\u03BC"),
+                um("nu", "\u03BD"),
+                um("xi", "\u03BE"),
+                um("omicron", "\u03BF"),
         };
     }
 

--- a/poi/src/main/java/org/apache/poi/ss/util/PropertyTemplate.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/PropertyTemplate.java
@@ -17,14 +17,14 @@
 
 package org.apache.poi.ss.util;
 
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.ss.SpreadsheetVersion;
+import org.apache.poi.ss.usermodel.*;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.SpreadsheetVersion;
-import org.apache.poi.ss.usermodel.*;
 
 /**
  * <p>
@@ -32,7 +32,7 @@ import org.apache.poi.ss.usermodel.*;
  * a project. It contains all the border type and color attributes needed to
  * draw all the borders for a single sheet. That template can be applied to any
  * sheet in any workbook.
- *
+ * <p>
  * This class requires the full spreadsheet to be in memory, so
  * {@link org.apache.poi.xssf.streaming.SXSSFWorkbook} Spreadsheets are not
  * supported. The same PropertyTemplate can, however, be applied to both
@@ -67,12 +67,12 @@ public final class PropertyTemplate {
      */
     public PropertyTemplate(PropertyTemplate template) {
         this();
-        for(Map.Entry<CellAddress, Map<CellPropertyType, Object>> entry : template.getTemplate().entrySet()) {
+        for (Map.Entry<CellAddress, Map<CellPropertyType, Object>> entry : template.getTemplate().entrySet()) {
             _propertyTemplate.put(new CellAddress(entry.getKey()), cloneCellProperties(entry.getValue()));
         }
     }
 
-    private Map<CellAddress,Map<CellPropertyType, Object>> getTemplate() {
+    private Map<CellAddress, Map<CellPropertyType, Object>> getTemplate() {
         return _propertyTemplate;
     }
 
@@ -85,62 +85,59 @@ public final class PropertyTemplate {
      * applied to the cells at this time, just the template is drawn. To apply
      * the drawn borders to a sheet, use {@link #applyBorders}.
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
-     * @param extent
-     *            - {@link BorderExtent} of the borders to be
-     *            applied.
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param extent     - {@link BorderExtent} of the borders to be
+     *                   applied.
      */
     public void drawBorders(CellRangeAddress range, BorderStyle borderType,
-            BorderExtent extent) {
+                            BorderExtent extent) {
         switch (extent) {
-        case NONE:
-            removeBorders(range);
-            break;
-        case ALL:
-            drawHorizontalBorders(range, borderType, BorderExtent.ALL);
-            drawVerticalBorders(range, borderType, BorderExtent.ALL);
-            break;
-        case INSIDE:
-            drawHorizontalBorders(range, borderType, BorderExtent.INSIDE);
-            drawVerticalBorders(range, borderType, BorderExtent.INSIDE);
-            break;
-        case OUTSIDE:
-            drawOutsideBorders(range, borderType, BorderExtent.ALL);
-            break;
-        case TOP:
-            drawTopBorder(range, borderType);
-            break;
-        case BOTTOM:
-            drawBottomBorder(range, borderType);
-            break;
-        case LEFT:
-            drawLeftBorder(range, borderType);
-            break;
-        case RIGHT:
-            drawRightBorder(range, borderType);
-            break;
-        case HORIZONTAL:
-            drawHorizontalBorders(range, borderType, BorderExtent.ALL);
-            break;
-        case INSIDE_HORIZONTAL:
-            drawHorizontalBorders(range, borderType, BorderExtent.INSIDE);
-            break;
-        case OUTSIDE_HORIZONTAL:
-            drawOutsideBorders(range, borderType, BorderExtent.HORIZONTAL);
-            break;
-        case VERTICAL:
-            drawVerticalBorders(range, borderType, BorderExtent.ALL);
-            break;
-        case INSIDE_VERTICAL:
-            drawVerticalBorders(range, borderType, BorderExtent.INSIDE);
-            break;
-        case OUTSIDE_VERTICAL:
-            drawOutsideBorders(range, borderType, BorderExtent.VERTICAL);
-            break;
+            case NONE:
+                removeBorders(range);
+                break;
+            case ALL:
+                drawHorizontalBorders(range, borderType, BorderExtent.ALL);
+                drawVerticalBorders(range, borderType, BorderExtent.ALL);
+                break;
+            case INSIDE:
+                drawHorizontalBorders(range, borderType, BorderExtent.INSIDE);
+                drawVerticalBorders(range, borderType, BorderExtent.INSIDE);
+                break;
+            case OUTSIDE:
+                drawOutsideBorders(range, borderType, BorderExtent.ALL);
+                break;
+            case TOP:
+                drawTopBorder(range, borderType);
+                break;
+            case BOTTOM:
+                drawBottomBorder(range, borderType);
+                break;
+            case LEFT:
+                drawLeftBorder(range, borderType);
+                break;
+            case RIGHT:
+                drawRightBorder(range, borderType);
+                break;
+            case HORIZONTAL:
+                drawHorizontalBorders(range, borderType, BorderExtent.ALL);
+                break;
+            case INSIDE_HORIZONTAL:
+                drawHorizontalBorders(range, borderType, BorderExtent.INSIDE);
+                break;
+            case OUTSIDE_HORIZONTAL:
+                drawOutsideBorders(range, borderType, BorderExtent.HORIZONTAL);
+                break;
+            case VERTICAL:
+                drawVerticalBorders(range, borderType, BorderExtent.ALL);
+                break;
+            case INSIDE_VERTICAL:
+                drawVerticalBorders(range, borderType, BorderExtent.INSIDE);
+                break;
+            case OUTSIDE_VERTICAL:
+                drawOutsideBorders(range, borderType, BorderExtent.VERTICAL);
+                break;
         }
     }
 
@@ -149,20 +146,16 @@ public final class PropertyTemplate {
      * applied to the cells at this time, just the template is drawn. To apply
      * the drawn borders to a sheet, use {@link #applyBorders}.
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
-     * @param extent
-     *            - {@link BorderExtent} of the borders to be
-     *            applied.
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param color      - Color index from {@link IndexedColors} used to draw the
+     *                   borders.
+     * @param extent     - {@link BorderExtent} of the borders to be
+     *                   applied.
      */
     public void drawBorders(CellRangeAddress range, BorderStyle borderType,
-            short color, BorderExtent extent) {
+                            short color, BorderExtent extent) {
         drawBorders(range, borderType, extent);
         if (borderType != BorderStyle.NONE) {
             drawBorderColors(range, color, extent);
@@ -174,11 +167,9 @@ public final class PropertyTemplate {
      * Draws the top border for a range of cells
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
      */
     private void drawTopBorder(CellRangeAddress range, BorderStyle borderType) {
         int row = range.getFirstRow();
@@ -197,14 +188,12 @@ public final class PropertyTemplate {
      * Draws the bottom border for a range of cells
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
      */
     private void drawBottomBorder(CellRangeAddress range,
-            BorderStyle borderType) {
+                                  BorderStyle borderType) {
         int row = range.getLastRow();
         int firstCol = range.getFirstColumn();
         int lastCol = range.getLastColumn();
@@ -222,14 +211,12 @@ public final class PropertyTemplate {
      * Draws the left border for a range of cells
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
      */
     private void drawLeftBorder(CellRangeAddress range,
-            BorderStyle borderType) {
+                                BorderStyle borderType) {
         int firstRow = range.getFirstRow();
         int lastRow = range.getLastRow();
         int col = range.getFirstColumn();
@@ -246,14 +233,12 @@ public final class PropertyTemplate {
      * Draws the right border for a range of cells
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
      */
     private void drawRightBorder(CellRangeAddress range,
-            BorderStyle borderType) {
+                                 BorderStyle borderType) {
         int firstRow = range.getFirstRow();
         int lastRow = range.getLastRow();
         int col = range.getLastColumn();
@@ -271,38 +256,35 @@ public final class PropertyTemplate {
      * Draws the outside borders for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
-     * @param extent
-     *            - {@link BorderExtent} of the borders to be
-     *            applied. Valid Values are:
-     *            <ul>
-     *            <li>BorderExtent.ALL</li>
-     *            <li>BorderExtent.HORIZONTAL</li>
-     *            <li>BorderExtent.VERTICAL</li>
-     *            </ul>
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param extent     - {@link BorderExtent} of the borders to be
+     *                   applied. Valid Values are:
+     *                   <ul>
+     *                   <li>BorderExtent.ALL</li>
+     *                   <li>BorderExtent.HORIZONTAL</li>
+     *                   <li>BorderExtent.VERTICAL</li>
+     *                   </ul>
      */
     private void drawOutsideBorders(CellRangeAddress range,
-            BorderStyle borderType, BorderExtent extent) {
+                                    BorderStyle borderType, BorderExtent extent) {
         switch (extent) {
-        case ALL:
-        case HORIZONTAL:
-        case VERTICAL:
-            if (extent == BorderExtent.ALL || extent == BorderExtent.HORIZONTAL) {
-                drawTopBorder(range, borderType);
-                drawBottomBorder(range, borderType);
-            }
-            if (extent == BorderExtent.ALL || extent == BorderExtent.VERTICAL) {
-                drawLeftBorder(range, borderType);
-                drawRightBorder(range, borderType);
-            }
-            break;
-        default:
-            throw new IllegalArgumentException(
-                    "Unsupported PropertyTemplate.Extent, valid Extents are ALL, HORIZONTAL, and VERTICAL");
+            case ALL:
+            case HORIZONTAL:
+            case VERTICAL:
+                if (extent == BorderExtent.ALL || extent == BorderExtent.HORIZONTAL) {
+                    drawTopBorder(range, borderType);
+                    drawBottomBorder(range, borderType);
+                }
+                if (extent == BorderExtent.ALL || extent == BorderExtent.VERTICAL) {
+                    drawLeftBorder(range, borderType);
+                    drawRightBorder(range, borderType);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported PropertyTemplate.Extent, valid Extents are ALL, HORIZONTAL, and VERTICAL");
         }
     }
 
@@ -311,42 +293,39 @@ public final class PropertyTemplate {
      * Draws the horizontal borders for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
-     * @param extent
-     *            - {@link BorderExtent} of the borders to be
-     *            applied. Valid Values are:
-     *            <ul>
-     *            <li>BorderExtent.ALL</li>
-     *            <li>BorderExtent.INSIDE</li>
-     *            </ul>
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param extent     - {@link BorderExtent} of the borders to be
+     *                   applied. Valid Values are:
+     *                   <ul>
+     *                   <li>BorderExtent.ALL</li>
+     *                   <li>BorderExtent.INSIDE</li>
+     *                   </ul>
      */
     private void drawHorizontalBorders(CellRangeAddress range,
-            BorderStyle borderType, BorderExtent extent) {
+                                       BorderStyle borderType, BorderExtent extent) {
         switch (extent) {
-        case ALL:
-        case INSIDE:
-            int firstRow = range.getFirstRow();
-            int lastRow = range.getLastRow();
-            int firstCol = range.getFirstColumn();
-            int lastCol = range.getLastColumn();
-            for (int i = firstRow; i <= lastRow; i++) {
-                CellRangeAddress row = new CellRangeAddress(i, i, firstCol,
-                        lastCol);
-                if (extent == BorderExtent.ALL || i > firstRow) {
-                    drawTopBorder(row, borderType);
+            case ALL:
+            case INSIDE:
+                int firstRow = range.getFirstRow();
+                int lastRow = range.getLastRow();
+                int firstCol = range.getFirstColumn();
+                int lastCol = range.getLastColumn();
+                for (int i = firstRow; i <= lastRow; i++) {
+                    CellRangeAddress row = new CellRangeAddress(i, i, firstCol,
+                            lastCol);
+                    if (extent == BorderExtent.ALL || i > firstRow) {
+                        drawTopBorder(row, borderType);
+                    }
+                    if (extent == BorderExtent.ALL || i < lastRow) {
+                        drawBottomBorder(row, borderType);
+                    }
                 }
-                if (extent == BorderExtent.ALL || i < lastRow) {
-                    drawBottomBorder(row, borderType);
-                }
-            }
-            break;
-        default:
-            throw new IllegalArgumentException(
-                    "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
         }
     }
 
@@ -355,42 +334,39 @@ public final class PropertyTemplate {
      * Draws the vertical borders for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which borders are
-     *            drawn.
-     * @param borderType
-     *            - Type of border to draw. {@link BorderStyle}.
-     * @param extent
-     *            - {@link BorderExtent} of the borders to be
-     *            applied. Valid Values are:
-     *            <ul>
-     *            <li>BorderExtent.ALL</li>
-     *            <li>BorderExtent.INSIDE</li>
-     *            </ul>
+     * @param range      - {@link CellRangeAddress} range of cells on which borders are
+     *                   drawn.
+     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param extent     - {@link BorderExtent} of the borders to be
+     *                   applied. Valid Values are:
+     *                   <ul>
+     *                   <li>BorderExtent.ALL</li>
+     *                   <li>BorderExtent.INSIDE</li>
+     *                   </ul>
      */
     private void drawVerticalBorders(CellRangeAddress range,
-            BorderStyle borderType, BorderExtent extent) {
+                                     BorderStyle borderType, BorderExtent extent) {
         switch (extent) {
-        case ALL:
-        case INSIDE:
-            int firstRow = range.getFirstRow();
-            int lastRow = range.getLastRow();
-            int firstCol = range.getFirstColumn();
-            int lastCol = range.getLastColumn();
-            for (int i = firstCol; i <= lastCol; i++) {
-                CellRangeAddress row = new CellRangeAddress(firstRow, lastRow,
-                        i, i);
-                if (extent == BorderExtent.ALL || i > firstCol) {
-                    drawLeftBorder(row, borderType);
+            case ALL:
+            case INSIDE:
+                int firstRow = range.getFirstRow();
+                int lastRow = range.getLastRow();
+                int firstCol = range.getFirstColumn();
+                int lastCol = range.getLastColumn();
+                for (int i = firstCol; i <= lastCol; i++) {
+                    CellRangeAddress row = new CellRangeAddress(firstRow, lastRow,
+                            i, i);
+                    if (extent == BorderExtent.ALL || i > firstCol) {
+                        drawLeftBorder(row, borderType);
+                    }
+                    if (extent == BorderExtent.ALL || i < lastCol) {
+                        drawRightBorder(row, borderType);
+                    }
                 }
-                if (extent == BorderExtent.ALL || i < lastCol) {
-                    drawRightBorder(row, borderType);
-                }
-            }
-            break;
-        default:
-            throw new IllegalArgumentException(
-                    "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
         }
     }
 
@@ -420,8 +396,7 @@ public final class PropertyTemplate {
      * the ones that have been drawn by the {@link #drawBorders} and
      * {@link #drawBorderColors} methods.
      *
-     * @param sheet
-     *            - {@link Sheet} on which to apply borders
+     * @param sheet - {@link Sheet} on which to apply borders
      */
     public void applyBorders(Sheet sheet) {
         Workbook wb = sheet.getWorkbook();
@@ -430,7 +405,7 @@ public final class PropertyTemplate {
             CellAddress cellAddress = entry.getKey();
             if (cellAddress.getRow() < wb.getSpreadsheetVersion().getMaxRows()
                     && cellAddress.getColumn() < wb.getSpreadsheetVersion()
-                            .getMaxColumns()) {
+                    .getMaxColumns()) {
                 Map<CellPropertyType, Object> properties = entry.getValue();
                 Row row = CellUtil.getRow(cellAddress.getRow(), sheet);
                 Cell cell = CellUtil.getCell(row, cellAddress.getColumn());
@@ -445,63 +420,60 @@ public final class PropertyTemplate {
      * the borders do not exist, a BORDER_THIN border is used. To apply the
      * drawn borders to a sheet, use {@link #applyBorders}.
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
-     * @param extent
-     *            - {@link BorderExtent} of the borders for which
-     *            colors are set.
+     * @param range  - {@link CellRangeAddress} range of cells on which colors are
+     *               set.
+     * @param color  - Color index from {@link IndexedColors} used to draw the
+     *               borders.
+     * @param extent - {@link BorderExtent} of the borders for which
+     *               colors are set.
      */
     public void drawBorderColors(CellRangeAddress range, short color,
-            BorderExtent extent) {
+                                 BorderExtent extent) {
         switch (extent) {
-        case NONE:
-            removeBorderColors(range);
-            break;
-        case ALL:
-            drawHorizontalBorderColors(range, color, BorderExtent.ALL);
-            drawVerticalBorderColors(range, color, BorderExtent.ALL);
-            break;
-        case INSIDE:
-            drawHorizontalBorderColors(range, color, BorderExtent.INSIDE);
-            drawVerticalBorderColors(range, color, BorderExtent.INSIDE);
-            break;
-        case OUTSIDE:
-            drawOutsideBorderColors(range, color, BorderExtent.ALL);
-            break;
-        case TOP:
-            drawTopBorderColor(range, color);
-            break;
-        case BOTTOM:
-            drawBottomBorderColor(range, color);
-            break;
-        case LEFT:
-            drawLeftBorderColor(range, color);
-            break;
-        case RIGHT:
-            drawRightBorderColor(range, color);
-            break;
-        case HORIZONTAL:
-            drawHorizontalBorderColors(range, color, BorderExtent.ALL);
-            break;
-        case INSIDE_HORIZONTAL:
-            drawHorizontalBorderColors(range, color, BorderExtent.INSIDE);
-            break;
-        case OUTSIDE_HORIZONTAL:
-            drawOutsideBorderColors(range, color, BorderExtent.HORIZONTAL);
-            break;
-        case VERTICAL:
-            drawVerticalBorderColors(range, color, BorderExtent.ALL);
-            break;
-        case INSIDE_VERTICAL:
-            drawVerticalBorderColors(range, color, BorderExtent.INSIDE);
-            break;
-        case OUTSIDE_VERTICAL:
-            drawOutsideBorderColors(range, color, BorderExtent.VERTICAL);
-            break;
+            case NONE:
+                removeBorderColors(range);
+                break;
+            case ALL:
+                drawHorizontalBorderColors(range, color, BorderExtent.ALL);
+                drawVerticalBorderColors(range, color, BorderExtent.ALL);
+                break;
+            case INSIDE:
+                drawHorizontalBorderColors(range, color, BorderExtent.INSIDE);
+                drawVerticalBorderColors(range, color, BorderExtent.INSIDE);
+                break;
+            case OUTSIDE:
+                drawOutsideBorderColors(range, color, BorderExtent.ALL);
+                break;
+            case TOP:
+                drawTopBorderColor(range, color);
+                break;
+            case BOTTOM:
+                drawBottomBorderColor(range, color);
+                break;
+            case LEFT:
+                drawLeftBorderColor(range, color);
+                break;
+            case RIGHT:
+                drawRightBorderColor(range, color);
+                break;
+            case HORIZONTAL:
+                drawHorizontalBorderColors(range, color, BorderExtent.ALL);
+                break;
+            case INSIDE_HORIZONTAL:
+                drawHorizontalBorderColors(range, color, BorderExtent.INSIDE);
+                break;
+            case OUTSIDE_HORIZONTAL:
+                drawOutsideBorderColors(range, color, BorderExtent.HORIZONTAL);
+                break;
+            case VERTICAL:
+                drawVerticalBorderColors(range, color, BorderExtent.ALL);
+                break;
+            case INSIDE_VERTICAL:
+                drawVerticalBorderColors(range, color, BorderExtent.INSIDE);
+                break;
+            case OUTSIDE_VERTICAL:
+                drawOutsideBorderColors(range, color, BorderExtent.VERTICAL);
+                break;
         }
     }
 
@@ -510,12 +482,10 @@ public final class PropertyTemplate {
      * Sets the color of the top border for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
+     * @param range - {@link CellRangeAddress} range of cells on which colors are
+     *              set.
+     * @param color - Color index from {@link IndexedColors} used to draw the
+     *              borders.
      */
     private void drawTopBorderColor(CellRangeAddress range, short color) {
         int row = range.getFirstRow();
@@ -536,12 +506,10 @@ public final class PropertyTemplate {
      * Sets the color of the bottom border for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
+     * @param range - {@link CellRangeAddress} range of cells on which colors are
+     *              set.
+     * @param color - Color index from {@link IndexedColors} used to draw the
+     *              borders.
      */
     private void drawBottomBorderColor(CellRangeAddress range, short color) {
         int row = range.getLastRow();
@@ -562,12 +530,10 @@ public final class PropertyTemplate {
      * Sets the color of the left border for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
+     * @param range - {@link CellRangeAddress} range of cells on which colors are
+     *              set.
+     * @param color - Color index from {@link IndexedColors} used to draw the
+     *              borders.
      */
     private void drawLeftBorderColor(CellRangeAddress range, short color) {
         int firstRow = range.getFirstRow();
@@ -589,12 +555,10 @@ public final class PropertyTemplate {
      * not drawn, it defaults to BORDER_THIN
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
+     * @param range - {@link CellRangeAddress} range of cells on which colors are
+     *              set.
+     * @param color - Color index from {@link IndexedColors} used to draw the
+     *              borders.
      */
     private void drawRightBorderColor(CellRangeAddress range, short color) {
         int firstRow = range.getFirstRow();
@@ -615,39 +579,36 @@ public final class PropertyTemplate {
      * Sets the color of the outside borders for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
-     * @param extent
-     *            - {@link BorderExtent} of the borders for which
-     *            colors are set. Valid Values are:
-     *            <ul>
-     *            <li>BorderExtent.ALL</li>
-     *            <li>BorderExtent.HORIZONTAL</li>
-     *            <li>BorderExtent.VERTICAL</li>
-     *            </ul>
+     * @param range  - {@link CellRangeAddress} range of cells on which colors are
+     *               set.
+     * @param color  - Color index from {@link IndexedColors} used to draw the
+     *               borders.
+     * @param extent - {@link BorderExtent} of the borders for which
+     *               colors are set. Valid Values are:
+     *               <ul>
+     *               <li>BorderExtent.ALL</li>
+     *               <li>BorderExtent.HORIZONTAL</li>
+     *               <li>BorderExtent.VERTICAL</li>
+     *               </ul>
      */
     private void drawOutsideBorderColors(CellRangeAddress range, short color,
-            BorderExtent extent) {
+                                         BorderExtent extent) {
         switch (extent) {
-        case ALL:
-        case HORIZONTAL:
-        case VERTICAL:
-            if (extent == BorderExtent.ALL || extent == BorderExtent.HORIZONTAL) {
-                drawTopBorderColor(range, color);
-                drawBottomBorderColor(range, color);
-            }
-            if (extent == BorderExtent.ALL || extent == BorderExtent.VERTICAL) {
-                drawLeftBorderColor(range, color);
-                drawRightBorderColor(range, color);
-            }
-            break;
-        default:
-            throw new IllegalArgumentException(
-                    "Unsupported PropertyTemplate.Extent, valid Extents are ALL, HORIZONTAL, and VERTICAL");
+            case ALL:
+            case HORIZONTAL:
+            case VERTICAL:
+                if (extent == BorderExtent.ALL || extent == BorderExtent.HORIZONTAL) {
+                    drawTopBorderColor(range, color);
+                    drawBottomBorderColor(range, color);
+                }
+                if (extent == BorderExtent.ALL || extent == BorderExtent.VERTICAL) {
+                    drawLeftBorderColor(range, color);
+                    drawRightBorderColor(range, color);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported PropertyTemplate.Extent, valid Extents are ALL, HORIZONTAL, and VERTICAL");
         }
     }
 
@@ -656,43 +617,40 @@ public final class PropertyTemplate {
      * Sets the color of the horizontal borders for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
-     * @param extent
-     *            - {@link BorderExtent} of the borders for which
-     *            colors are set. Valid Values are:
-     *            <ul>
-     *            <li>BorderExtent.ALL</li>
-     *            <li>BorderExtent.INSIDE</li>
-     *            </ul>
+     * @param range  - {@link CellRangeAddress} range of cells on which colors are
+     *               set.
+     * @param color  - Color index from {@link IndexedColors} used to draw the
+     *               borders.
+     * @param extent - {@link BorderExtent} of the borders for which
+     *               colors are set. Valid Values are:
+     *               <ul>
+     *               <li>BorderExtent.ALL</li>
+     *               <li>BorderExtent.INSIDE</li>
+     *               </ul>
      */
     private void drawHorizontalBorderColors(CellRangeAddress range, short color,
-            BorderExtent extent) {
+                                            BorderExtent extent) {
         switch (extent) {
-        case ALL:
-        case INSIDE:
-            int firstRow = range.getFirstRow();
-            int lastRow = range.getLastRow();
-            int firstCol = range.getFirstColumn();
-            int lastCol = range.getLastColumn();
-            for (int i = firstRow; i <= lastRow; i++) {
-                CellRangeAddress row = new CellRangeAddress(i, i, firstCol,
-                        lastCol);
-                if (extent == BorderExtent.ALL || i > firstRow) {
-                    drawTopBorderColor(row, color);
+            case ALL:
+            case INSIDE:
+                int firstRow = range.getFirstRow();
+                int lastRow = range.getLastRow();
+                int firstCol = range.getFirstColumn();
+                int lastCol = range.getLastColumn();
+                for (int i = firstRow; i <= lastRow; i++) {
+                    CellRangeAddress row = new CellRangeAddress(i, i, firstCol,
+                            lastCol);
+                    if (extent == BorderExtent.ALL || i > firstRow) {
+                        drawTopBorderColor(row, color);
+                    }
+                    if (extent == BorderExtent.ALL || i < lastRow) {
+                        drawBottomBorderColor(row, color);
+                    }
                 }
-                if (extent == BorderExtent.ALL || i < lastRow) {
-                    drawBottomBorderColor(row, color);
-                }
-            }
-            break;
-        default:
-            throw new IllegalArgumentException(
-                    "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
         }
     }
 
@@ -701,43 +659,40 @@ public final class PropertyTemplate {
      * Sets the color of the vertical borders for a range of cells.
      * </p>
      *
-     * @param range
-     *            - {@link CellRangeAddress} range of cells on which colors are
-     *            set.
-     * @param color
-     *            - Color index from {@link IndexedColors} used to draw the
-     *            borders.
-     * @param extent
-     *            - {@link BorderExtent} of the borders for which
-     *            colors are set. Valid Values are:
-     *            <ul>
-     *            <li>BorderExtent.ALL</li>
-     *            <li>BorderExtent.INSIDE</li>
-     *            </ul>
+     * @param range  - {@link CellRangeAddress} range of cells on which colors are
+     *               set.
+     * @param color  - Color index from {@link IndexedColors} used to draw the
+     *               borders.
+     * @param extent - {@link BorderExtent} of the borders for which
+     *               colors are set. Valid Values are:
+     *               <ul>
+     *               <li>BorderExtent.ALL</li>
+     *               <li>BorderExtent.INSIDE</li>
+     *               </ul>
      */
     private void drawVerticalBorderColors(CellRangeAddress range, short color,
-            BorderExtent extent) {
+                                          BorderExtent extent) {
         switch (extent) {
-        case ALL:
-        case INSIDE:
-            int firstRow = range.getFirstRow();
-            int lastRow = range.getLastRow();
-            int firstCol = range.getFirstColumn();
-            int lastCol = range.getLastColumn();
-            for (int i = firstCol; i <= lastCol; i++) {
-                CellRangeAddress row = new CellRangeAddress(firstRow, lastRow,
-                        i, i);
-                if (extent == BorderExtent.ALL || i > firstCol) {
-                    drawLeftBorderColor(row, color);
+            case ALL:
+            case INSIDE:
+                int firstRow = range.getFirstRow();
+                int lastRow = range.getLastRow();
+                int firstCol = range.getFirstColumn();
+                int lastCol = range.getLastColumn();
+                for (int i = firstCol; i <= lastCol; i++) {
+                    CellRangeAddress row = new CellRangeAddress(firstRow, lastRow,
+                            i, i);
+                    if (extent == BorderExtent.ALL || i > firstCol) {
+                        drawLeftBorderColor(row, color);
+                    }
+                    if (extent == BorderExtent.ALL || i < lastCol) {
+                        drawRightBorderColor(row, color);
+                    }
                 }
-                if (extent == BorderExtent.ALL || i < lastCol) {
-                    drawRightBorderColor(row, color);
-                }
-            }
-            break;
-        default:
-            throw new IllegalArgumentException(
-                    "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported PropertyTemplate.Extent, valid Extents are ALL and INSIDE");
         }
     }
 
@@ -875,9 +830,29 @@ public final class PropertyTemplate {
 
     /**
      * Retrieves the border style for a given cell
+     *
+     * @deprecated See {@link #getBorderStyle(CellAddress, CellPropertyType)}
+     */
+    @Deprecated
+    public BorderStyle getBorderStyle(CellAddress cell, String propertyName) {
+        return getBorderStyle(cell, CellUtil.namePropertyMap.get(propertyName));
+    }
+
+    /**
+     * Retrieves the border style for a given cell
      */
     public BorderStyle getBorderStyle(int row, int col, CellPropertyType property) {
         return getBorderStyle(new CellAddress(row, col), property);
+    }
+
+    /**
+     * Retrieves the border style for a given cell
+     *
+     * @deprecated See {@link #getBorderStyle(int, int, CellPropertyType)}
+     */
+    @Deprecated
+    public BorderStyle getBorderStyle(int row, int col, String propertyName) {
+        return getBorderStyle(new CellAddress(row, col), CellUtil.namePropertyMap.get(propertyName));
     }
 
     /**
@@ -897,9 +872,29 @@ public final class PropertyTemplate {
 
     /**
      * Retrieves the border style for a given cell
+     *
+     * @deprecated See {@link #getTemplateProperty(CellAddress, CellPropertyType)}
+     */
+    @Deprecated
+    public short getTemplateProperty(CellAddress cell, String propertyName) {
+        return getTemplateProperty(cell, CellUtil.namePropertyMap.get(propertyName));
+    }
+
+    /**
+     * Retrieves the border style for a given cell
      */
     public short getTemplateProperty(int row, int col, CellPropertyType property) {
         return getTemplateProperty(new CellAddress(row, col), property);
+    }
+
+    /**
+     * Retrieves the border style for a given cell
+     *
+     * @deprecated See {@link #getTemplateProperty(int, int, CellPropertyType)}
+     */
+    @Deprecated
+    public short getTemplateProperty(int row, int col, String propertyName) {
+        return getTemplateProperty(new CellAddress(row, col), CellUtil.namePropertyMap.get(propertyName));
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/ss/util/PropertyTemplate.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/PropertyTemplate.java
@@ -19,7 +19,15 @@ package org.apache.poi.ss.util;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.SpreadsheetVersion;
-import org.apache.poi.ss.usermodel.*;
+
+import org.apache.poi.ss.usermodel.BorderExtent;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellPropertyType;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,7 +40,7 @@ import java.util.Set;
  * a project. It contains all the border type and color attributes needed to
  * draw all the borders for a single sheet. That template can be applied to any
  * sheet in any workbook.
- * <p>
+ *
  * This class requires the full spreadsheet to be in memory, so
  * {@link org.apache.poi.xssf.streaming.SXSSFWorkbook} Spreadsheets are not
  * supported. The same PropertyTemplate can, however, be applied to both
@@ -85,11 +93,14 @@ public final class PropertyTemplate {
      * applied to the cells at this time, just the template is drawn. To apply
      * the drawn borders to a sheet, use {@link #applyBorders}.
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
-     * @param extent     - {@link BorderExtent} of the borders to be
-     *                   applied.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
+     * @param extent
+     *            - {@link BorderExtent} of the borders to be
+     *            applied.
      */
     public void drawBorders(CellRangeAddress range, BorderStyle borderType,
                             BorderExtent extent) {
@@ -146,13 +157,17 @@ public final class PropertyTemplate {
      * applied to the cells at this time, just the template is drawn. To apply
      * the drawn borders to a sheet, use {@link #applyBorders}.
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
-     * @param color      - Color index from {@link IndexedColors} used to draw the
-     *                   borders.
-     * @param extent     - {@link BorderExtent} of the borders to be
-     *                   applied.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
+     * @param extent
+     *            - {@link BorderExtent} of the borders to be
+     *            applied.
      */
     public void drawBorders(CellRangeAddress range, BorderStyle borderType,
                             short color, BorderExtent extent) {
@@ -167,9 +182,11 @@ public final class PropertyTemplate {
      * Draws the top border for a range of cells
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
      */
     private void drawTopBorder(CellRangeAddress range, BorderStyle borderType) {
         int row = range.getFirstRow();
@@ -188,9 +205,11 @@ public final class PropertyTemplate {
      * Draws the bottom border for a range of cells
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
      */
     private void drawBottomBorder(CellRangeAddress range,
                                   BorderStyle borderType) {
@@ -211,9 +230,11 @@ public final class PropertyTemplate {
      * Draws the left border for a range of cells
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
      */
     private void drawLeftBorder(CellRangeAddress range,
                                 BorderStyle borderType) {
@@ -233,9 +254,11 @@ public final class PropertyTemplate {
      * Draws the right border for a range of cells
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
      */
     private void drawRightBorder(CellRangeAddress range,
                                  BorderStyle borderType) {
@@ -256,16 +279,19 @@ public final class PropertyTemplate {
      * Draws the outside borders for a range of cells.
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
-     * @param extent     - {@link BorderExtent} of the borders to be
-     *                   applied. Valid Values are:
-     *                   <ul>
-     *                   <li>BorderExtent.ALL</li>
-     *                   <li>BorderExtent.HORIZONTAL</li>
-     *                   <li>BorderExtent.VERTICAL</li>
-     *                   </ul>
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
+     * @param extent
+     *            - {@link BorderExtent} of the borders to be
+     *            applied. Valid Values are:
+     *            <ul>
+     *            <li>BorderExtent.ALL</li>
+     *            <li>BorderExtent.HORIZONTAL</li>
+     *            <li>BorderExtent.VERTICAL</li>
+     *            </ul>
      */
     private void drawOutsideBorders(CellRangeAddress range,
                                     BorderStyle borderType, BorderExtent extent) {
@@ -293,15 +319,18 @@ public final class PropertyTemplate {
      * Draws the horizontal borders for a range of cells.
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
-     * @param extent     - {@link BorderExtent} of the borders to be
-     *                   applied. Valid Values are:
-     *                   <ul>
-     *                   <li>BorderExtent.ALL</li>
-     *                   <li>BorderExtent.INSIDE</li>
-     *                   </ul>
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
+     * @param extent
+     *            - {@link BorderExtent} of the borders to be
+     *            applied. Valid Values are:
+     *            <ul>
+     *            <li>BorderExtent.ALL</li>
+     *            <li>BorderExtent.INSIDE</li>
+     *            </ul>
      */
     private void drawHorizontalBorders(CellRangeAddress range,
                                        BorderStyle borderType, BorderExtent extent) {
@@ -334,15 +363,18 @@ public final class PropertyTemplate {
      * Draws the vertical borders for a range of cells.
      * </p>
      *
-     * @param range      - {@link CellRangeAddress} range of cells on which borders are
-     *                   drawn.
-     * @param borderType - Type of border to draw. {@link BorderStyle}.
-     * @param extent     - {@link BorderExtent} of the borders to be
-     *                   applied. Valid Values are:
-     *                   <ul>
-     *                   <li>BorderExtent.ALL</li>
-     *                   <li>BorderExtent.INSIDE</li>
-     *                   </ul>
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which borders are
+     *            drawn.
+     * @param borderType
+     *            - Type of border to draw. {@link BorderStyle}.
+     * @param extent
+     *            - {@link BorderExtent} of the borders to be
+     *            applied. Valid Values are:
+     *            <ul>
+     *            <li>BorderExtent.ALL</li>
+     *            <li>BorderExtent.INSIDE</li>
+     *            </ul>
      */
     private void drawVerticalBorders(CellRangeAddress range,
                                      BorderStyle borderType, BorderExtent extent) {
@@ -396,7 +428,8 @@ public final class PropertyTemplate {
      * the ones that have been drawn by the {@link #drawBorders} and
      * {@link #drawBorderColors} methods.
      *
-     * @param sheet - {@link Sheet} on which to apply borders
+     * @param sheet
+     *            - {@link Sheet} on which to apply borders
      */
     public void applyBorders(Sheet sheet) {
         Workbook wb = sheet.getWorkbook();
@@ -420,12 +453,15 @@ public final class PropertyTemplate {
      * the borders do not exist, a BORDER_THIN border is used. To apply the
      * drawn borders to a sheet, use {@link #applyBorders}.
      *
-     * @param range  - {@link CellRangeAddress} range of cells on which colors are
-     *               set.
-     * @param color  - Color index from {@link IndexedColors} used to draw the
-     *               borders.
-     * @param extent - {@link BorderExtent} of the borders for which
-     *               colors are set.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
+     * @param extent
+     *            - {@link BorderExtent} of the borders for which
+     *            colors are set.
      */
     public void drawBorderColors(CellRangeAddress range, short color,
                                  BorderExtent extent) {
@@ -482,10 +518,12 @@ public final class PropertyTemplate {
      * Sets the color of the top border for a range of cells.
      * </p>
      *
-     * @param range - {@link CellRangeAddress} range of cells on which colors are
-     *              set.
-     * @param color - Color index from {@link IndexedColors} used to draw the
-     *              borders.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
      */
     private void drawTopBorderColor(CellRangeAddress range, short color) {
         int row = range.getFirstRow();
@@ -506,10 +544,12 @@ public final class PropertyTemplate {
      * Sets the color of the bottom border for a range of cells.
      * </p>
      *
-     * @param range - {@link CellRangeAddress} range of cells on which colors are
-     *              set.
-     * @param color - Color index from {@link IndexedColors} used to draw the
-     *              borders.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
      */
     private void drawBottomBorderColor(CellRangeAddress range, short color) {
         int row = range.getLastRow();
@@ -530,10 +570,12 @@ public final class PropertyTemplate {
      * Sets the color of the left border for a range of cells.
      * </p>
      *
-     * @param range - {@link CellRangeAddress} range of cells on which colors are
-     *              set.
-     * @param color - Color index from {@link IndexedColors} used to draw the
-     *              borders.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
      */
     private void drawLeftBorderColor(CellRangeAddress range, short color) {
         int firstRow = range.getFirstRow();
@@ -555,10 +597,12 @@ public final class PropertyTemplate {
      * not drawn, it defaults to BORDER_THIN
      * </p>
      *
-     * @param range - {@link CellRangeAddress} range of cells on which colors are
-     *              set.
-     * @param color - Color index from {@link IndexedColors} used to draw the
-     *              borders.
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
      */
     private void drawRightBorderColor(CellRangeAddress range, short color) {
         int firstRow = range.getFirstRow();
@@ -579,17 +623,20 @@ public final class PropertyTemplate {
      * Sets the color of the outside borders for a range of cells.
      * </p>
      *
-     * @param range  - {@link CellRangeAddress} range of cells on which colors are
-     *               set.
-     * @param color  - Color index from {@link IndexedColors} used to draw the
-     *               borders.
-     * @param extent - {@link BorderExtent} of the borders for which
-     *               colors are set. Valid Values are:
-     *               <ul>
-     *               <li>BorderExtent.ALL</li>
-     *               <li>BorderExtent.HORIZONTAL</li>
-     *               <li>BorderExtent.VERTICAL</li>
-     *               </ul>
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
+     * @param extent
+     *            - {@link BorderExtent} of the borders for which
+     *            colors are set. Valid Values are:
+     *            <ul>
+     *            <li>BorderExtent.ALL</li>
+     *            <li>BorderExtent.HORIZONTAL</li>
+     *            <li>BorderExtent.VERTICAL</li>
+     *            </ul>
      */
     private void drawOutsideBorderColors(CellRangeAddress range, short color,
                                          BorderExtent extent) {
@@ -617,16 +664,19 @@ public final class PropertyTemplate {
      * Sets the color of the horizontal borders for a range of cells.
      * </p>
      *
-     * @param range  - {@link CellRangeAddress} range of cells on which colors are
-     *               set.
-     * @param color  - Color index from {@link IndexedColors} used to draw the
-     *               borders.
-     * @param extent - {@link BorderExtent} of the borders for which
-     *               colors are set. Valid Values are:
-     *               <ul>
-     *               <li>BorderExtent.ALL</li>
-     *               <li>BorderExtent.INSIDE</li>
-     *               </ul>
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
+     * @param extent
+     *            - {@link BorderExtent} of the borders for which
+     *            colors are set. Valid Values are:
+     *            <ul>
+     *            <li>BorderExtent.ALL</li>
+     *            <li>BorderExtent.INSIDE</li>
+     *            </ul>
      */
     private void drawHorizontalBorderColors(CellRangeAddress range, short color,
                                             BorderExtent extent) {
@@ -659,16 +709,19 @@ public final class PropertyTemplate {
      * Sets the color of the vertical borders for a range of cells.
      * </p>
      *
-     * @param range  - {@link CellRangeAddress} range of cells on which colors are
-     *               set.
-     * @param color  - Color index from {@link IndexedColors} used to draw the
-     *               borders.
-     * @param extent - {@link BorderExtent} of the borders for which
-     *               colors are set. Valid Values are:
-     *               <ul>
-     *               <li>BorderExtent.ALL</li>
-     *               <li>BorderExtent.INSIDE</li>
-     *               </ul>
+     * @param range
+     *            - {@link CellRangeAddress} range of cells on which colors are
+     *            set.
+     * @param color
+     *            - Color index from {@link IndexedColors} used to draw the
+     *            borders.
+     * @param extent
+     *            - {@link BorderExtent} of the borders for which
+     *            colors are set. Valid Values are:
+     *            <ul>
+     *            <li>BorderExtent.ALL</li>
+     *            <li>BorderExtent.INSIDE</li>
+     *            </ul>
      */
     private void drawVerticalBorderColors(CellRangeAddress range, short color,
                                           BorderExtent extent) {

--- a/poi/src/main/java/org/apache/poi/ss/util/PropertyTemplate.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/PropertyTemplate.java
@@ -409,7 +409,7 @@ public final class PropertyTemplate {
                 Map<CellPropertyType, Object> properties = entry.getValue();
                 Row row = CellUtil.getRow(cellAddress.getRow(), sheet);
                 Cell cell = CellUtil.getCell(row, cellAddress.getColumn());
-                CellUtil.setCellStyleProperties(cell, properties);
+                CellUtil.setCellStylePropertiesEnum(cell, properties);
             }
         }
     }

--- a/poi/src/main/java/org/apache/poi/ss/util/RegionUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/RegionUtil.java
@@ -17,10 +17,7 @@
 
 package org.apache.poi.ss.util;
 
-import org.apache.poi.ss.usermodel.BorderStyle;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.*;
 
 /**
  * Various utility functions that make working with a region of cells easier.
@@ -36,33 +33,34 @@ public final class RegionUtil {
      */
     private static final class CellPropertySetter {
 
-        private final String _propertyName;
+        private final CellPropertyType property;
         private final Object _propertyValue;
 
 
-        public CellPropertySetter(String propertyName, int value) {
-            _propertyName = propertyName;
+        public CellPropertySetter(CellPropertyType property, int value) {
+            this.property = property;
             _propertyValue = Integer.valueOf(value);
         }
-        public CellPropertySetter(String propertyName, BorderStyle value) {
-            _propertyName = propertyName;
+
+        public CellPropertySetter(CellPropertyType property, BorderStyle value) {
+            this.property = property;
             _propertyValue = value;
         }
 
         public void setProperty(Row row, int column) {
             // create cell if it does not exist
             Cell cell = CellUtil.getCell(row, column);
-            CellUtil.setCellStyleProperty(cell, _propertyName, _propertyValue);
+            CellUtil.setCellStyleProperty(cell, property, _propertyValue);
         }
     }
 
     /**
      * Sets the left border style for a region of cells by manipulating the cell style of the individual
      * cells on the left
-     * 
+     *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderLeft(BorderStyle border, CellRangeAddress region, Sheet sheet) {
@@ -70,7 +68,7 @@ public final class RegionUtil {
         int rowEnd = region.getLastRow();
         int column = region.getFirstColumn();
 
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.BORDER_LEFT, border);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.BORDER_LEFT, border);
         for (int i = rowStart; i <= rowEnd; i++) {
             cps.setProperty(CellUtil.getRow(i, sheet), column);
         }
@@ -79,10 +77,10 @@ public final class RegionUtil {
     /**
      * Sets the left border color for a region of cells by manipulating the cell style of the individual
      * cells on the left
-     * 
-     * @param color The color of the border
+     *
+     * @param color  The color of the border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setLeftBorderColor(int color, CellRangeAddress region, Sheet sheet) {
@@ -90,7 +88,7 @@ public final class RegionUtil {
         int rowEnd = region.getLastRow();
         int column = region.getFirstColumn();
 
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.LEFT_BORDER_COLOR, color);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.LEFT_BORDER_COLOR, color);
         for (int i = rowStart; i <= rowEnd; i++) {
             cps.setProperty(CellUtil.getRow(i, sheet), column);
         }
@@ -99,10 +97,10 @@ public final class RegionUtil {
     /**
      * Sets the right border style for a region of cells by manipulating the cell style of the individual
      * cells on the right
-     * 
+     *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderRight(BorderStyle border, CellRangeAddress region, Sheet sheet) {
@@ -110,7 +108,7 @@ public final class RegionUtil {
         int rowEnd = region.getLastRow();
         int column = region.getLastColumn();
 
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.BORDER_RIGHT, border);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.BORDER_RIGHT, border);
         for (int i = rowStart; i <= rowEnd; i++) {
             cps.setProperty(CellUtil.getRow(i, sheet), column);
         }
@@ -119,10 +117,10 @@ public final class RegionUtil {
     /**
      * Sets the right border color for a region of cells by manipulating the cell style of the individual
      * cells on the right
-     * 
-     * @param color The color of the border
+     *
+     * @param color  The color of the border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setRightBorderColor(int color, CellRangeAddress region, Sheet sheet) {
@@ -130,7 +128,7 @@ public final class RegionUtil {
         int rowEnd = region.getLastRow();
         int column = region.getLastColumn();
 
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.RIGHT_BORDER_COLOR, color);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.RIGHT_BORDER_COLOR, color);
         for (int i = rowStart; i <= rowEnd; i++) {
             cps.setProperty(CellUtil.getRow(i, sheet), column);
         }
@@ -139,17 +137,17 @@ public final class RegionUtil {
     /**
      * Sets the bottom border style for a region of cells by manipulating the cell style of the individual
      * cells on the bottom
-     * 
+     *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderBottom(BorderStyle border, CellRangeAddress region, Sheet sheet) {
         int colStart = region.getFirstColumn();
         int colEnd = region.getLastColumn();
         int rowIndex = region.getLastRow();
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.BORDER_BOTTOM, border);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.BORDER_BOTTOM, border);
         Row row = CellUtil.getRow(rowIndex, sheet);
         for (int i = colStart; i <= colEnd; i++) {
             cps.setProperty(row, i);
@@ -159,17 +157,17 @@ public final class RegionUtil {
     /**
      * Sets the bottom border color for a region of cells by manipulating the cell style of the individual
      * cells on the bottom
-     * 
-     * @param color The color of the border
+     *
+     * @param color  The color of the border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setBottomBorderColor(int color, CellRangeAddress region, Sheet sheet) {
         int colStart = region.getFirstColumn();
         int colEnd = region.getLastColumn();
         int rowIndex = region.getLastRow();
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.BOTTOM_BORDER_COLOR, color);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.BOTTOM_BORDER_COLOR, color);
         Row row = CellUtil.getRow(rowIndex, sheet);
         for (int i = colStart; i <= colEnd; i++) {
             cps.setProperty(row, i);
@@ -179,17 +177,17 @@ public final class RegionUtil {
     /**
      * Sets the top border style for a region of cells by manipulating the cell style of the individual
      * cells on the top
-     * 
+     *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderTop(BorderStyle border, CellRangeAddress region, Sheet sheet) {
         int colStart = region.getFirstColumn();
         int colEnd = region.getLastColumn();
         int rowIndex = region.getFirstRow();
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.BORDER_TOP, border);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.BORDER_TOP, border);
         Row row = CellUtil.getRow(rowIndex, sheet);
         for (int i = colStart; i <= colEnd; i++) {
             cps.setProperty(row, i);
@@ -199,17 +197,17 @@ public final class RegionUtil {
     /**
      * Sets the top border color for a region of cells by manipulating the cell style of the individual
      * cells on the top
-     * 
-     * @param color The color of the border
+     *
+     * @param color  The color of the border
      * @param region The region that should have the border
-     * @param sheet The sheet that the region is on.
+     * @param sheet  The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setTopBorderColor(int color, CellRangeAddress region, Sheet sheet) {
         int colStart = region.getFirstColumn();
         int colEnd = region.getLastColumn();
         int rowIndex = region.getFirstRow();
-        CellPropertySetter cps = new CellPropertySetter(CellUtil.TOP_BORDER_COLOR, color);
+        CellPropertySetter cps = new CellPropertySetter(CellPropertyType.TOP_BORDER_COLOR, color);
         Row row = CellUtil.getRow(rowIndex, sheet);
         for (int i = colStart; i <= colEnd; i++) {
             cps.setProperty(row, i);

--- a/poi/src/main/java/org/apache/poi/ss/util/RegionUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/RegionUtil.java
@@ -36,6 +36,15 @@ public final class RegionUtil {
         private final CellPropertyType property;
         private final Object _propertyValue;
 
+        @Deprecated
+        public CellPropertySetter(String propertyName, int value) {
+            this(CellUtil.namePropertyMap.get(propertyName), value);
+        }
+
+        @Deprecated
+        public CellPropertySetter(String propertyName, BorderStyle value) {
+            this(CellUtil.namePropertyMap.get(propertyName), value);
+        }
 
         public CellPropertySetter(CellPropertyType property, int value) {
             this.property = property;

--- a/poi/src/main/java/org/apache/poi/ss/util/RegionUtil.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/RegionUtil.java
@@ -69,7 +69,7 @@ public final class RegionUtil {
      *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderLeft(BorderStyle border, CellRangeAddress region, Sheet sheet) {
@@ -87,9 +87,9 @@ public final class RegionUtil {
      * Sets the left border color for a region of cells by manipulating the cell style of the individual
      * cells on the left
      *
-     * @param color  The color of the border
+     * @param color The color of the border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setLeftBorderColor(int color, CellRangeAddress region, Sheet sheet) {
@@ -109,7 +109,7 @@ public final class RegionUtil {
      *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderRight(BorderStyle border, CellRangeAddress region, Sheet sheet) {
@@ -127,9 +127,9 @@ public final class RegionUtil {
      * Sets the right border color for a region of cells by manipulating the cell style of the individual
      * cells on the right
      *
-     * @param color  The color of the border
+     * @param color The color of the border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setRightBorderColor(int color, CellRangeAddress region, Sheet sheet) {
@@ -149,7 +149,7 @@ public final class RegionUtil {
      *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderBottom(BorderStyle border, CellRangeAddress region, Sheet sheet) {
@@ -167,9 +167,9 @@ public final class RegionUtil {
      * Sets the bottom border color for a region of cells by manipulating the cell style of the individual
      * cells on the bottom
      *
-     * @param color  The color of the border
+     * @param color The color of the border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setBottomBorderColor(int color, CellRangeAddress region, Sheet sheet) {
@@ -189,7 +189,7 @@ public final class RegionUtil {
      *
      * @param border The new border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.16 beta 1
      */
     public static void setBorderTop(BorderStyle border, CellRangeAddress region, Sheet sheet) {
@@ -207,9 +207,9 @@ public final class RegionUtil {
      * Sets the top border color for a region of cells by manipulating the cell style of the individual
      * cells on the top
      *
-     * @param color  The color of the border
+     * @param color The color of the border
      * @param region The region that should have the border
-     * @param sheet  The sheet that the region is on.
+     * @param sheet The sheet that the region is on.
      * @since POI 3.15 beta 2
      */
     public static void setTopBorderColor(int color, CellRangeAddress region, Sheet sheet) {

--- a/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
@@ -30,17 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.poi.ss.ITestDataProvider;
-import org.apache.poi.ss.usermodel.BorderStyle;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.FillPatternType;
-import org.apache.poi.ss.usermodel.Font;
-import org.apache.poi.ss.usermodel.HorizontalAlignment;
-import org.apache.poi.ss.usermodel.IndexedColors;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.VerticalAlignment;
-import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.*;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -64,13 +54,13 @@ public abstract class BaseTestCellUtil {
 
             // Add a border should create a new style
             int styCnt1 = wb.getNumCellStyles();
-            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
             int styCnt2 = wb.getNumCellStyles();
             assertEquals(styCnt1 + 1, styCnt2);
 
             // Add same border to another cell, should not create another style
             c = r.createCell(1);
-            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
             int styCnt3 = wb.getNumCellStyles();
             assertEquals(styCnt2, styCnt3);
         }
@@ -84,7 +74,7 @@ public abstract class BaseTestCellUtil {
             Cell c = r.createCell(0);
 
             // An invalid BorderStyle constant
-            assertThrows(RuntimeException.class, () -> CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, 42));
+            assertThrows(RuntimeException.class, () -> CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_BOTTOM, 42));
         }
     }
 
@@ -96,11 +86,11 @@ public abstract class BaseTestCellUtil {
             Cell c = r.createCell(0);
 
             // A valid BorderStyle constant, as a Short
-            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.DASH_DOT.getCode());
+            CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_BOTTOM, BorderStyle.DASH_DOT.getCode());
             assertEquals(BorderStyle.DASH_DOT, c.getCellStyle().getBorderBottom());
 
             // A valid BorderStyle constant, as an Enum
-            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_TOP, BorderStyle.MEDIUM_DASH_DOT);
+            CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_TOP, BorderStyle.MEDIUM_DASH_DOT);
             assertEquals(BorderStyle.MEDIUM_DASH_DOT, c.getCellStyle().getBorderTop());
         }
     }
@@ -116,7 +106,7 @@ public abstract class BaseTestCellUtil {
             assertFalse(c.getCellStyle().getShrinkToFit());
 
             // Set shrinkToFit to true
-            CellUtil.setCellStyleProperty(c, CellUtil.SHRINK_TO_FIT, true);
+            CellUtil.setCellStyleProperty(c, CellPropertyType.SHRINK_TO_FIT, true);
             assertTrue(c.getCellStyle().getShrinkToFit());
         }
     }
@@ -132,7 +122,7 @@ public abstract class BaseTestCellUtil {
             assertFalse(c.getCellStyle().getQuotePrefixed());
 
             // Set quotePrefixed to true
-            CellUtil.setCellStyleProperty(c, CellUtil.QUOTE_PREFIXED, true);
+            CellUtil.setCellStyleProperty(c, CellPropertyType.QUOTE_PREFIXED, true);
             assertTrue(c.getCellStyle().getQuotePrefixed());
         }
     }
@@ -197,7 +187,7 @@ public abstract class BaseTestCellUtil {
             c.setCellStyle(cs);
 
             // Set BorderBottom from THIN to DOUBLE with setCellStyleProperty()
-            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.DOUBLE);
+            CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_BOTTOM, BorderStyle.DOUBLE);
 
             // Assert that only BorderBottom has been changed and no others.
             assertEquals(BorderStyle.DOUBLE, c.getCellStyle().getBorderBottom());
@@ -234,13 +224,13 @@ public abstract class BaseTestCellUtil {
 
             // Add multiple border properties to cell should create a single new style
             int styCnt1 = wb.getNumCellStyles();
-            Map<String, Object> props = new HashMap<>();
-            props.put(CellUtil.BORDER_TOP, BorderStyle.THIN);
-            props.put(CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
-            props.put(CellUtil.BORDER_LEFT, BorderStyle.THIN);
-            props.put(CellUtil.BORDER_RIGHT, BorderStyle.THIN);
-            props.put(CellUtil.ALIGNMENT, HorizontalAlignment.CENTER.getCode()); // try it both with a Short (deprecated)
-            props.put(CellUtil.VERTICAL_ALIGNMENT, VerticalAlignment.CENTER); // and with an enum
+            Map<CellPropertyType, Object> props = new HashMap<>();
+            props.put(CellPropertyType.BORDER_TOP, BorderStyle.THIN);
+            props.put(CellPropertyType.BORDER_BOTTOM, BorderStyle.THIN);
+            props.put(CellPropertyType.BORDER_LEFT, BorderStyle.THIN);
+            props.put(CellPropertyType.BORDER_RIGHT, BorderStyle.THIN);
+            props.put(CellPropertyType.ALIGNMENT, HorizontalAlignment.CENTER.getCode()); // try it both with a Short (deprecated)
+            props.put(CellPropertyType.VERTICAL_ALIGNMENT, VerticalAlignment.CENTER); // and with an enum
             CellUtil.setCellStyleProperties(c, props);
             int styCnt2 = wb.getNumCellStyles();
             assertEquals(styCnt1 + 1, styCnt2, "Only one additional style should have been created");
@@ -468,10 +458,10 @@ public abstract class BaseTestCellUtil {
     protected void setFillForegroundColorBeforeFillBackgroundColorEnum() throws IOException {
         try (Workbook wb1 = _testDataProvider.createWorkbook()) {
             Cell A1 = wb1.createSheet().createRow(0).createCell(0);
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(CellUtil.FILL_PATTERN, FillPatternType.BRICKS);
-            properties.put(CellUtil.FILL_FOREGROUND_COLOR, IndexedColors.BLUE.index);
-            properties.put(CellUtil.FILL_BACKGROUND_COLOR, IndexedColors.RED.index);
+            Map<CellPropertyType, Object> properties = new HashMap<>();
+            properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.BRICKS);
+            properties.put(CellPropertyType.FILL_FOREGROUND_COLOR, IndexedColors.BLUE.index);
+            properties.put(CellPropertyType.FILL_BACKGROUND_COLOR, IndexedColors.RED.index);
 
             CellUtil.setCellStyleProperties(A1, properties);
             CellStyle style = A1.getCellStyle();

--- a/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
@@ -25,7 +25,13 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests Spreadsheet CellUtil
@@ -61,7 +67,6 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     void setCellStyleProperty() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
@@ -96,7 +101,6 @@ public abstract class BaseTestCellUtil {
 
 
     @Test
-    @Deprecated
     void setCellStylePropertyWithInvalidValue() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
@@ -109,7 +113,6 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test()
-    @Deprecated
     void setCellStylePropertyBorderWithShortAndEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
@@ -160,7 +163,6 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test()
-    @Deprecated
     void setCellStylePropertyWithShrinkToFit() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
@@ -193,7 +195,6 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test()
-    @Deprecated
     void setCellStylePropertyWithQuotePrefixed() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
@@ -302,7 +303,6 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test
-    @Deprecated
     void setCellStyleProperties() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
@@ -593,7 +593,6 @@ public abstract class BaseTestCellUtil {
      * @since POI 3.15 beta 3
      */
     @Test
-    @Deprecated
     protected void setFillForegroundColorBeforeFillBackgroundColorEnum() throws IOException {
         try (Workbook wb1 = _testDataProvider.createWorkbook()) {
             Cell A1 = wb1.createSheet().createRow(0).createCell(0);

--- a/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
@@ -17,21 +17,15 @@
 
 package org.apache.poi.ss.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.apache.poi.ss.ITestDataProvider;
+import org.apache.poi.ss.usermodel.*;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.poi.ss.ITestDataProvider;
-import org.apache.poi.ss.usermodel.*;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests Spreadsheet CellUtil
@@ -46,7 +40,7 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test
-    void setCellStyleProperty() throws IOException {
+    void setCellStylePropertyByEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
@@ -67,7 +61,29 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test
-    void setCellStylePropertyWithInvalidValue() throws IOException {
+    @Deprecated
+    void setCellStyleProperty() throws IOException {
+        try (Workbook wb = _testDataProvider.createWorkbook()) {
+            Sheet s = wb.createSheet();
+            Row r = s.createRow(0);
+            Cell c = r.createCell(0);
+
+            // Add a border should create a new style
+            int styCnt1 = wb.getNumCellStyles();
+            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            int styCnt2 = wb.getNumCellStyles();
+            assertEquals(styCnt1 + 1, styCnt2);
+
+            // Add same border to another cell, should not create another style
+            c = r.createCell(1);
+            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            int styCnt3 = wb.getNumCellStyles();
+            assertEquals(styCnt2, styCnt3);
+        }
+    }
+
+    @Test
+    void setCellStylePropertyWithInvalidValueByEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
@@ -78,8 +94,40 @@ public abstract class BaseTestCellUtil {
         }
     }
 
+
+    @Test
+    @Deprecated
+    void setCellStylePropertyWithInvalidValue() throws IOException {
+        try (Workbook wb = _testDataProvider.createWorkbook()) {
+            Sheet s = wb.createSheet();
+            Row r = s.createRow(0);
+            Cell c = r.createCell(0);
+
+            // An invalid BorderStyle constant
+            assertThrows(RuntimeException.class, () -> CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, 42));
+        }
+    }
+
     @Test()
+    @Deprecated
     void setCellStylePropertyBorderWithShortAndEnum() throws IOException {
+        try (Workbook wb = _testDataProvider.createWorkbook()) {
+            Sheet s = wb.createSheet();
+            Row r = s.createRow(0);
+            Cell c = r.createCell(0);
+
+            // A valid BorderStyle constant, as a Short
+            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_BOTTOM, BorderStyle.DASH_DOT.getCode());
+            assertEquals(BorderStyle.DASH_DOT, c.getCellStyle().getBorderBottom());
+
+            // A valid BorderStyle constant, as an Enum
+            CellUtil.setCellStyleProperty(c, CellUtil.BORDER_TOP, BorderStyle.MEDIUM_DASH_DOT);
+            assertEquals(BorderStyle.MEDIUM_DASH_DOT, c.getCellStyle().getBorderTop());
+        }
+    }
+
+    @Test()
+    void setCellStylePropertyBorderWithShortAndEnumByEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
@@ -96,7 +144,7 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test()
-    void setCellStylePropertyWithShrinkToFit() throws IOException {
+    void setCellStylePropertyWithShrinkToFitByEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
@@ -112,7 +160,24 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test()
-    void setCellStylePropertyWithQuotePrefixed() throws IOException {
+    @Deprecated
+    void setCellStylePropertyWithShrinkToFit() throws IOException {
+        try (Workbook wb = _testDataProvider.createWorkbook()) {
+            Sheet s = wb.createSheet();
+            Row r = s.createRow(0);
+            Cell c = r.createCell(0);
+
+            // Assert that the default shrinkToFit is false
+            assertFalse(c.getCellStyle().getShrinkToFit());
+
+            // Set shrinkToFit to true
+            CellUtil.setCellStyleProperty(c, CellUtil.SHRINK_TO_FIT, true);
+            assertTrue(c.getCellStyle().getShrinkToFit());
+        }
+    }
+
+    @Test()
+    void setCellStylePropertyWithQuotePrefixedByEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
@@ -128,11 +193,29 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test()
+    @Deprecated
+    void setCellStylePropertyWithQuotePrefixed() throws IOException {
+        try (Workbook wb = _testDataProvider.createWorkbook()) {
+            Sheet s = wb.createSheet();
+            Row r = s.createRow(0);
+            Cell c = r.createCell(0);
+
+            // Assert that the default quotePrefixed is false
+            assertFalse(c.getCellStyle().getQuotePrefixed());
+
+            // Set quotePrefixed to true
+            CellUtil.setCellStyleProperty(c, CellUtil.QUOTE_PREFIXED, true);
+            assertTrue(c.getCellStyle().getQuotePrefixed());
+        }
+    }
+
+    @Test()
     void setCellStylePropertyWithExistingStyles() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
             Cell c = r.createCell(0);
+            Cell c2 = r.createCell(1);
             Font f = wb.createFont();
             f.setBold(true);
 
@@ -185,12 +268,15 @@ public abstract class BaseTestCellUtil {
             cs.setShrinkToFit(true);
             cs.setQuotePrefixed(true);
             c.setCellStyle(cs);
+            c2.setCellStyle(cs);
 
             // Set BorderBottom from THIN to DOUBLE with setCellStyleProperty()
             CellUtil.setCellStyleProperty(c, CellPropertyType.BORDER_BOTTOM, BorderStyle.DOUBLE);
+            CellUtil.setCellStyleProperty(c2, CellUtil.BORDER_BOTTOM, BorderStyle.DOUBLE);
 
             // Assert that only BorderBottom has been changed and no others.
             assertEquals(BorderStyle.DOUBLE, c.getCellStyle().getBorderBottom());
+            assertEquals(BorderStyle.DOUBLE, c2.getCellStyle().getBorderBottom());
             assertEquals(HorizontalAlignment.CENTER, c.getCellStyle().getAlignment());
             assertEquals(BorderStyle.THIN, c.getCellStyle().getBorderLeft());
             assertEquals(BorderStyle.THIN, c.getCellStyle().getBorderRight());
@@ -216,7 +302,36 @@ public abstract class BaseTestCellUtil {
     }
 
     @Test
+    @Deprecated
     void setCellStyleProperties() throws IOException {
+        try (Workbook wb = _testDataProvider.createWorkbook()) {
+            Sheet s = wb.createSheet();
+            Row r = s.createRow(0);
+            Cell c = r.createCell(0);
+
+            // Add multiple border properties to cell should create a single new style
+            int styCnt1 = wb.getNumCellStyles();
+            Map<String, Object> props = new HashMap<>();
+            props.put(CellUtil.BORDER_TOP, BorderStyle.THIN);
+            props.put(CellUtil.BORDER_BOTTOM, BorderStyle.THIN);
+            props.put(CellUtil.BORDER_LEFT, BorderStyle.THIN);
+            props.put(CellUtil.BORDER_RIGHT, BorderStyle.THIN);
+            props.put(CellUtil.ALIGNMENT, HorizontalAlignment.CENTER.getCode()); // try it both with a Short (deprecated)
+            props.put(CellUtil.VERTICAL_ALIGNMENT, VerticalAlignment.CENTER); // and with an enum
+            CellUtil.setCellStyleProperties(c, props);
+            int styCnt2 = wb.getNumCellStyles();
+            assertEquals(styCnt1 + 1, styCnt2, "Only one additional style should have been created");
+
+            // Add same border another to same cell, should not create another style
+            c = r.createCell(1);
+            CellUtil.setCellStyleProperties(c, props);
+            int styCnt3 = wb.getNumCellStyles();
+            assertEquals(styCnt2, styCnt3, "No additional styles should have been created");
+        }
+    }
+
+    @Test
+    void setCellStylePropertiesEnum() throws IOException {
         try (Workbook wb = _testDataProvider.createWorkbook()) {
             Sheet s = wb.createSheet();
             Row r = s.createRow(0);
@@ -231,13 +346,13 @@ public abstract class BaseTestCellUtil {
             props.put(CellPropertyType.BORDER_RIGHT, BorderStyle.THIN);
             props.put(CellPropertyType.ALIGNMENT, HorizontalAlignment.CENTER.getCode()); // try it both with a Short (deprecated)
             props.put(CellPropertyType.VERTICAL_ALIGNMENT, VerticalAlignment.CENTER); // and with an enum
-            CellUtil.setCellStyleProperties(c, props);
+            CellUtil.setCellStylePropertiesEnum(c, props);
             int styCnt2 = wb.getNumCellStyles();
             assertEquals(styCnt1 + 1, styCnt2, "Only one additional style should have been created");
 
             // Add same border another to same cell, should not create another style
             c = r.createCell(1);
-            CellUtil.setCellStyleProperties(c, props);
+            CellUtil.setCellStylePropertiesEnum(c, props);
             int styCnt3 = wb.getNumCellStyles();
             assertEquals(styCnt2, styCnt3, "No additional styles should have been created");
         }
@@ -433,7 +548,7 @@ public abstract class BaseTestCellUtil {
     @Test
     void setFontFromDifferentWorkbook() throws IOException {
         try (Workbook wb1 = _testDataProvider.createWorkbook();
-            Workbook wb2 = _testDataProvider.createWorkbook()) {
+             Workbook wb2 = _testDataProvider.createWorkbook()) {
             Font font1 = wb1.createFont();
             Font font2 = wb2.createFont();
             // do something to make font1 and font2 different
@@ -452,16 +567,40 @@ public abstract class BaseTestCellUtil {
 
     /**
      * bug 55555
+     *
      * @since POI 3.15 beta 3
      */
     @Test
-    protected void setFillForegroundColorBeforeFillBackgroundColorEnum() throws IOException {
+    protected void setFillForegroundColorBeforeFillBackgroundColorEnumByEnum() throws IOException {
         try (Workbook wb1 = _testDataProvider.createWorkbook()) {
             Cell A1 = wb1.createSheet().createRow(0).createCell(0);
             Map<CellPropertyType, Object> properties = new HashMap<>();
             properties.put(CellPropertyType.FILL_PATTERN, FillPatternType.BRICKS);
             properties.put(CellPropertyType.FILL_FOREGROUND_COLOR, IndexedColors.BLUE.index);
             properties.put(CellPropertyType.FILL_BACKGROUND_COLOR, IndexedColors.RED.index);
+
+            CellUtil.setCellStylePropertiesEnum(A1, properties);
+            CellStyle style = A1.getCellStyle();
+            assertEquals(FillPatternType.BRICKS, style.getFillPattern(), "fill pattern");
+            assertEquals(IndexedColors.BLUE, IndexedColors.fromInt(style.getFillForegroundColor()), "fill foreground color");
+            assertEquals(IndexedColors.RED, IndexedColors.fromInt(style.getFillBackgroundColor()), "fill background color");
+        }
+    }
+
+    /**
+     * bug 55555
+     *
+     * @since POI 3.15 beta 3
+     */
+    @Test
+    @Deprecated
+    protected void setFillForegroundColorBeforeFillBackgroundColorEnum() throws IOException {
+        try (Workbook wb1 = _testDataProvider.createWorkbook()) {
+            Cell A1 = wb1.createSheet().createRow(0).createCell(0);
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(CellUtil.FILL_PATTERN, FillPatternType.BRICKS);
+            properties.put(CellUtil.FILL_FOREGROUND_COLOR, IndexedColors.BLUE.index);
+            properties.put(CellUtil.FILL_BACKGROUND_COLOR, IndexedColors.RED.index);
 
             CellUtil.setCellStyleProperties(A1, properties);
             CellStyle style = A1.getCellStyle();
@@ -473,6 +612,7 @@ public abstract class BaseTestCellUtil {
 
     /**
      * bug 63268
+     *
      * @since POI 4.1.0
      */
     @Test

--- a/poi/src/test/java/org/apache/poi/ss/util/TestPropertyTemplate.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/TestPropertyTemplate.java
@@ -17,14 +17,14 @@
 
 package org.apache.poi.ss.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-
-import java.io.IOException;
-
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.*;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Tests Spreadsheet PropertyTemplate
@@ -57,7 +57,7 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    void getTemplateProperties() throws IOException {
+    void getTemplatePropertiesByEnum() throws IOException {
         CellRangeAddress a1 = new CellRangeAddress(0, 0, 0, 0);
         PropertyTemplate pt = new PropertyTemplate();
         pt.drawBorders(a1, BorderStyle.THIN, BorderExtent.TOP);
@@ -75,7 +75,26 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    void drawBorders() throws IOException {
+    @Deprecated
+    void getTemplateProperties() throws IOException {
+        CellRangeAddress a1 = new CellRangeAddress(0, 0, 0, 0);
+        PropertyTemplate pt = new PropertyTemplate();
+        pt.drawBorders(a1, BorderStyle.THIN, BorderExtent.TOP);
+        assertEquals(BorderStyle.THIN,
+                pt.getBorderStyle(0, 0, CellUtil.BORDER_TOP));
+        pt.drawBorders(a1, BorderStyle.MEDIUM, BorderExtent.BOTTOM);
+        assertEquals(BorderStyle.MEDIUM,
+                pt.getBorderStyle(0, 0, CellUtil.BORDER_BOTTOM));
+        pt.drawBorderColors(a1, IndexedColors.RED.getIndex(), BorderExtent.TOP);
+        assertEquals(IndexedColors.RED.getIndex(),
+                pt.getTemplateProperty(0, 0, CellUtil.TOP_BORDER_COLOR));
+        pt.drawBorderColors(a1, IndexedColors.BLUE.getIndex(), BorderExtent.BOTTOM);
+        assertEquals(IndexedColors.BLUE.getIndex(),
+                pt.getTemplateProperty(0, 0, CellUtil.BOTTOM_BORDER_COLOR));
+    }
+
+    @Test
+    void drawBordersByEnum() throws IOException {
         CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
         PropertyTemplate pt = new PropertyTemplate();
         pt.drawBorders(a1c3, BorderStyle.THIN,
@@ -402,7 +421,335 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    void drawBorderColors() throws IOException {
+    @Deprecated
+    void drawBorders() throws IOException {
+        CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
+        PropertyTemplate pt = new PropertyTemplate();
+        pt.drawBorders(a1c3, BorderStyle.THIN,
+                BorderExtent.ALL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(4, pt.getNumBorders(i, j));
+                assertEquals(BorderStyle.THIN,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                assertEquals(BorderStyle.THIN,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                assertEquals(BorderStyle.THIN,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                assertEquals(BorderStyle.THIN,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.OUTSIDE);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(4, pt.getNumBorders(i, j));
+                if (i == 0) {
+                    if (j == 0) {
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    } else if (j == 2) {
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    } else {
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    }
+                } else if (i == 2) {
+                    if (j == 0) {
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    } else if (j == 2) {
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    } else {
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    }
+                } else {
+                    if (j == 0) {
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    } else if (j == 2) {
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.MEDIUM,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    } else {
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_TOP));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_BOTTOM));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_LEFT));
+                        assertEquals(BorderStyle.THIN,
+                                pt.getBorderStyle(i, j,
+                                        CellUtil.BORDER_RIGHT));
+                    }
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(0, pt.getNumBorders(i, j));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.TOP);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.BOTTOM);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.LEFT);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.RIGHT);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.HORIZONTAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(2, pt.getNumBorders(i, j));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.INSIDE_HORIZONTAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                } else if (i == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                } else {
+                    assertEquals(2, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.OUTSIDE_HORIZONTAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                } else if (i == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.VERTICAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(2, pt.getNumBorders(i, j));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.INSIDE_VERTICAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                } else if (j == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                } else {
+                    assertEquals(2, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM,
+                BorderExtent.OUTSIDE_VERTICAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM,
+                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                } else if (j == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(BorderStyle.MEDIUM, pt
+                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                }
+            }
+        }
+    }
+
+    @Test
+    void drawBorderColorsByEnum() throws IOException {
         CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
         PropertyTemplate pt = new PropertyTemplate();
         pt.drawBorderColors(a1c3, IndexedColors.RED.getIndex(),
@@ -794,7 +1141,449 @@ final class TestPropertyTemplate {
     }
 
     @Test
+    @Deprecated
+    void drawBorderColors() throws IOException {
+        CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
+        PropertyTemplate pt = new PropertyTemplate();
+        pt.drawBorderColors(a1c3, IndexedColors.RED.getIndex(),
+                BorderExtent.ALL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(4, pt.getNumBorders(i, j));
+                assertEquals(4, pt.getNumBorderColors(i, j));
+                assertEquals(IndexedColors.RED.getIndex(), pt
+                        .getTemplateProperty(i, j, CellUtil.TOP_BORDER_COLOR));
+                assertEquals(IndexedColors.RED.getIndex(),
+                        pt.getTemplateProperty(i, j,
+                                CellUtil.BOTTOM_BORDER_COLOR));
+                assertEquals(IndexedColors.RED.getIndex(), pt
+                        .getTemplateProperty(i, j, CellUtil.LEFT_BORDER_COLOR));
+                assertEquals(IndexedColors.RED.getIndex(),
+                        pt.getTemplateProperty(i, j,
+                                CellUtil.RIGHT_BORDER_COLOR));
+            }
+        }
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.OUTSIDE);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(4, pt.getNumBorders(i, j));
+                assertEquals(4, pt.getNumBorderColors(i, j));
+                if (i == 0) {
+                    if (j == 0) {
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    } else if (j == 2) {
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    } else {
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    }
+                } else if (i == 2) {
+                    if (j == 0) {
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    } else if (j == 2) {
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    } else {
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    }
+                } else {
+                    if (j == 0) {
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    } else if (j == 2) {
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.BLUE.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    } else {
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.TOP_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.BOTTOM_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.LEFT_BORDER_COLOR));
+                        assertEquals(IndexedColors.RED.getIndex(),
+                                pt.getTemplateProperty(i, j,
+                                        CellUtil.RIGHT_BORDER_COLOR));
+                    }
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(0, pt.getNumBorders(i, j));
+                assertEquals(0, pt.getNumBorderColors(i, j));
+            }
+        }
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.TOP);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.TOP_BORDER_COLOR));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                    assertEquals(0, pt.getNumBorderColors(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.BOTTOM);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.BOTTOM_BORDER_COLOR));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                    assertEquals(0, pt.getNumBorderColors(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.LEFT);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.LEFT_BORDER_COLOR));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                    assertEquals(0, pt.getNumBorderColors(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.RIGHT);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.RIGHT_BORDER_COLOR));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                    assertEquals(0, pt.getNumBorderColors(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.HORIZONTAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(2, pt.getNumBorders(i, j));
+                assertEquals(2, pt.getNumBorderColors(i, j));
+                assertEquals(IndexedColors.BLUE.getIndex(), pt
+                        .getTemplateProperty(i, j, CellUtil.TOP_BORDER_COLOR));
+                assertEquals(IndexedColors.BLUE.getIndex(),
+                        pt.getTemplateProperty(i, j,
+                                CellUtil.BOTTOM_BORDER_COLOR));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.INSIDE_HORIZONTAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.BOTTOM_BORDER_COLOR));
+                } else if (i == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.TOP_BORDER_COLOR));
+                } else {
+                    assertEquals(2, pt.getNumBorders(i, j));
+                    assertEquals(2, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.TOP_BORDER_COLOR));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.BOTTOM_BORDER_COLOR));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.OUTSIDE_HORIZONTAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (i == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.TOP_BORDER_COLOR));
+                } else if (i == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.BOTTOM_BORDER_COLOR));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                    assertEquals(0, pt.getNumBorderColors(i, j));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.VERTICAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(2, pt.getNumBorders(i, j));
+                assertEquals(2, pt.getNumBorderColors(i, j));
+                assertEquals(IndexedColors.BLUE.getIndex(), pt
+                        .getTemplateProperty(i, j, CellUtil.LEFT_BORDER_COLOR));
+                assertEquals(IndexedColors.BLUE.getIndex(),
+                        pt.getTemplateProperty(i, j,
+                                CellUtil.RIGHT_BORDER_COLOR));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.INSIDE_VERTICAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.RIGHT_BORDER_COLOR));
+                } else if (j == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.LEFT_BORDER_COLOR));
+                } else {
+                    assertEquals(2, pt.getNumBorders(i, j));
+                    assertEquals(2, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.LEFT_BORDER_COLOR));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.RIGHT_BORDER_COLOR));
+                }
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE,
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.AUTOMATIC.getIndex(),
+                BorderExtent.NONE);
+        pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
+                BorderExtent.OUTSIDE_VERTICAL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                if (j == 0) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.LEFT_BORDER_COLOR));
+                } else if (j == 2) {
+                    assertEquals(1, pt.getNumBorders(i, j));
+                    assertEquals(1, pt.getNumBorderColors(i, j));
+                    assertEquals(IndexedColors.BLUE.getIndex(),
+                            pt.getTemplateProperty(i, j,
+                                    CellUtil.RIGHT_BORDER_COLOR));
+                } else {
+                    assertEquals(0, pt.getNumBorders(i, j));
+                    assertEquals(0, pt.getNumBorderColors(i, j));
+                }
+            }
+        }
+    }
+
+    @Test
+    @Deprecated
     void drawBordersWithColors() throws IOException {
+        CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
+        PropertyTemplate pt = new PropertyTemplate();
+
+        pt.drawBorders(a1c3, BorderStyle.MEDIUM, IndexedColors.RED.getIndex(), BorderExtent.ALL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(4, pt.getNumBorders(i, j));
+                assertEquals(4, pt.getNumBorderColors(i, j));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                assertEquals(BorderStyle.MEDIUM,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                assertEquals(IndexedColors.RED.getIndex(), pt
+                        .getTemplateProperty(i, j, CellUtil.TOP_BORDER_COLOR));
+                assertEquals(IndexedColors.RED.getIndex(),
+                        pt.getTemplateProperty(i, j,
+                                CellUtil.BOTTOM_BORDER_COLOR));
+                assertEquals(IndexedColors.RED.getIndex(), pt
+                        .getTemplateProperty(i, j, CellUtil.LEFT_BORDER_COLOR));
+                assertEquals(IndexedColors.RED.getIndex(),
+                        pt.getTemplateProperty(i, j,
+                                CellUtil.RIGHT_BORDER_COLOR));
+            }
+        }
+        pt.drawBorders(a1c3, BorderStyle.NONE, BorderExtent.NONE);
+        pt.drawBorders(a1c3, BorderStyle.NONE, IndexedColors.RED.getIndex(), BorderExtent.ALL);
+        for (int i = 0; i <= 2; i++) {
+            for (int j = 0; j <= 2; j++) {
+                assertEquals(4, pt.getNumBorders(i, j));
+                assertEquals(0, pt.getNumBorderColors(i, j));
+                assertEquals(BorderStyle.NONE,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                assertEquals(BorderStyle.NONE,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                assertEquals(BorderStyle.NONE,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                assertEquals(BorderStyle.NONE,
+                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+            }
+        }
+    }
+
+    @Test
+    void drawBordersWithColorsByEnum() throws IOException {
         CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
         PropertyTemplate pt = new PropertyTemplate();
 
@@ -852,8 +1641,8 @@ final class TestPropertyTemplate {
         pt.drawBorders(a1c3, BorderStyle.THIN, IndexedColors.RED.getIndex(), BorderExtent.ALL);
         pt.applyBorders(sheet);
 
-        for (Row row: sheet) {
-            for (Cell cell: row) {
+        for (Row row : sheet) {
+            for (Cell cell : row) {
                 CellStyle cs = cell.getCellStyle();
                 assertEquals(BorderStyle.THIN, cs.getBorderTop());
                 assertEquals(IndexedColors.RED.getIndex(), cs.getTopBorderColor());
@@ -869,30 +1658,30 @@ final class TestPropertyTemplate {
         pt.drawBorders(b2, BorderStyle.NONE, BorderExtent.ALL);
         pt.applyBorders(sheet);
 
-        for (Row row: sheet) {
-            for (Cell cell: row) {
+        for (Row row : sheet) {
+            for (Cell cell : row) {
                 CellStyle cs = cell.getCellStyle();
                 if (cell.getColumnIndex() != 1 || row.getRowNum() == 0) {
-                assertEquals(BorderStyle.THIN, cs.getBorderTop());
-                assertEquals(IndexedColors.RED.getIndex(), cs.getTopBorderColor());
+                    assertEquals(BorderStyle.THIN, cs.getBorderTop());
+                    assertEquals(IndexedColors.RED.getIndex(), cs.getTopBorderColor());
                 } else {
                     assertEquals(BorderStyle.NONE, cs.getBorderTop());
                 }
                 if (cell.getColumnIndex() != 1 || row.getRowNum() == 2) {
-                assertEquals(BorderStyle.THIN, cs.getBorderBottom());
-                assertEquals(IndexedColors.RED.getIndex(), cs.getBottomBorderColor());
+                    assertEquals(BorderStyle.THIN, cs.getBorderBottom());
+                    assertEquals(IndexedColors.RED.getIndex(), cs.getBottomBorderColor());
                 } else {
                     assertEquals(BorderStyle.NONE, cs.getBorderBottom());
                 }
                 if (cell.getColumnIndex() == 0 || row.getRowNum() != 1) {
-                assertEquals(BorderStyle.THIN, cs.getBorderLeft());
-                assertEquals(IndexedColors.RED.getIndex(), cs.getLeftBorderColor());
+                    assertEquals(BorderStyle.THIN, cs.getBorderLeft());
+                    assertEquals(IndexedColors.RED.getIndex(), cs.getLeftBorderColor());
                 } else {
                     assertEquals(BorderStyle.NONE, cs.getBorderLeft());
                 }
                 if (cell.getColumnIndex() == 2 || row.getRowNum() != 1) {
-                assertEquals(BorderStyle.THIN, cs.getBorderRight());
-                assertEquals(IndexedColors.RED.getIndex(), cs.getRightBorderColor());
+                    assertEquals(BorderStyle.THIN, cs.getBorderRight());
+                    assertEquals(IndexedColors.RED.getIndex(), cs.getRightBorderColor());
                 } else {
                     assertEquals(BorderStyle.NONE, cs.getBorderRight());
                 }
@@ -916,7 +1705,7 @@ final class TestPropertyTemplate {
             }
         }
 
-        CellRangeAddress b2 = new CellRangeAddress(1,1,1,1);
+        CellRangeAddress b2 = new CellRangeAddress(1, 1, 1, 1);
         pt2.drawBorders(b2, BorderStyle.THIN, BorderExtent.ALL);
 
         Workbook wb = new HSSFWorkbook();

--- a/poi/src/test/java/org/apache/poi/ss/util/TestPropertyTemplate.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/TestPropertyTemplate.java
@@ -18,7 +18,15 @@
 package org.apache.poi.ss.util;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.BorderExtent;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellPropertyType;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -75,7 +83,6 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    @Deprecated
     void getTemplateProperties() throws IOException {
         CellRangeAddress a1 = new CellRangeAddress(0, 0, 0, 0);
         PropertyTemplate pt = new PropertyTemplate();
@@ -421,7 +428,6 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    @Deprecated
     void drawBorders() throws IOException {
         CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
         PropertyTemplate pt = new PropertyTemplate();
@@ -1141,7 +1147,6 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    @Deprecated
     void drawBorderColors() throws IOException {
         CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
         PropertyTemplate pt = new PropertyTemplate();
@@ -1534,7 +1539,6 @@ final class TestPropertyTemplate {
     }
 
     @Test
-    @Deprecated
     void drawBordersWithColors() throws IOException {
         CellRangeAddress a1c3 = new CellRangeAddress(0, 2, 0, 2);
         PropertyTemplate pt = new PropertyTemplate();

--- a/poi/src/test/java/org/apache/poi/ss/util/TestPropertyTemplate.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/TestPropertyTemplate.java
@@ -23,14 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import java.io.IOException;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.usermodel.BorderExtent;
-import org.apache.poi.ss.usermodel.BorderStyle;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.IndexedColors;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.*;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -69,16 +62,16 @@ final class TestPropertyTemplate {
         PropertyTemplate pt = new PropertyTemplate();
         pt.drawBorders(a1, BorderStyle.THIN, BorderExtent.TOP);
         assertEquals(BorderStyle.THIN,
-                pt.getBorderStyle(0, 0, CellUtil.BORDER_TOP));
+                pt.getBorderStyle(0, 0, CellPropertyType.BORDER_TOP));
         pt.drawBorders(a1, BorderStyle.MEDIUM, BorderExtent.BOTTOM);
         assertEquals(BorderStyle.MEDIUM,
-                pt.getBorderStyle(0, 0, CellUtil.BORDER_BOTTOM));
+                pt.getBorderStyle(0, 0, CellPropertyType.BORDER_BOTTOM));
         pt.drawBorderColors(a1, IndexedColors.RED.getIndex(), BorderExtent.TOP);
         assertEquals(IndexedColors.RED.getIndex(),
-                pt.getTemplateProperty(0, 0, CellUtil.TOP_BORDER_COLOR));
+                pt.getTemplateProperty(0, 0, CellPropertyType.TOP_BORDER_COLOR));
         pt.drawBorderColors(a1, IndexedColors.BLUE.getIndex(), BorderExtent.BOTTOM);
         assertEquals(IndexedColors.BLUE.getIndex(),
-                pt.getTemplateProperty(0, 0, CellUtil.BOTTOM_BORDER_COLOR));
+                pt.getTemplateProperty(0, 0, CellPropertyType.BOTTOM_BORDER_COLOR));
     }
 
     @Test
@@ -91,13 +84,13 @@ final class TestPropertyTemplate {
             for (int j = 0; j <= 2; j++) {
                 assertEquals(4, pt.getNumBorders(i, j));
                 assertEquals(BorderStyle.THIN,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 assertEquals(BorderStyle.THIN,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 assertEquals(BorderStyle.THIN,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 assertEquals(BorderStyle.THIN,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
             }
         }
         pt.drawBorders(a1c3, BorderStyle.MEDIUM,
@@ -109,124 +102,124 @@ final class TestPropertyTemplate {
                     if (j == 0) {
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     } else if (j == 2) {
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     } else {
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     }
                 } else if (i == 2) {
                     if (j == 0) {
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     } else if (j == 2) {
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     } else {
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     }
                 } else {
                     if (j == 0) {
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     } else if (j == 2) {
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.MEDIUM,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     } else {
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_TOP));
+                                        CellPropertyType.BORDER_TOP));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_BOTTOM));
+                                        CellPropertyType.BORDER_BOTTOM));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_LEFT));
+                                        CellPropertyType.BORDER_LEFT));
                         assertEquals(BorderStyle.THIN,
                                 pt.getBorderStyle(i, j,
-                                        CellUtil.BORDER_RIGHT));
+                                        CellPropertyType.BORDER_RIGHT));
                     }
                 }
             }
@@ -245,7 +238,7 @@ final class TestPropertyTemplate {
                 if (i == 0) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                 }
@@ -260,7 +253,7 @@ final class TestPropertyTemplate {
                 if (i == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                 }
@@ -275,7 +268,7 @@ final class TestPropertyTemplate {
                 if (j == 0) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                 }
@@ -290,7 +283,7 @@ final class TestPropertyTemplate {
                 if (j == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                 }
@@ -304,9 +297,9 @@ final class TestPropertyTemplate {
             for (int j = 0; j <= 2; j++) {
                 assertEquals(2, pt.getNumBorders(i, j));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
             }
         }
         pt.drawBorders(a1c3, BorderStyle.NONE,
@@ -318,17 +311,17 @@ final class TestPropertyTemplate {
                 if (i == 0) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 } else if (i == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 } else {
                     assertEquals(2, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 }
             }
         }
@@ -341,11 +334,11 @@ final class TestPropertyTemplate {
                 if (i == 0) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 } else if (i == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                 }
@@ -359,9 +352,9 @@ final class TestPropertyTemplate {
             for (int j = 0; j <= 2; j++) {
                 assertEquals(2, pt.getNumBorders(i, j));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
             }
         }
         pt.drawBorders(a1c3, BorderStyle.NONE,
@@ -373,17 +366,17 @@ final class TestPropertyTemplate {
                 if (j == 0) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
                 } else if (j == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 } else {
                     assertEquals(2, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
                 }
             }
         }
@@ -396,11 +389,11 @@ final class TestPropertyTemplate {
                 if (j == 0) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM,
-                            pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                            pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 } else if (j == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(BorderStyle.MEDIUM, pt
-                            .getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                            .getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                 }
@@ -419,15 +412,15 @@ final class TestPropertyTemplate {
                 assertEquals(4, pt.getNumBorders(i, j));
                 assertEquals(4, pt.getNumBorderColors(i, j));
                 assertEquals(IndexedColors.RED.getIndex(), pt
-                        .getTemplateProperty(i, j, CellUtil.TOP_BORDER_COLOR));
+                        .getTemplateProperty(i, j, CellPropertyType.TOP_BORDER_COLOR));
                 assertEquals(IndexedColors.RED.getIndex(),
                         pt.getTemplateProperty(i, j,
-                                CellUtil.BOTTOM_BORDER_COLOR));
+                                CellPropertyType.BOTTOM_BORDER_COLOR));
                 assertEquals(IndexedColors.RED.getIndex(), pt
-                        .getTemplateProperty(i, j, CellUtil.LEFT_BORDER_COLOR));
+                        .getTemplateProperty(i, j, CellPropertyType.LEFT_BORDER_COLOR));
                 assertEquals(IndexedColors.RED.getIndex(),
                         pt.getTemplateProperty(i, j,
-                                CellUtil.RIGHT_BORDER_COLOR));
+                                CellPropertyType.RIGHT_BORDER_COLOR));
             }
         }
         pt.drawBorderColors(a1c3, IndexedColors.BLUE.getIndex(),
@@ -440,124 +433,124 @@ final class TestPropertyTemplate {
                     if (j == 0) {
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     } else if (j == 2) {
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     } else {
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     }
                 } else if (i == 2) {
                     if (j == 0) {
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     } else if (j == 2) {
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     } else {
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     }
                 } else {
                     if (j == 0) {
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     } else if (j == 2) {
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.BLUE.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     } else {
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.TOP_BORDER_COLOR));
+                                        CellPropertyType.TOP_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.BOTTOM_BORDER_COLOR));
+                                        CellPropertyType.BOTTOM_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.LEFT_BORDER_COLOR));
+                                        CellPropertyType.LEFT_BORDER_COLOR));
                         assertEquals(IndexedColors.RED.getIndex(),
                                 pt.getTemplateProperty(i, j,
-                                        CellUtil.RIGHT_BORDER_COLOR));
+                                        CellPropertyType.RIGHT_BORDER_COLOR));
                     }
                 }
             }
@@ -581,7 +574,7 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.TOP_BORDER_COLOR));
+                                    CellPropertyType.TOP_BORDER_COLOR));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                     assertEquals(0, pt.getNumBorderColors(i, j));
@@ -601,7 +594,7 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.BOTTOM_BORDER_COLOR));
+                                    CellPropertyType.BOTTOM_BORDER_COLOR));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                     assertEquals(0, pt.getNumBorderColors(i, j));
@@ -621,7 +614,7 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.LEFT_BORDER_COLOR));
+                                    CellPropertyType.LEFT_BORDER_COLOR));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                     assertEquals(0, pt.getNumBorderColors(i, j));
@@ -641,7 +634,7 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.RIGHT_BORDER_COLOR));
+                                    CellPropertyType.RIGHT_BORDER_COLOR));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                     assertEquals(0, pt.getNumBorderColors(i, j));
@@ -659,10 +652,10 @@ final class TestPropertyTemplate {
                 assertEquals(2, pt.getNumBorders(i, j));
                 assertEquals(2, pt.getNumBorderColors(i, j));
                 assertEquals(IndexedColors.BLUE.getIndex(), pt
-                        .getTemplateProperty(i, j, CellUtil.TOP_BORDER_COLOR));
+                        .getTemplateProperty(i, j, CellPropertyType.TOP_BORDER_COLOR));
                 assertEquals(IndexedColors.BLUE.getIndex(),
                         pt.getTemplateProperty(i, j,
-                                CellUtil.BOTTOM_BORDER_COLOR));
+                                CellPropertyType.BOTTOM_BORDER_COLOR));
             }
         }
         pt.drawBorders(a1c3, BorderStyle.NONE,
@@ -678,22 +671,22 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.BOTTOM_BORDER_COLOR));
+                                    CellPropertyType.BOTTOM_BORDER_COLOR));
                 } else if (i == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.TOP_BORDER_COLOR));
+                                    CellPropertyType.TOP_BORDER_COLOR));
                 } else {
                     assertEquals(2, pt.getNumBorders(i, j));
                     assertEquals(2, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.TOP_BORDER_COLOR));
+                                    CellPropertyType.TOP_BORDER_COLOR));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.BOTTOM_BORDER_COLOR));
+                                    CellPropertyType.BOTTOM_BORDER_COLOR));
                 }
             }
         }
@@ -710,13 +703,13 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.TOP_BORDER_COLOR));
+                                    CellPropertyType.TOP_BORDER_COLOR));
                 } else if (i == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.BOTTOM_BORDER_COLOR));
+                                    CellPropertyType.BOTTOM_BORDER_COLOR));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                     assertEquals(0, pt.getNumBorderColors(i, j));
@@ -734,10 +727,10 @@ final class TestPropertyTemplate {
                 assertEquals(2, pt.getNumBorders(i, j));
                 assertEquals(2, pt.getNumBorderColors(i, j));
                 assertEquals(IndexedColors.BLUE.getIndex(), pt
-                        .getTemplateProperty(i, j, CellUtil.LEFT_BORDER_COLOR));
+                        .getTemplateProperty(i, j, CellPropertyType.LEFT_BORDER_COLOR));
                 assertEquals(IndexedColors.BLUE.getIndex(),
                         pt.getTemplateProperty(i, j,
-                                CellUtil.RIGHT_BORDER_COLOR));
+                                CellPropertyType.RIGHT_BORDER_COLOR));
             }
         }
         pt.drawBorders(a1c3, BorderStyle.NONE,
@@ -753,22 +746,22 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.RIGHT_BORDER_COLOR));
+                                    CellPropertyType.RIGHT_BORDER_COLOR));
                 } else if (j == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.LEFT_BORDER_COLOR));
+                                    CellPropertyType.LEFT_BORDER_COLOR));
                 } else {
                     assertEquals(2, pt.getNumBorders(i, j));
                     assertEquals(2, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.LEFT_BORDER_COLOR));
+                                    CellPropertyType.LEFT_BORDER_COLOR));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.RIGHT_BORDER_COLOR));
+                                    CellPropertyType.RIGHT_BORDER_COLOR));
                 }
             }
         }
@@ -785,13 +778,13 @@ final class TestPropertyTemplate {
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.LEFT_BORDER_COLOR));
+                                    CellPropertyType.LEFT_BORDER_COLOR));
                 } else if (j == 2) {
                     assertEquals(1, pt.getNumBorders(i, j));
                     assertEquals(1, pt.getNumBorderColors(i, j));
                     assertEquals(IndexedColors.BLUE.getIndex(),
                             pt.getTemplateProperty(i, j,
-                                    CellUtil.RIGHT_BORDER_COLOR));
+                                    CellPropertyType.RIGHT_BORDER_COLOR));
                 } else {
                     assertEquals(0, pt.getNumBorders(i, j));
                     assertEquals(0, pt.getNumBorderColors(i, j));
@@ -811,23 +804,23 @@ final class TestPropertyTemplate {
                 assertEquals(4, pt.getNumBorders(i, j));
                 assertEquals(4, pt.getNumBorderColors(i, j));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 assertEquals(BorderStyle.MEDIUM,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
                 assertEquals(IndexedColors.RED.getIndex(), pt
-                        .getTemplateProperty(i, j, CellUtil.TOP_BORDER_COLOR));
+                        .getTemplateProperty(i, j, CellPropertyType.TOP_BORDER_COLOR));
                 assertEquals(IndexedColors.RED.getIndex(),
                         pt.getTemplateProperty(i, j,
-                                CellUtil.BOTTOM_BORDER_COLOR));
+                                CellPropertyType.BOTTOM_BORDER_COLOR));
                 assertEquals(IndexedColors.RED.getIndex(), pt
-                        .getTemplateProperty(i, j, CellUtil.LEFT_BORDER_COLOR));
+                        .getTemplateProperty(i, j, CellPropertyType.LEFT_BORDER_COLOR));
                 assertEquals(IndexedColors.RED.getIndex(),
                         pt.getTemplateProperty(i, j,
-                                CellUtil.RIGHT_BORDER_COLOR));
+                                CellPropertyType.RIGHT_BORDER_COLOR));
             }
         }
         pt.drawBorders(a1c3, BorderStyle.NONE, BorderExtent.NONE);
@@ -837,13 +830,13 @@ final class TestPropertyTemplate {
                 assertEquals(4, pt.getNumBorders(i, j));
                 assertEquals(0, pt.getNumBorderColors(i, j));
                 assertEquals(BorderStyle.NONE,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_TOP));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_TOP));
                 assertEquals(BorderStyle.NONE,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_BOTTOM));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_BOTTOM));
                 assertEquals(BorderStyle.NONE,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_LEFT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_LEFT));
                 assertEquals(BorderStyle.NONE,
-                        pt.getBorderStyle(i, j, CellUtil.BORDER_RIGHT));
+                        pt.getBorderStyle(i, j, CellPropertyType.BORDER_RIGHT));
             }
         }
     }


### PR DESCRIPTION
CellUtil class constants have been replaced by Enum. Added CellUtilProperty enum, changed all references from CellUtil constants to CellUtilProperty enums.
Reason: comment “FIXME: Move these constants to enum” in CellUtil.

Tests that failed for me personally:
**_1) poi-ooxml_**
```
Test [80] Days360, 343, 344 FAILED
java.lang.NullPointerException at org.apache.poi.xssf.usermodel.TestFormulaEvaluatorOnXSSF.processFunctionRow(TestFormulaEvaluatorOnXSSF.java:188)

```
**_2) poi_**
```
Test [82] Days360, 351, 352 FAILED
java.lang.NullPointerException at org.apache.poi.poi.ss.formula.eval.TestFormulasFromSpreadsheet.processFunctionRow(TestFormulasFromSpreadsheet.java:174)

```
Which is very strange, please check.