### PR TITLE
using hashmap is not thread-safe, may cause death cycle in concurrent use

### DIFF
--- a/poi/src/main/java/org/apache/poi/util/BitFieldFactory.java
+++ b/poi/src/main/java/org/apache/poi/util/BitFieldFactory.java
@@ -19,12 +19,13 @@
 package org.apache.poi.util;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Returns immutable Bitfield instances.
  */
 public class BitFieldFactory {
-    private static Map<Integer, BitField> instances = new HashMap<>();
+    private static Map<Integer, BitField> instances = new ConcurrentHashMap<>();
 
     public static BitField getInstance(int mask) {
         return instances.computeIfAbsent(mask, k -> new BitField(mask));


### PR DESCRIPTION
using hashmap is not thread-safe, may cause death cycle in concurrent use
