### PR TITLE
Do not replace the @DSTAMP@ token when generating Version.java

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1563,7 +1563,6 @@ under the License.
         <copy file="${main.version.template}" tofile="${main.version.java}" overwrite="true">
             <filterset>
                 <filter token="VERSION" value="${version.id}"/>
-                <filter token="DSTAMP" value="${DSTAMP}"/>
             </filterset>
         </copy>
 

--- a/poi/build.gradle
+++ b/poi/build.gradle
@@ -69,7 +69,6 @@ task generateVersionJava() {
         String content = fileIn.text
 
         content = content.replace("@VERSION@", version)
-        content = content.replace("@DSTAMP@", new Date().format('yyyyMMdd'))
 
         fileOut.write content
     }


### PR DESCRIPTION
The timestamp was removed from `Version.java` last year (23caf67c58fb5e6ecbe50eb1a24b02ef40585629), but the Ant and Gradle builds still attempt to replace the `@DSTAMP@` token. This PR removes this now unnecessary replacement.