### PR TITLE
Add a check to verify that the tmp/poifiles directory still exists

### DIFF
--- a/poi/src/main/java/org/apache/poi/util/DefaultTempFileCreationStrategy.java
+++ b/poi/src/main/java/org/apache/poi/util/DefaultTempFileCreationStrategy.java
@@ -76,6 +76,10 @@ public class DefaultTempFileCreationStrategy implements TempFileCreationStrategy
     private void createPOIFilesDirectory() throws IOException {
         // Create our temp dir only once by double-checked locking
         // The directory is not deleted, even if it was created by this TempFileCreationStrategy
+        // First make sure we recreate the directory if it was not somehow removed by a third party
+        if (dir != null && !dir.exists()) {
+            dir = null;
+        }
         if (dir == null) {
             final String tmpDir = System.getProperty(JAVA_IO_TMPDIR);
             if (tmpDir == null) {


### PR DESCRIPTION
There are mechanisms outside the application, such as periodic routines in the operating system, that will clean tmp directories of old files. Make sure we recreate the directory if this happens.

The refers to bug 69323 and a regression introduced on commit 1def0cba387d8c86
https://bz.apache.org/bugzilla/show_bug.cgi?id=69323