### PR TITLE
Bug 69411: Changed XSSFReader#getSheetsData to return a SheetIterator instead of Iterator<InputStream>

### DIFF
--- a/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/LoadPasswordProtectedXlsxStreaming.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/LoadPasswordProtectedXlsxStreaming.java
@@ -25,7 +25,6 @@ import org.apache.poi.examples.xssf.usermodel.LoadPasswordProtectedXlsx;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.poifs.crypt.temp.AesZipFileZipEntrySource;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
-import org.apache.poi.xssf.eventusermodel.XSSFReader.SheetIterator;
 
 /**
  * An example that loads a password protected workbook and counts the sheets.
@@ -48,7 +47,7 @@ public final class LoadPasswordProtectedXlsxStreaming {
         try (AesZipFileZipEntrySource source = AesZipFileZipEntrySource.createZipEntrySource(inputStream);
              OPCPackage pkg = OPCPackage.open(source)) {
             XSSFReader reader = new XSSFReader(pkg);
-            SheetIterator iter = (SheetIterator)reader.getSheetsData();
+            XSSFReader.SheetIterator iter = reader.getSheetsData();
             int count = 0;
             while(iter.hasNext()) {
                 iter.next();

--- a/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/XLSX2CSV.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/XLSX2CSV.java
@@ -227,7 +227,7 @@ public class XLSX2CSV {
         ReadOnlySharedStringsTable strings = new ReadOnlySharedStringsTable(this.xlsxPackage);
         XSSFReader xssfReader = new XSSFReader(this.xlsxPackage);
         StylesTable styles = xssfReader.getStylesTable();
-        XSSFReader.SheetIterator iter = (XSSFReader.SheetIterator) xssfReader.getSheetsData();
+        XSSFReader.SheetIterator iter = xssfReader.getSheetsData();
         int index = 0;
         while (iter.hasNext()) {
             try (InputStream stream = iter.next()) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFBReader.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFBReader.java
@@ -104,12 +104,12 @@ public class XSSFBReader extends XSSFReader {
      *  from the Iterator. It's up to you to close the
      *  InputStreams when done with each one.
      *
-     * @return iterator of {@link InputStream}s
+     * @return iterator {@link SheetIterator}
      * @throws InvalidFormatException if the sheet data format is invalid
      * @throws IOException if there is an I/O issue reading the data
      */
     @Override
