### PR TITLE
Occupied size optimization

### DIFF
--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSMiniStore.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSMiniStore.java
@@ -266,10 +266,9 @@ public class POIFSMiniStore extends BlockStore {
         int entriesPerBlock = _filesystem.getBigBlockSizeDetails().getBATEntriesPerBlock();
         for (int sbatIndex = _sbat_blocks.size() - 1; sbatIndex >= 0; sbatIndex--) {
             BATBlock sbat = _sbat_blocks.get(sbatIndex);
-            for (int miniBlockIndex = entriesPerBlock - 1; miniBlockIndex >= 0; miniBlockIndex--) {
-                if (sbat.getValueAt(miniBlockIndex) != POIFSConstants.UNUSED_BLOCK) {
-                    return (sbatIndex * entriesPerBlock) + miniBlockIndex + 1;
-                }
+            int occupiedSize = sbat.getOccupiedSize();
+            if (occupiedSize > 0) {
+                return (sbatIndex * entriesPerBlock) + occupiedSize;
             }
         }
 

--- a/poi/src/main/java/org/apache/poi/poifs/storage/BATBlock.java
+++ b/poi/src/main/java/org/apache/poi/poifs/storage/BATBlock.java
@@ -202,15 +202,12 @@ public final class BATBlock implements BlockWritable {
      * @since POI 5.0.0
      */
     public int getOccupiedSize() {
-        int usedSectors = _values.length;
         for (int k = _values.length - 1; k >= 0; k--) {
-            if(_values[k] == POIFSConstants.UNUSED_BLOCK) {
-                usedSectors--;
-            } else {
-                break;
+            if (_values[k] != POIFSConstants.UNUSED_BLOCK) {
+                return k + 1;
             }
         }
-        return usedSectors;
+        return 0;
     }
 
     public int getValueAt(int relativeOffset) {


### PR DESCRIPTION
As discussed in PR #731, here is a minor optimization to `BATBlock.getOccupiedSize()`