### PR TITLE
Write the number of blocks used by the property table in the header of files using 4K blocks only

### DIFF
--- a/poi/src/main/java/org/apache/poi/poifs/storage/HeaderBlock.java
+++ b/poi/src/main/java/org/apache/poi/poifs/storage/HeaderBlock.java
@@ -392,7 +392,7 @@ public final class HeaderBlock implements HeaderBlockConstants {
    public void writeData(final OutputStream stream) throws IOException {
       // Update the counts and start positions 
       new IntegerField(_bat_count_offset,      _bat_count, _data);
-      new IntegerField(_property_count_offset, _property_count, _data);
+      new IntegerField(_property_count_offset, bigBlockSize.getBigBlockSize() == 512 ? 0 : _property_count, _data);
       new IntegerField(_property_start_offset, _property_start, _data);
       new IntegerField(_sbat_start_offset,     _sbat_start, _data);
       new IntegerField(_sbat_block_count_offset, _sbat_count, _data);

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestPOIFSStream.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestPOIFSStream.java
@@ -2125,7 +2125,7 @@ final class TestPOIFSStream {
                 // Check the header has the right points in it
                 assertEquals(1, header.getBATCount());
                 assertEquals(1, header.getBATArray()[0]);
-                assertEquals(2, header.getPropertyCount());
+                assertEquals(0, header.getPropertyCount());
                 assertEquals(0, header.getPropertyStart());
                 assertEquals(1, header.getSBATCount());
                 assertEquals(21, header.getSBATStart());
@@ -2236,7 +2236,7 @@ final class TestPOIFSStream {
             // Will have fat then properties stream
             assertEquals(1, hdr.getBATCount());
             assertEquals(1, hdr.getBATArray()[0]);
-            assertEquals(1, hdr.getPropertyCount());
+            assertEquals(0, hdr.getPropertyCount());
             assertEquals(0, hdr.getPropertyStart());
             assertEquals(POIFSConstants.END_OF_CHAIN, hdr.getSBATStart());
             assertEquals(POIFSConstants.END_OF_CHAIN, hdr.getXBATIndex());
@@ -2295,7 +2295,7 @@ final class TestPOIFSStream {
                 assertEquals(1, hdr.getBATCount());
                 assertEquals(1, hdr.getBATArray()[0]);
                 assertEquals(2, hdr.getSBATStart());
-                assertEquals(2, hdr.getPropertyCount());
+                assertEquals(0, hdr.getPropertyCount());
                 assertEquals(0, hdr.getPropertyStart());
                 assertEquals(POIFSConstants.END_OF_CHAIN, hdr.getXBATIndex());
 
@@ -2491,6 +2491,38 @@ final class TestPOIFSStream {
                 assertEquals(3, testDir.getProperty().getStartBlock());
                 assertEquals(64, testDir.getProperty().getSize());
             }
+        }
+    }
+
+    /**
+     * Test that the property count is always 0 when writing files with a block size of 512 bytes.
+     */
+    @Test
+    void testWritePropertyCount512() throws Exception {
+        try (POIFSFileSystem fs = new POIFSFileSystem(_inst.openResourceAsStream("BlockSize512.zvi"))) {
+            assertEquals(0, fs.getHeaderBlock().getPropertyCount(), "Property count");
+
+            for (int i = 1; i <= 100; i++) {
+                fs.getRoot().createOrUpdateDocument("Entry " + i, new ByteArrayInputStream(new byte[8192]));
+            }
+
+            assertEquals(0, writeOutAndReadBack(fs).getHeaderBlock().getPropertyCount(), "Property count");
+        }
+    }
+
+    /**
+     * Test that the property count is updated when writing files with a block size of 4096 bytes.
+     */
+    @Test
+    void testWritePropertyCount4096() throws Exception {
+        try (POIFSFileSystem fs = new POIFSFileSystem(_inst.openResourceAsStream("BlockSize4096.zvi"))) {
+            assertEquals(0, fs.getHeaderBlock().getPropertyCount(), "Property count");
+
+            for (int i = 1; i <= 100; i++) {
+                fs.getRoot().createOrUpdateDocument("Entry " + i, new ByteArrayInputStream(new byte[8192]));
+            }
+
+            assertEquals(5, writeOutAndReadBack(fs).getHeaderBlock().getPropertyCount(), "Property count");
         }
     }
 


### PR DESCRIPTION
This is a follow up to the PR #462 for Bug 66590, the header field must be updated only if the file uses 4K blocks. If small blocks are used the field must remain nul.