### PR TITLE
Make the default temporary directory contain the username to avoid permission issues when deploying applications on the same server with multiple users

### DIFF
--- a/poi/src/main/java/org/apache/poi/util/DefaultTempFileCreationStrategy.java
+++ b/poi/src/main/java/org/apache/poi/util/DefaultTempFileCreationStrategy.java
@@ -47,6 +47,9 @@ public class DefaultTempFileCreationStrategy implements TempFileCreationStrategy
     /** To use files.deleteOnExit after clean JVM exit, set the <code>-Dpoi.delete.tmp.files.on.exit</code> JVM property */
     public static final String DELETE_FILES_ON_EXIT = "poi.delete.tmp.files.on.exit";
 
+    /** JVM property for the current username. */
+    private static final String JAVA_PROP_USER_NAME = "user.name";
+
     /** The directory where the temporary files will be created (<code>null</code> to use the default directory). */
     private volatile File dir;
 
@@ -85,10 +88,17 @@ public class DefaultTempFileCreationStrategy implements TempFileCreationStrategy
             if (tmpDir == null) {
                 throw new IOException("System's temporary directory not defined - set the -D" + JAVA_IO_TMPDIR + " jvm property!");
             }
+            String poifilesDir = POIFILES;
+            // Make the default temporary directory contain the username to avoid permission issues
+            // when deploying applications on the same server with multiple users
+            String username = System.getProperty(JAVA_PROP_USER_NAME);
+            if (null != username && !username.isEmpty()) {
+                poifilesDir += "_" + username;
+            }
             dirLock.lock();
             try {
                 if (dir == null) {
-                    Path dirPath = Paths.get(tmpDir, POIFILES);
+                    Path dirPath = Paths.get(tmpDir, poifilesDir);
                     File fileDir = dirPath.toFile();
                     if (fileDir.exists()) {
                         if (!fileDir.isDirectory()) {


### PR DESCRIPTION
When deploying applications for multiple users on the same server, according to the current poi behavior, a fixed temporary directory named 'poifiles' is always created in <java.io.tmpdir> by default, which will cause 'java.io.IOException: Permission denied' exceptions in applications run by other users. Here I add the <user.name> as part of the directory name like the jdk perf dir 'hsperfdata_<userid>' to avoid the permission issue.