-    public Iterator<InputStream> getSheetsData() throws IOException, InvalidFormatException {
+    public SheetIterator getSheetsData() throws IOException, InvalidFormatException {
         return new SheetIterator(workbookPart);
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFReader.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFReader.java
@@ -263,10 +263,11 @@ public class XSSFReader {
      * from the Iterator. It's up to you to close the
      * InputStreams when done with each one.
      *
+     * @return iterator {@link SheetIterator}
      * @throws InvalidFormatException if the sheet data format is invalid
      * @throws IOException if there is an I/O issue reading the data
      */
-    public Iterator<InputStream> getSheetsData() throws IOException, InvalidFormatException {
+    public SheetIterator getSheetsData() throws IOException, InvalidFormatException {
         return new SheetIterator(workbookPart);
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFBEventBasedExcelExtractor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFBEventBasedExcelExtractor.java
@@ -109,7 +109,7 @@ public class XSSFBEventBasedExcelExtractor extends XSSFEventBasedExcelExtractor 
             XSSFBSharedStringsTable strings = new XSSFBSharedStringsTable(getPackage());
             XSSFBReader xssfbReader = new XSSFBReader(getPackage());
             XSSFBStylesTable styles = xssfbReader.getXSSFBStylesTable();
-            XSSFBReader.SheetIterator iter = (XSSFBReader.SheetIterator) xssfbReader.getSheetsData();
+            XSSFBReader.SheetIterator iter = xssfbReader.getSheetsData();
 
             StringBuilder text = new StringBuilder(64);
             SheetTextExtractor sheetExtractor = new SheetTextExtractor();

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFEventBasedExcelExtractor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFEventBasedExcelExtractor.java
@@ -262,7 +262,7 @@ public class XSSFEventBasedExcelExtractor
             XSSFReader xssfReader = new XSSFReader(container);
             SharedStrings strings = createSharedStringsTable(xssfReader, container);
             StylesTable styles = xssfReader.getStylesTable();
-            XSSFReader.SheetIterator iter = (XSSFReader.SheetIterator) xssfReader.getSheetsData();
+            XSSFReader.SheetIterator iter = xssfReader.getSheetsData();
             StringBuilder text = new StringBuilder(64);
             SheetTextExtractor sheetExtractor = new SheetTextExtractor();
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/binary/TestXSSFBSheetHyperlinkManager.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/binary/TestXSSFBSheetHyperlinkManager.java
@@ -36,7 +36,7 @@ class TestXSSFBSheetHyperlinkManager {
     void testBasic() throws Exception {
         try (OPCPackage pkg = OPCPackage.open(_ssTests.openResourceAsStream("hyperlink.xlsb"))) {
             XSSFBReader reader = new XSSFBReader(pkg);
-            XSSFReader.SheetIterator it = (XSSFReader.SheetIterator) reader.getSheetsData();
+            XSSFReader.SheetIterator it = reader.getSheetsData();
             it.next();
             XSSFBHyperlinksTable manager = new XSSFBHyperlinksTable(it.getSheetPart());
             List<XSSFHyperlinkRecord> records = manager.getHyperLinks().get(new CellAddress(0, 0));

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/binary/TestXSSFBSheetParser.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/binary/TestXSSFBSheetParser.java
@@ -47,7 +47,7 @@ class TestXSSFBSheetParser {
     void test66682() throws Exception {
         try (OPCPackage pkg = OPCPackage.open(_ssTests.openResourceAsStream("bug66682.xlsb"))) {
             XSSFBReader reader = new XSSFBReader(pkg);
-            XSSFBReader.SheetIterator it = (XSSFBReader.SheetIterator) reader.getSheetsData();
+            XSSFBReader.SheetIterator it = reader.getSheetsData();
 
             while (it.hasNext()) {
                 try (InputStream is = it.next()) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFBReader.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFBReader.java
@@ -136,7 +136,7 @@ class TestXSSFBReader {
             assertNotNull(r.getXSSFBStylesTable());
             XSSFBSharedStringsTable sst = new XSSFBSharedStringsTable(pkg);
             XSSFBStylesTable xssfbStylesTable = r.getXSSFBStylesTable();
-            XSSFBReader.SheetIterator it = (XSSFBReader.SheetIterator) r.getSheetsData();
+            XSSFBReader.SheetIterator it = r.getSheetsData();
 
             while (it.hasNext()) {
                 InputStream is = it.next();

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFReader.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFReader.java
@@ -156,7 +156,7 @@ public final class TestXSSFReader {
             XSSFReader r = new XSSFReader(pkg);
 
             String[] sheetNames = {"Sheet4", "Sheet2", "Sheet3", "Sheet1"};
-            XSSFReader.SheetIterator it = (XSSFReader.SheetIterator) r.getSheetsData();
+            XSSFReader.SheetIterator it = r.getSheetsData();
 
             int count = 0;
             while (it.hasNext()) {
@@ -175,7 +175,7 @@ public final class TestXSSFReader {
     void testComments() throws Exception {
       try (OPCPackage pkg =  XSSFTestDataSamples.openSamplePackage("comments.xlsx")) {
           XSSFReader r = new XSSFReader(pkg);
-          XSSFReader.SheetIterator it = (XSSFReader.SheetIterator) r.getSheetsData();
+          XSSFReader.SheetIterator it = r.getSheetsData();
 
           int count = 0;
           while (it.hasNext()) {
@@ -215,7 +215,7 @@ public final class TestXSSFReader {
     void testShapes() throws Exception {
         try (OPCPackage pkg = XSSFTestDataSamples.openSamplePackage("WithTextBox.xlsx")) {
             XSSFReader r = new XSSFReader(pkg);
-            XSSFReader.SheetIterator it = (XSSFReader.SheetIterator) r.getSheetsData();
+            XSSFReader.SheetIterator it = r.getSheetsData();
 
             String text = getShapesString(it);
             assertContains(text, "Line 1");
@@ -249,7 +249,7 @@ public final class TestXSSFReader {
             POIXMLException e = assertThrows(POIXMLException.class, () -> {
                 final XSSFReader r = new XSSFReader(pkg);
 
-                XSSFReader.SheetIterator it = (XSSFReader.SheetIterator) r.getSheetsData();
+                XSSFReader.SheetIterator it = r.getSheetsData();
 
                 String text = getShapesString(it);
                 assertContains(text, "Line 1");
@@ -273,7 +273,7 @@ public final class TestXSSFReader {
             StylesTable styles = reader.getStylesTable();
             assertNotNull(styles);
 
-            XSSFReader.SheetIterator iter = (XSSFReader.SheetIterator) reader.getSheetsData();
+            XSSFReader.SheetIterator iter = reader.getSheetsData();
             assertTrue(iter.hasNext());
             assertNotNull(iter.next());
 
@@ -295,7 +295,7 @@ public final class TestXSSFReader {
             StylesTable styles = reader.getStylesTable();
             assertNotNull(styles);
 
-            XSSFReader.SheetIterator iter = (XSSFReader.SheetIterator) reader.getSheetsData();
+            XSSFReader.SheetIterator iter = reader.getSheetsData();
             assertNotNull(iter.next());
             assertFalse(iter.hasNext());
         }
@@ -317,7 +317,7 @@ public final class TestXSSFReader {
     void test61034() throws Exception {
         try (OPCPackage pkg = XSSFTestDataSamples.openSamplePackage("61034.xlsx")) {
             XSSFReader reader = new XSSFReader(pkg);
-            XSSFReader.SheetIterator iter = (XSSFReader.SheetIterator) reader.getSheetsData();
+            XSSFReader.SheetIterator iter = reader.getSheetsData();
             Set<String> seen = new HashSet<>();
             while (iter.hasNext()) {
                 InputStream stream = iter.next();


### PR DESCRIPTION
This would cut down on the common need to cast the returned value to get access to the sheet name, sheet comments, etc.