### PR TITLE
Misplaced comment in DirectoryNode

### DIFF
--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/DirectoryNode.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/DirectoryNode.java
@@ -610,6 +610,8 @@ public class DirectoryNode
         return getName();
     }
 
+    /* **********  END  begin implementation of POIFSViewable ********** */
+
     /**
      * Returns an Iterator over all the entries
      */
@@ -627,7 +629,5 @@ public class DirectoryNode
     public Spliterator<Entry> spliterator() {
         return _entries.spliterator();
     }
-
-    /* **********  END  begin implementation of POIFSViewable ********** */
 }   // end public class DirectoryNode
 


### PR DESCRIPTION
There is a misplaced comment in the `DirectoryNode` class, the `iterator()` and `spliterator()` methods aren't part of the `POIFSViewable` interface and should be under the `/* **********  END  begin implementation of POIFSViewable ********** */` comment.