### PR TITLE
Avoiding needless `java.awt.Color` dependency in `HSSFColor`

### DIFF
--- a/poi/src/main/java/org/apache/poi/hssf/util/HSSFColor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/util/HSSFColor.java
@@ -353,16 +353,15 @@ public class HSSFColor implements Color {
                Integer.toHexString(getBlue()*0x101)).toUpperCase(Locale.ROOT);
     }
 
-    final short getBlue() {
+    private final short getBlue() {
         return (short) (rgb & 0xff);
     }
-    final short getGreen() {
+    private final short getGreen() {
         return (short) ((rgb >> 8) & 0xff);
     }
-    final short getRed() {
+    private final short getRed() {
         return (short) ((rgb >> 16) & 0xff);
     }
-
 
     @Override
     public boolean equals(Object o) {

--- a/poi/src/main/java/org/apache/poi/hssf/util/HSSFColor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/util/HSSFColor.java
@@ -42,7 +42,7 @@ public class HSSFColor implements Color {
     private static Map<Integer,HSSFColor> indexHash;
     private static Map<HSSFColorPredefined,HSSFColor> enumList;
 
-    private final java.awt.Color color;
+    private final int rgb;
     private final int index;
     private final int index2;
 
@@ -110,7 +110,7 @@ public class HSSFColor implements Color {
         private final HSSFColor color;
 
         HSSFColorPredefined(int index, int index2, int rgb) {
-            this.color = new HSSFColor(index, index2, new java.awt.Color(rgb));
+            this.color = new HSSFColor(index, index2, rgb);
         }
 
         /**
@@ -145,7 +145,7 @@ public class HSSFColor implements Color {
          * @return (a copy of) the HSSFColor assigned to the enum
          */
         public HSSFColor getColor() {
-            return new HSSFColor(getIndex(), getIndex2(), color.color);
+            return new HSSFColor(getIndex(), getIndex2(), color.rgb);
         }
     }
 
@@ -153,13 +153,37 @@ public class HSSFColor implements Color {
     /** Creates a new instance of HSSFColor */
     public HSSFColor() {
         // automatic index
-        this(0x40, -1, java.awt.Color.BLACK);
+        this(0x40, -1, 0x00);
     }
 
+    /** Deprecated constructor. Adds dependency on {@code java.desktop} module
+     * just to extract RGB from {@link java.awt.Color}. Replace usage of
+     * this constructor by:
+     * <pre>
+     * new HSSFColor(index, index2, color.getRGB());
+     * </pre>
+     * or specify RGB directly.
+     *
+     * @param index
+     * @param index2
+     * @param color
+     * @deprecated prefer constructor that specifies RGB directly as a value
+     */
+    @Deprecated
     public HSSFColor(int index, int index2, java.awt.Color color) {
+        this(index, index2, color.getRGB());
+    }
+
+    /* Creates new instance of HSSFColor by specifying RGB as an {@code int}
+    * value.
+    * @param index
+    * @param index2
+    *
+    */
+    public HSSFColor(int index, int index2, int rgb) {
         this.index = index;
         this.index2 = index2;
-        this.color = color;
+        this.rgb = 0xff000000 | rgb;
     }
 
     /**
@@ -315,7 +339,7 @@ public class HSSFColor implements Color {
      */
 
     public short [] getTriplet() {
-        return new short[] { (short)color.getRed(), (short)color.getGreen(), (short)color.getBlue() };
+        return new short[] { getRed(), getGreen(), getBlue() };
     }
 
     /**
@@ -324,10 +348,21 @@ public class HSSFColor implements Color {
      */
 
     public String getHexString() {
-        return (Integer.toHexString(color.getRed()*0x101) + ":" +
-               Integer.toHexString(color.getGreen()*0x101) + ":" +
-               Integer.toHexString(color.getBlue()*0x101)).toUpperCase(Locale.ROOT);
+        return (Integer.toHexString(getRed()*0x101) + ":" +
+               Integer.toHexString(getGreen()*0x101) + ":" +
+               Integer.toHexString(getBlue()*0x101)).toUpperCase(Locale.ROOT);
     }
+
+    final short getBlue() {
+        return (short) (rgb & 0xff);
+    }
+    final short getGreen() {
+        return (short) ((rgb >> 8) & 0xff);
+    }
+    final short getRed() {
+        return (short) ((rgb >> 16) & 0xff);
+    }
+
 
     @Override
     public boolean equals(Object o) {
@@ -338,12 +373,12 @@ public class HSSFColor implements Color {
 
         if (index != hssfColor.index) return false;
         if (index2 != hssfColor.index2) return false;
-        return Objects.equals(color, hssfColor.color);
+        return Objects.equals(rgb, hssfColor.rgb);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(color,index,index2);
+        return Objects.hash(rgb,index,index2);
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/hssf/util/HSSFColor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/util/HSSFColor.java
@@ -156,29 +156,29 @@ public class HSSFColor implements Color {
         this(0x40, -1, 0x00);
     }
 
-    /** Deprecated constructor. Adds dependency on {@code java.desktop} module
-     * just to extract RGB from {@link java.awt.Color}. Replace usage of
-     * this constructor by:
+    /** Constructs new instance of {@code HSSFColor} by
+     * extracting RGB from {@link java.awt.Color}. The code is equivalent
+     * to calling:
      * <pre>
      * new HSSFColor(index, index2, color.getRGB());
      * </pre>
-     * or specify RGB directly.
+     * or specifying {@link #HSSFColor(int, int, int) RGB directly}.
      *
      * @param index
      * @param index2
-     * @param color
-     * @deprecated prefer constructor that specifies RGB directly as a value
+     * @param color color to extract RGB from
      */
-    @Deprecated
     public HSSFColor(int index, int index2, java.awt.Color color) {
         this(index, index2, color.getRGB());
     }
 
-    /* Creates new instance of HSSFColor by specifying RGB as an {@code int}
-    * value.
+    /** Constructs new instance of {@code HSSFColor} by
+    * specifying RGB as an {@code int} value. Given {@code blue}, {@code green} and
+    * {@code blue} being byte values between {@code 0x00 to 0xff}, then
+    * {@code rgb = blue + (green >> 8) + (red >> 16)}.
     * @param index
     * @param index2
-    *
+    * @param rgb combined value of RGB
     */
     public HSSFColor(int index, int index2, int rgb) {
         this.index = index;

--- a/poi/src/test/java/org/apache/poi/hssf/util/TestHSSFColor.java
+++ b/poi/src/test/java/org/apache/poi/hssf/util/TestHSSFColor.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.hssf.util;
 
+import java.awt.Color;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,5 +56,16 @@ final class TestHSSFColor {
                 HSSFColorPredefined.YELLOW.getColor(),
                 triplets.get(HSSFColorPredefined.YELLOW.getHexString())
         );
+    }
+
+    @Test
+    void testRgbAndColorWorkTheSame() {
+        Color color = java.awt.Color.YELLOW;
+        @SuppressWarnings("deprecation")
+        HSSFColor fromColor = new HSSFColor(10, 20, color);
+        HSSFColor fromRgb = new HSSFColor(10, 20, color.getRGB());
+
+        assertEquals(fromColor, fromRgb, "Both colors are equal");
+        assertEquals(fromColor.hashCode(), fromRgb.hashCode(), "Both have the same hash code");
     }
 }


### PR DESCRIPTION
I am currently working on project called [Enso](https://github.com/enso-org/enso). We are making [heavy use of Apache POI](https://github.com/enso-org/enso/blob/59eb1f2aeb6369fe2abde95f66385a3927064a9e/build.sbt#L1395) to parse Excel documents our users are processing.

[![Excel in Enso](https://github.com/user-attachments/assets/c65fed38-9b3c-49ad-baa3-d284cd8f25fa)](https://community.ensoanalytics.com/c/enso101/sections/245392/lessons/914097 "Excel in Enso")

We are also using [GraalVM Native Image](http://graalvm.org) to compile our application to _native executable_. Recently we realized in https://github.com/enso-org/enso/pull/12843 that it is necessary to **avoid dependency on `java.desktop`** module.

### Why Avoiding `java.desktop` Dependency?

Since Java9 the JDK offers tool called [jlink](https://openjdk.org/jeps/282). It can be used to create a smaller JDK ready for execution in the cloud and other restricted environments:
- one can specify set of JDK modules to include 
- often it is useful to exclude `java.desktop`
- in https://github.com/enso-org/enso/pull/12843 exclusion of `java.desktop` was necessary
- as GraalVM was crashing when `java.desktop` was included

Excluding `java.desktop` is a good practice anyway - reduces bloat of the final application by tens of megabytes.

### Patching `HSSFColor`

- to resolve all the needs of https://github.com/enso-org/enso/pull/12843
- I had to [copy the code of HSSFColor](https://github.com/enso-org/enso/pull/12843/files#r2081091554) into our repository
- and modify it to avoid instantiating `java.awt.Color`

Such a solution was good short-term workaround, but I **don't want to maintain a fork** of POI! Hence my goal is to find a way to include the necessary fixes in your project in the long term. Hence the creation of this PR. Can you please consider its acceptance?

### Technicalities

- this PR replaces the RGB handling code in `HSSFColor`
- originally this code relied on `java.awt.Color`
   - however that creates _unnecessary dependency_ on `java.desktop`
- the PR proposes direct manipulation with RGB `int` compatible with handling in `java.awt.Color`
- the _behavior remains the same_
- dependency of `HSSFColor` on `java.desktop` is removed

### Other Fixes

- there are [other places in POI where dependency](https://github.com/enso-org/enso/pull/12843) on `java.desktop` deserves to be removed 
-  however that's a long term direction
- I am starting with this simple `HSSFColor` proposal 
- if it is accepted, I create subsequent PRs addressing other `java.desktop` dependencies