### PR TITLE
Allowing custom TempFileCreationStrategy per document

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -34,11 +34,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,17 +48,14 @@ import org.apache.poi.openxml4j.exceptions.OpenXML4JRuntimeException;
 import org.apache.poi.openxml4j.exceptions.PartAlreadyExistsException;
 import org.apache.poi.openxml4j.opc.internal.ContentType;
 import org.apache.poi.openxml4j.opc.internal.ContentTypeManager;
-import org.apache.poi.openxml4j.opc.internal.InvalidZipException;
 import org.apache.poi.openxml4j.opc.internal.PackagePropertiesPart;
 import org.apache.poi.openxml4j.opc.internal.PartMarshaller;
 import org.apache.poi.openxml4j.opc.internal.PartUnmarshaller;
-import org.apache.poi.openxml4j.opc.internal.ZipContentTypeManager;
 import org.apache.poi.openxml4j.opc.internal.marshallers.DefaultMarshaller;
 import org.apache.poi.openxml4j.opc.internal.marshallers.ZipPackagePropertiesMarshaller;
 import org.apache.poi.openxml4j.opc.internal.unmarshallers.PackagePropertiesUnmarshaller;
 import org.apache.poi.openxml4j.opc.internal.unmarshallers.UnmarshallContext;
 import org.apache.poi.openxml4j.util.ZipEntrySource;
-import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.NotImplemented;
 import org.apache.poi.util.StringUtil;
 
@@ -85,9 +80,9 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
     private final PackageAccess packageAccess;
 
     /**
-     * Package parts collection.
+     * Package parts collection. Package-private for OPCPackageOpener.
      */
-    private PackagePartCollection partList;
+    PackagePartCollection partList;
 
     /**
      * Package relationships.
@@ -268,19 +263,10 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      * @since POI 5.4.1
      */
     public static OPCPackage open(ZipEntrySource zipEntry, OPCComplianceFlags opcComplianceFlags) throws InvalidFormatException {
-        OPCPackage pack = new ZipPackage(zipEntry, PackageAccess.READ, opcComplianceFlags);
-        try {
-            if (pack.partList == null) {
-                pack.getParts();
-            }
-            // pack.originalPackagePath = file.getAbsolutePath();
-            return pack;
-        } catch (InvalidFormatException | RuntimeException e) {
-            // use revert() to free resources when the package is opened read-only
-            pack.revert();
-
-            throw e;
-        }
+        return withOpener(opener -> {
+            opener.setOpcComplianceFlags(opcComplianceFlags);
+            return opener.open(zipEntry);
+        });
     }
 
     /**
@@ -321,30 +307,11 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      */
     public static OPCPackage open(String path, PackageAccess access, OPCComplianceFlags opcComplianceFlags)
             throws InvalidFormatException, InvalidOperationException {
-        if (StringUtil.isBlank(path)) {
-            throw new IllegalArgumentException("'path' must be given");
-        }
 
-        File file = new File(path);
-        if (file.exists() && file.isDirectory()) {
-            throw new IllegalArgumentException("path must not be a directory");
-        }
-
-        OPCPackage pack = new ZipPackage(path, access, opcComplianceFlags); // NOSONAR
-        boolean success = false;
-        if (pack.partList == null && access != PackageAccess.WRITE) {
-            try {
-                pack.getParts();
-                success = true;
-            } finally {
-                if (! success) {
-                    IOUtils.closeQuietly(pack);
-                }
-            }
-        }
-
-        pack.originalPackagePath = new File(path).getAbsolutePath();
-        return pack;
+        OPCPackageOpener opener = new OPCPackageOpener();
+        opener.setPackageAccess(access);
+        opener.setOpcComplianceFlags(opcComplianceFlags);
+        return opener.open(path);
     }
 
    /**
@@ -381,33 +348,11 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      */
     public static OPCPackage open(File file, PackageAccess access, OPCComplianceFlags opcComplianceFlags)
             throws InvalidFormatException {
-        if (file == null) {
-            throw new IllegalArgumentException("'file' must be given");
-        }
-        if (file.exists() && file.isDirectory()) {
-            throw new IllegalArgumentException("file must not be a directory");
-        }
-
-        final OPCPackage pack;
-        try {
-            pack = new ZipPackage(file, access, opcComplianceFlags); //NOSONAR
-        } catch (InvalidOperationException e) {
-            throw new InvalidFormatException(e.getMessage(), e);
-        }
-        try {
-            if (pack.partList == null && access != PackageAccess.WRITE) {
-                pack.getParts();
-            }
-            pack.originalPackagePath = file.getAbsolutePath();
-            return pack;
-        } catch (InvalidFormatException | RuntimeException e) {
-            if (access == PackageAccess.READ) {
-                pack.revert();
-            } else {
-                IOUtils.closeQuietly(pack);
-            }
-            throw e;
-        }
+        return withOpener(opener -> {
+            opener.setPackageAccess(access);
+            opener.setOpcComplianceFlags(opcComplianceFlags);
+            return opener.open(file);
+        });
     }
 
     /**
@@ -450,21 +395,9 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      */
     public static OPCPackage open(InputStream in, OPCComplianceFlags opcComplianceFlags) throws InvalidFormatException,
             IOException {
-        final OPCPackage pack;
-        try {
-            pack = new ZipPackage(in, PackageAccess.READ_WRITE, opcComplianceFlags);
-        } catch (InvalidZipException e) {
-            throw new InvalidFormatException(e.getMessage(), e);
-        }
-        try {
-            if (pack.partList == null) {
-                pack.getParts();
-            }
-        } catch (InvalidFormatException | RuntimeException e) {
-            IOUtils.closeQuietly(pack);
-            throw e;
-        }
-        return pack;
+        OPCPackageOpener opener = new OPCPackageOpener();
+        opener.setOpcComplianceFlags(opcComplianceFlags);
+        return opener.open(in);
     }
 
     /**
@@ -512,21 +445,9 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      */
     public static OPCPackage open(InputStream in, boolean closeStream, OPCComplianceFlags opcComplianceFlags) throws InvalidFormatException,
             IOException {
-        final OPCPackage pack;
-        try {
-            pack = new ZipPackage(in, PackageAccess.READ_WRITE, closeStream, opcComplianceFlags);
-        } catch (InvalidZipException e) {
-            throw new InvalidFormatException(e.getMessage(), e);
-        }
-        try {
-            if (pack.partList == null) {
-                pack.getParts();
-            }
-        } catch (InvalidFormatException | RuntimeException e) {
-            IOUtils.closeQuietly(pack);
-            throw e;
-        }
-        return pack;
+        OPCPackageOpener opener = new OPCPackageOpener();
+        opener.setOpcComplianceFlags(opcComplianceFlags);
+        return opener.open(in, closeStream);
     }
 
     /**
@@ -540,11 +461,7 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      *             Throws if the specified file exist and is not valid.
      */
     public static OPCPackage openOrCreate(File file) throws InvalidFormatException {
-        if (file.exists()) {
-            return open(file.getAbsolutePath());
-        } else {
-            return create(file);
-        }
+        return withOpener(opener -> opener.openOrCreate(file));
     }
 
     /**
@@ -566,55 +483,15 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      * @return A newly created PackageBase ready to use.
      */
     public static OPCPackage create(File file) {
-        if (file == null || (file.exists() && file.isDirectory())) {
-            throw new IllegalArgumentException("file");
-        }
-
-        if (file.exists()) {
-            throw new InvalidOperationException(
-                    "This package (or file) already exists : use the open() method or delete the file.");
-        }
-
-        // Creates a new package
-        OPCPackage pkg = new ZipPackage();
-        pkg.originalPackagePath = file.getAbsolutePath();
-
-        configurePackage(pkg);
-        return pkg;
+        return withOpener(opener -> opener.create(file));
     }
 
     public static OPCPackage create(OutputStream output) {
-        OPCPackage pkg = new ZipPackage();
-        pkg.originalPackagePath = null;
-        pkg.output = output;
-
-        configurePackage(pkg);
-        return pkg;
+        return withOpener(opener -> opener.create(output));
     }
 
-    private static void configurePackage(OPCPackage pkg) {
-        try {
-            // Content type manager
-            pkg.contentTypeManager = new ZipContentTypeManager(null, pkg);
-
-            // Add default content types for .xml and .rels
-            pkg.contentTypeManager.addContentType(
-                    PackagingURIHelper.createPartName(
-                            PackagingURIHelper.PACKAGE_RELATIONSHIPS_ROOT_URI),
-                    RELATIONSHIPS_PART);
-            pkg.contentTypeManager.addContentType(
-                    PackagingURIHelper.createPartName("/default.xml"),
-                    PLAIN_OLD_XML);
-
-            // Initialise some PackageBase properties
-            pkg.packageProperties = new PackagePropertiesPart(pkg,
-                    PackagingURIHelper.CORE_PROPERTIES_PART_NAME);
-            pkg.packageProperties.setCreatorProperty("Generated by Apache POI OpenXML4J");
-            pkg.packageProperties.setCreatedProperty(Optional.of(new Date()));
-        } catch (InvalidFormatException e) {
-            // Should never happen
-            throw new IllegalStateException(e);
-        }
+    private static <R, E extends Exception> R withOpener(OPCPackageOpenerConfigurer<R, E> config) throws E {
+        return config.configure(new OPCPackageOpener());
     }
 
     /**
@@ -1879,5 +1756,9 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
                 ", isDirty=" + isDirty +
                 //", originalPackagePath='" + originalPackagePath + '\'' +
                 '}';
+    }
+
+    private interface OPCPackageOpenerConfigurer<R, E extends Exception> {
+        R configure(OPCPackageOpener opener) throws E;
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackageOpener.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackageOpener.java
@@ -1,0 +1,364 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.opc;
+
+import static org.apache.poi.openxml4j.opc.ContentTypes.PLAIN_OLD_XML;
+import static org.apache.poi.openxml4j.opc.ContentTypes.RELATIONSHIPS_PART;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.InvalidOperationException;
+import org.apache.poi.openxml4j.opc.internal.InvalidZipException;
+import org.apache.poi.openxml4j.opc.internal.PackagePropertiesPart;
+import org.apache.poi.openxml4j.opc.internal.ZipContentTypeManager;
+import org.apache.poi.openxml4j.util.ZipEntrySource;
+import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.StringUtil;
+import org.apache.poi.util.TempFileCreationStrategy;
+
+/**
+ * Defines a class to open OPC packages with particular configuration.
+ *
+ * @since POI 5.5.0
+ */
+public final class OPCPackageOpener {
+    private static final OPCComplianceFlags defaultOpcComplianceFlags = OPCComplianceFlags.enforceAll();
+
+    /**
+     * Package access.
+     */
+    private PackageAccess packageAccess;
+
+    /**
+     * Whether OPC compliance requirements are checked (e.g., M4.2, M4.3, M4.4, and M4.5)
+     */
+    private OPCComplianceFlags opcComplianceFlags;
+
+    /**
+     * Strategy to create temporary files.
+     */
+    private TempFileCreationStrategy tmpStrategy;
+
+    public OPCPackageOpener() {
+        this.packageAccess = OPCPackage.defaultPackageAccess;
+        this.opcComplianceFlags = defaultOpcComplianceFlags;
+        this.tmpStrategy = TempFileCreationStrategy.getDefaultStrategy();
+    }
+
+    /**
+     * Sets the package access.
+     *
+     * @param packageAccess the package access. May not be {@code null}.
+     */
+    public void setPackageAccess(PackageAccess packageAccess) {
+        this.packageAccess = Objects.requireNonNull(packageAccess, "packageAccess");
+    }
+
+    /**
+     * Sets whether OPC compliance requirements are checked (e.g., M4.2, M4.3, M4.4, and M4.5).
+     *
+     * @param opcComplianceFlags whether OPC compliance requirements are checked (e.g., M4.2, M4.3, M4.4, and M4.5).
+     *   May not be {@code null}.
+     */
+    public void setOpcComplianceFlags(OPCComplianceFlags opcComplianceFlags) {
+        this.opcComplianceFlags = Objects.requireNonNull(opcComplianceFlags, "opcComplianceFlags");
+    }
+
+    /**
+     * Sets the strategy to create temporary files.
+     *
+     * @param tmpStrategy the strategy to create temporary files. May not be {@code null}.
+     */
+    public void setTmpStrategy(TempFileCreationStrategy tmpStrategy) {
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
+    }
+
+    /**
+     * Open a user provided {@link ZipEntrySource} with read-only permission.
+     * This method can be used to stream data into POI.
+     * Opposed to other open variants, the data is read as-is, e.g. there aren't
+     * any zip-bomb protection put in place.
+     *
+     * @param zipEntry the custom source
+     * @return A Package object
+     * @throws InvalidFormatException if a parsing error occur.
+     */
+    public OPCPackage open(ZipEntrySource zipEntry) throws InvalidFormatException {
+        OPCPackage pack = new ZipPackage(zipEntry, packageAccess, opcComplianceFlags, tmpStrategy);
+        try {
+            if (pack.partList == null) {
+                pack.getParts();
+            }
+            // pack.originalPackagePath = file.getAbsolutePath();
+            return pack;
+        } catch (InvalidFormatException | RuntimeException e) {
+            // use revert() to free resources when the package is opened read-only
+            pack.revert();
+
+            throw e;
+        }
+    }
+
+    /**
+     * Open a package with read/write permission.
+     *
+     * @param path
+     *            The document path.
+     * @return A Package object, else <b>null</b>.
+     * @throws InvalidFormatException
+     *             If the specified file doesn't exist, and a parsing error
+     *             occur.
+     */
+    public OPCPackage open(String path)
+            throws InvalidFormatException, InvalidOperationException {
+        if (StringUtil.isBlank(path)) {
+            throw new IllegalArgumentException("'path' must be given");
+        }
+
+        File file = new File(path);
+        if (file.exists() && file.isDirectory()) {
+            throw new IllegalArgumentException("path must not be a directory");
+        }
+
+        OPCPackage pack = new ZipPackage(path, packageAccess, opcComplianceFlags, tmpStrategy); // NOSONAR
+        boolean success = false;
+        if (pack.partList == null && packageAccess != PackageAccess.WRITE) {
+            try {
+                pack.getParts();
+                success = true;
+            } finally {
+                if (! success) {
+                    IOUtils.closeQuietly(pack);
+                }
+            }
+        }
+
+        pack.originalPackagePath = new File(path).getAbsolutePath();
+        return pack;
+    }
+
+    /**
+     * Open a package with read/write permission.
+     *
+     * @param file
+     *            The file to open.
+     * @return A Package object, else <b>null</b>.
+     * @throws InvalidFormatException
+     *             If the specified file doesn't exist, and a parsing error
+     *             occur.
+     */
+    public OPCPackage open(File file)
+            throws InvalidFormatException {
+        if (file == null) {
+            throw new IllegalArgumentException("'file' must be given");
+        }
+        if (file.exists() && file.isDirectory()) {
+            throw new IllegalArgumentException("file must not be a directory");
+        }
+
+        final OPCPackage pack;
+        try {
+            pack = new ZipPackage(file, packageAccess, opcComplianceFlags, tmpStrategy); //NOSONAR
+        } catch (InvalidOperationException e) {
+            throw new InvalidFormatException(e.getMessage(), e);
+        }
+        try {
+            if (pack.partList == null && packageAccess != PackageAccess.WRITE) {
+                pack.getParts();
+            }
+            pack.originalPackagePath = file.getAbsolutePath();
+            return pack;
+        } catch (InvalidFormatException | RuntimeException e) {
+            if (packageAccess == PackageAccess.READ) {
+                pack.revert();
+            } else {
+                IOUtils.closeQuietly(pack);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Open a package.
+     *
+     * Note - uses quite a bit more memory than {@link #open(String)}, which
+     * doesn't need to hold the whole zip file in memory, and can take advantage
+     * of native methods
+     *
+     * @param in
+     *            The InputStream to read the package from. The stream is closed.
+     * @return A PackageBase object
+     *
+     * @throws InvalidFormatException
+     *              Throws if the specified file exist and is not valid.
+     * @throws IOException If reading the stream fails
+     */
+    public OPCPackage open(InputStream in) throws InvalidFormatException,
+            IOException {
+        final OPCPackage pack;
+        try {
+            pack = new ZipPackage(in, packageAccess, opcComplianceFlags, tmpStrategy);
+        } catch (InvalidZipException e) {
+            throw new InvalidFormatException(e.getMessage(), e);
+        }
+        try {
+            if (pack.partList == null) {
+                pack.getParts();
+            }
+        } catch (InvalidFormatException | RuntimeException e) {
+            IOUtils.closeQuietly(pack);
+            throw e;
+        }
+        return pack;
+    }
+
+    /**
+     * Open a package.
+     *
+     * Note - uses quite a bit more memory than {@link #open(String)}, which
+     * doesn't need to hold the whole zip file in memory, and can take advantage
+     * of native methods
+     *
+     * @param in
+     *            The InputStream to read the package from.
+     * @param closeStream
+     *            Whether to close the input stream.
+     * @return A PackageBase object
+     *
+     * @throws InvalidFormatException
+     *              Throws if the specified file exist and is not valid.
+     * @throws IOException If reading the stream fails
+     */
+    public OPCPackage open(InputStream in, boolean closeStream) throws InvalidFormatException,
+            IOException {
+        final OPCPackage pack;
+        try {
+            pack = new ZipPackage(in, packageAccess, closeStream, opcComplianceFlags, tmpStrategy);
+        } catch (InvalidZipException e) {
+            throw new InvalidFormatException(e.getMessage(), e);
+        }
+        try {
+            if (pack.partList == null) {
+                pack.getParts();
+            }
+        } catch (InvalidFormatException | RuntimeException e) {
+            IOUtils.closeQuietly(pack);
+            throw e;
+        }
+        return pack;
+    }
+
+    /**
+     * Opens a package if it exists, else it creates one.
+     *
+     * @param file
+     *            The file to open or to create.
+     * @return A newly created package if the specified file does not exist,
+     *         else the package extract from the file.
+     * @throws InvalidFormatException
+     *             Throws if the specified file exist and is not valid.
+     */
+    public OPCPackage openOrCreate(File file) throws InvalidFormatException {
+        if (file.exists()) {
+            return open(file.getAbsolutePath());
+        } else {
+            return create(file);
+        }
+    }
+
+    /**
+     * Creates a new package.
+     *
+     * @param path
+     *            Path of the document.
+     * @return A newly created PackageBase ready to use.
+     */
+    public OPCPackage create(String path) {
+        return create(new File(path));
+    }
+
+    /**
+     * Creates a new package.
+     *
+     * @param file
+     *            Path of the document.
+     * @return A newly created PackageBase ready to use.
+     */
+    public OPCPackage create(File file) {
+        if (file == null || (file.exists() && file.isDirectory())) {
+            throw new IllegalArgumentException("file");
+        }
+
+        if (file.exists()) {
+            throw new InvalidOperationException(
+                    "This package (or file) already exists : use the open() method or delete the file.");
+        }
+
+        // Creates a new package
+        OPCPackage pkg = newZipPackage();
+        pkg.originalPackagePath = file.getAbsolutePath();
+
+        configurePackage(pkg);
+        return pkg;
+    }
+
+    public OPCPackage create(OutputStream output) {
+        OPCPackage pkg = newZipPackage();
+        pkg.originalPackagePath = null;
+        pkg.output = output;
+
+        configurePackage(pkg);
+        return pkg;
+    }
+
+    private ZipPackage newZipPackage() {
+        return new ZipPackage(packageAccess, opcComplianceFlags, tmpStrategy);
+    }
+
+    private static void configurePackage(OPCPackage pkg) {
+        try {
+            // Content type manager
+            pkg.contentTypeManager = new ZipContentTypeManager(null, pkg);
+
+            // Add default content types for .xml and .rels
+            pkg.contentTypeManager.addContentType(
+                    PackagingURIHelper.createPartName(
+                            PackagingURIHelper.PACKAGE_RELATIONSHIPS_ROOT_URI),
+                    RELATIONSHIPS_PART);
+            pkg.contentTypeManager.addContentType(
+                    PackagingURIHelper.createPartName("/default.xml"),
+                    PLAIN_OLD_XML);
+
+            // Initialise some PackageBase properties
+            pkg.packageProperties = new PackagePropertiesPart(pkg,
+                    PackagingURIHelper.CORE_PROPERTIES_PART_NAME);
+            pkg.packageProperties.setCreatorProperty("Generated by Apache POI OpenXML4J");
+            pkg.packageProperties.setCreatedProperty(Optional.of(new Date()));
+        } catch (InvalidFormatException e) {
+            // Should never happen
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/ZipPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/ZipPackage.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
@@ -52,7 +53,7 @@ import org.apache.poi.openxml4j.util.ZipFileZipEntrySource;
 import org.apache.poi.openxml4j.util.ZipInputStreamZipEntrySource;
 import org.apache.poi.openxml4j.util.ZipSecureFile;
 import org.apache.poi.util.IOUtils;
-import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 /**
  * Physical zip package.
@@ -70,6 +71,11 @@ public final class ZipPackage extends OPCPackage {
      *  or a stream
      */
     private final ZipEntrySource zipArchive;
+
+    /**
+     * Strategy to create temporary files.
+     */
+    private final TempFileCreationStrategy tmpStrategy;
 
     /**
      * @param tempFilePackageParts whether to save package part data in temp files to save memory
@@ -110,10 +116,35 @@ public final class ZipPackage extends OPCPackage {
      * Constructor. Creates a new, empty ZipPackage.
      * @param opcComplianceFlags
      *            The level of OPC compliance to enforce when reading the package
-     * @since POI 5.4.1
      */
     public ZipPackage(OPCComplianceFlags opcComplianceFlags) {
-        super(defaultPackageAccess, opcComplianceFlags);
+        this(opcComplianceFlags, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Constructor. Creates a new, empty ZipPackage.
+     * @param opcComplianceFlags
+     *            The level of OPC compliance to enforce when reading the package
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
+     * @since POI 5.5.0
+     */
+    public ZipPackage(OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) {
+        this(defaultPackageAccess, opcComplianceFlags, tmpStrategy);
+    }
+
+    /**
+     * Constructor. Creates a new, empty ZipPackage.
+     * @param access
+     *            The package access mode.
+     * @param opcComplianceFlags
+     *            The level of OPC compliance to enforce when reading the package
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
+     */
+    ZipPackage(PackageAccess access, OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) {
+        super(access, opcComplianceFlags);
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
         this.zipArchive = null;
 
         try {
@@ -131,14 +162,16 @@ public final class ZipPackage extends OPCPackage {
      *            Zip input stream to load.
      * @param access
      *            The package access mode.
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws IllegalArgumentException
      *             If the specified input stream is not an instance of
      *             ZipInputStream.
      * @throws IOException
      *            if input stream cannot be opened, read, or closed
      */
-    ZipPackage(InputStream in, PackageAccess access) throws IOException {
-        this(in, access, OPCComplianceFlags.enforceAll());
+    ZipPackage(InputStream in, PackageAccess access, TempFileCreationStrategy tmpStrategy) throws IOException {
+        this(in, access, OPCComplianceFlags.enforceAll(), tmpStrategy);
     }
 
     /**
@@ -151,6 +184,8 @@ public final class ZipPackage extends OPCPackage {
      *            The package access mode.
      * @param opcComplianceFlags
      *            The level of OPC compliance to enforce when reading the package
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws IllegalArgumentException
      *             If the specified input stream is not an instance of
      *             ZipInputStream.
@@ -158,10 +193,11 @@ public final class ZipPackage extends OPCPackage {
      *            if input stream cannot be opened, read, or closed
      * @since POI 5.4.1
      */
-    ZipPackage(InputStream in, PackageAccess access, OPCComplianceFlags opcComplianceFlags) throws IOException {
+    ZipPackage(InputStream in, PackageAccess access, OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) throws IOException {
         super(access, opcComplianceFlags);
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
         try (ZipArchiveThresholdInputStream zis = ZipHelper.openZipStream(in)) {
-            this.zipArchive = new ZipInputStreamZipEntrySource(zis);
+            this.zipArchive = new ZipInputStreamZipEntrySource(zis, tmpStrategy);
         }
     }
 
@@ -175,6 +211,8 @@ public final class ZipPackage extends OPCPackage {
      *            The package access mode.
      * @param closeStream
      *            Whether to close the input stream.
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws IllegalArgumentException
      *             If the specified input stream is not an instance of
      *             ZipInputStream.
@@ -182,8 +220,8 @@ public final class ZipPackage extends OPCPackage {
      *            if input stream cannot be opened, read, or closed
      * @since POI 5.2.5
      */
-    ZipPackage(InputStream in, PackageAccess access, boolean closeStream) throws IOException {
-        this(in, access, closeStream, OPCComplianceFlags.enforceAll());
+    ZipPackage(InputStream in, PackageAccess access, boolean closeStream, TempFileCreationStrategy tmpStrategy) throws IOException {
+        this(in, access, closeStream, OPCComplianceFlags.enforceAll(), tmpStrategy);
     }
 
     /**
@@ -198,6 +236,8 @@ public final class ZipPackage extends OPCPackage {
      *            Whether to close the input stream.
      * @param opcComplianceFlags
      *            The level of OPC compliance to enforce when reading the package
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws IllegalArgumentException
      *             If the specified input stream is not an instance of
      *             ZipInputStream.
@@ -205,10 +245,11 @@ public final class ZipPackage extends OPCPackage {
      *            if input stream cannot be opened, read, or closed
      * @since POI 5.4.1
      */
-    ZipPackage(InputStream in, PackageAccess access, boolean closeStream, OPCComplianceFlags opcComplianceFlags) throws IOException {
+    ZipPackage(InputStream in, PackageAccess access, boolean closeStream, OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) throws IOException {
         super(access, opcComplianceFlags);
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
         try (ZipArchiveThresholdInputStream zis = ZipHelper.openZipStream(in, closeStream)) {
-            this.zipArchive = new ZipInputStreamZipEntrySource(zis);
+            this.zipArchive = new ZipInputStreamZipEntrySource(zis, tmpStrategy);
         }
     }
 
@@ -219,10 +260,12 @@ public final class ZipPackage extends OPCPackage {
      *            The path of the file to open or create.
      * @param access
      *            The package access mode.
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws InvalidOperationException If the zip file cannot be opened.
      */
-    ZipPackage(String path, PackageAccess access) throws InvalidOperationException {
-        this(path, access, OPCComplianceFlags.enforceAll());
+    ZipPackage(String path, PackageAccess access, TempFileCreationStrategy tmpStrategy) throws InvalidOperationException {
+        this(path, access, OPCComplianceFlags.enforceAll(), tmpStrategy);
     }
 
     /**
@@ -234,11 +277,13 @@ public final class ZipPackage extends OPCPackage {
      *            The package access mode.
      * @param opcComplianceFlags
      *            The level of OPC compliance to enforce when reading the package
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws InvalidOperationException If the zip file cannot be opened.
      * @since POI 5.4.1
      */
-    ZipPackage(String path, PackageAccess access, OPCComplianceFlags opcComplianceFlags) throws InvalidOperationException {
-        this(new File(path), access, opcComplianceFlags);
+    ZipPackage(String path, PackageAccess access, OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) throws InvalidOperationException {
+        this(new File(path), access, opcComplianceFlags, tmpStrategy);
     }
 
     /**
@@ -248,10 +293,12 @@ public final class ZipPackage extends OPCPackage {
      *            The file to open or create.
      * @param access
      *            The package access mode.
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws InvalidOperationException If the zip file cannot be opened.
      */
-    ZipPackage(File file, PackageAccess access) throws InvalidOperationException {
-        this(file, access, OPCComplianceFlags.enforceAll());
+    ZipPackage(File file, PackageAccess access, TempFileCreationStrategy tmpStrategy) throws InvalidOperationException {
+        this(file, access, OPCComplianceFlags.enforceAll(), tmpStrategy);
     }
 
     /**
@@ -263,11 +310,14 @@ public final class ZipPackage extends OPCPackage {
      *            The package access mode.
      * @param opcComplianceFlags
      *            The level of OPC compliance to enforce when reading the package
+     * @param tmpStrategy
+     *            The strategy to create temporary files, may not be null
      * @throws InvalidOperationException If the zip file cannot be opened.
      * @since POI 5.4.1
      */
-    ZipPackage(File file, PackageAccess access, OPCComplianceFlags opcComplianceFlags) throws InvalidOperationException {
+    ZipPackage(File file, PackageAccess access, OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) throws InvalidOperationException {
         super(access, opcComplianceFlags);
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
 
         ZipEntrySource ze;
         try {
@@ -282,12 +332,12 @@ public final class ZipPackage extends OPCPackage {
             }
 
             LOG.atWarn().log("Error in zip file {} - falling back to stream processing (i.e. ignoring zip central directory)", file);
-            ze = openZipEntrySourceStream(file);
+            ze = openZipEntrySourceStream(file, tmpStrategy);
         }
         this.zipArchive = ze;
     }
 
-    private static ZipEntrySource openZipEntrySourceStream(File file) throws InvalidOperationException {
+    private static ZipEntrySource openZipEntrySourceStream(File file, TempFileCreationStrategy tmpStrategy) throws InvalidOperationException {
         final InputStream fis;
         // Acquire a resource that is needed to read the next level of openZipEntrySourceStream
         try {
@@ -309,7 +359,7 @@ public final class ZipPackage extends OPCPackage {
             // read from the zip input stream
 
             // Acquire the final level resource. If this is acquired successfully, the zip package was read successfully from the input stream
-            return new ZipInputStreamZipEntrySource(zis);
+            return new ZipInputStreamZipEntrySource(zis, tmpStrategy);
         } catch (final InvalidOperationException|UnsupportedFileFormatException e) {
             // abort: close the zip input stream
             IOUtils.closeQuietly(fis);
@@ -333,8 +383,8 @@ public final class ZipPackage extends OPCPackage {
      * @param access
      *            The package access mode.
      */
-    ZipPackage(ZipEntrySource zipEntry, PackageAccess access) {
-        this(zipEntry, access, OPCComplianceFlags.enforceAll());
+    ZipPackage(ZipEntrySource zipEntry, PackageAccess access, TempFileCreationStrategy tmpStrategy) {
+        this(zipEntry, access, OPCComplianceFlags.enforceAll(), tmpStrategy);
     }
 
     /**
@@ -350,9 +400,10 @@ public final class ZipPackage extends OPCPackage {
      *            The package access mode.
      * @since POI 5.4.1
      */
-    ZipPackage(ZipEntrySource zipEntry, PackageAccess access, OPCComplianceFlags opcComplianceFlags) {
+    ZipPackage(ZipEntrySource zipEntry, PackageAccess access, OPCComplianceFlags opcComplianceFlags, TempFileCreationStrategy tmpStrategy) {
         super(access, opcComplianceFlags);
         this.zipArchive = zipEntry;
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
     }
 
     /**
@@ -516,9 +567,9 @@ public final class ZipPackage extends OPCPackage {
         try {
             if (useTempFilePackageParts) {
                 if (encryptTempFilePackageParts) {
-                    return new EncryptedTempFilePackagePart(this, partName, contentType, loadRelationships);
+                    return new EncryptedTempFilePackagePart(this, partName, contentType, loadRelationships, tmpStrategy);
                 } else {
-                    return new TempFilePackagePart(this, partName, contentType, loadRelationships);
+                    return new TempFilePackagePart(this, partName, contentType, loadRelationships, tmpStrategy);
                 }
             } else {
                 return new MemoryPackagePart(this, partName, contentType, loadRelationships);
@@ -569,7 +620,7 @@ public final class ZipPackage extends OPCPackage {
         File tempFile;
         try {
             String tempFileName = generateTempFileName(FileHelper.getDirectory(targetFile));
-            tempFile = TempFile.createTempFile(tempFileName, ".tmp");
+            tempFile = tmpStrategy.createTempFile(tempFileName, ".tmp");
         } catch (IOException|RuntimeException|Error e) {
             IOUtils.closeQuietly(zipArchive);
             throw e;

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/EncryptedTempFilePackagePart.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/EncryptedTempFilePackagePart.java
@@ -28,6 +28,7 @@ import org.apache.poi.openxml4j.opc.internal.marshallers.ZipPartMarshaller;
 import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 import java.io.*;
 
@@ -61,7 +62,33 @@ public final class EncryptedTempFilePackagePart extends PackagePart {
      */
     public EncryptedTempFilePackagePart(OPCPackage pack, PackagePartName partName,
                                         String contentType) throws InvalidFormatException, IOException {
-        this(pack, partName, contentType, true);
+        this(pack, partName, contentType, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @param tmpStrategy
+     *            The strategy to create temporary files (if needed), may not be null.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     * @since POI 5.5.0
+     */
+    public EncryptedTempFilePackagePart(
+            OPCPackage pack,
+            PackagePartName partName,
+            String contentType,
+            TempFileCreationStrategy tmpStrategy
+    ) throws InvalidFormatException, IOException {
+        this(pack, partName, contentType, true, tmpStrategy);
     }
 
     /**
@@ -83,8 +110,37 @@ public final class EncryptedTempFilePackagePart extends PackagePart {
     public EncryptedTempFilePackagePart(OPCPackage pack, PackagePartName partName,
                                         String contentType, boolean loadRelationships)
             throws InvalidFormatException, IOException {
+        this(pack, partName, contentType, loadRelationships, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @param loadRelationships
+     *            Specify if the relationships will be loaded.
+     * @param tmpStrategy
+     *            The strategy to create temporary files (if needed), may not be null.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     * @since POI 5.5.0
+     */
+    public EncryptedTempFilePackagePart(
+            OPCPackage pack,
+            PackagePartName partName,
+            String contentType,
+            boolean loadRelationships,
+            TempFileCreationStrategy tmpStrategy
+    ) throws InvalidFormatException, IOException {
         super(pack, partName, new ContentType(contentType), loadRelationships);
-        tempFile = new EncryptedTempData();
+        tempFile = new EncryptedTempData(tmpStrategy);
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/TempFilePackagePart.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/TempFilePackagePart.java
@@ -28,6 +28,7 @@ import org.apache.poi.openxml4j.opc.internal.marshallers.ZipPartMarshaller;
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -62,7 +63,32 @@ public final class TempFilePackagePart extends PackagePart {
      */
     public TempFilePackagePart(OPCPackage pack, PackagePartName partName,
                                String contentType) throws InvalidFormatException, IOException {
-        this(pack, partName, contentType, true);
+        this(pack, partName, contentType, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     *
+     * @since POI 5.5.0
+     */
+    public TempFilePackagePart(
+            OPCPackage pack,
+            PackagePartName partName,
+            String contentType,
+            TempFileCreationStrategy tmpStrategy
+    ) throws InvalidFormatException, IOException {
+        this(pack, partName, contentType, true, tmpStrategy);
     }
 
     /**
@@ -84,8 +110,36 @@ public final class TempFilePackagePart extends PackagePart {
     public TempFilePackagePart(OPCPackage pack, PackagePartName partName,
                                String contentType, boolean loadRelationships)
             throws InvalidFormatException, IOException {
+        this(pack, partName, contentType, loadRelationships, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pack
+     *            The owner package.
+     * @param partName
+     *            The part name.
+     * @param contentType
+     *            The content type.
+     * @param loadRelationships
+     *            Specify if the relationships will be loaded.
+     * @throws InvalidFormatException
+     *             If the specified URI is not OPC compliant.
+     * @throws IOException
+     *             If temp file cannot be created.
+     *
+     * @since POI 5.5.0
+     */
+    public TempFilePackagePart(
+            OPCPackage pack,
+            PackagePartName partName,
+            String contentType,
+            boolean loadRelationships,
+            TempFileCreationStrategy tmpStrategy
+    ) throws InvalidFormatException, IOException {
         super(pack, partName, new ContentType(contentType), loadRelationships);
-        tempFile = TempFile.createTempFile("poi-package-part", ".tmp");
+        tempFile = tmpStrategy.createTempFile("poi-package-part", ".tmp");
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveFakeEntry.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveFakeEntry.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
 import org.apache.poi.util.IOUtils;
-import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 /**
  * So we can close the real zip entry and still
@@ -65,7 +65,7 @@ public final class ZipArchiveFakeEntry extends ZipArchiveEntry implements Closea
     private File tempFile;
     private EncryptedTempData encryptedTempData;
 
-    ZipArchiveFakeEntry(ZipArchiveEntry entry, InputStream inp) throws IOException {
+    ZipArchiveFakeEntry(ZipArchiveEntry entry, InputStream inp, TempFileCreationStrategy tmpStrategy) throws IOException {
         super(entry.getName());
 
         final long entrySize = entry.getSize();
@@ -73,12 +73,12 @@ public final class ZipArchiveFakeEntry extends ZipArchiveEntry implements Closea
         final int threshold = ZipInputStreamZipEntrySource.getThresholdBytesForTempFiles();
         if (threshold >= 0 && (entrySize >= threshold || entrySize == -1)) {
             if (ZipInputStreamZipEntrySource.shouldEncryptTempFiles()) {
-                encryptedTempData = new EncryptedTempData();
+                encryptedTempData = new EncryptedTempData(tmpStrategy);
                 try (OutputStream os = encryptedTempData.getOutputStream()) {
                     IOUtils.copy(inp, os);
                 }
             } else {
-                tempFile = TempFile.createTempFile("poi-zip-entry", ".tmp");
+                tempFile = tmpStrategy.createTempFile("poi-zip-entry", ".tmp");
                 LOG.atInfo().log("Creating temp file {} for zip entry {} of size {} bytes",
                         tempFile.getAbsolutePath(), entry.getName(), entrySize);
                 IOUtils.copy(inp, tempFile);

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.poi.openxml4j.opc.internal.InvalidZipException;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 /**
  * Provides a way to get at all the ZipEntries
@@ -87,7 +88,7 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
     }
 
     /**
-     * Reads all the entries from the ZipInputStream 
+     * Reads all the entries from the ZipInputStream
      *  into memory, and don't close (since POI 4.0.1) the source stream.
      * We'll then eat lots of memory, but be able to
      *  work with the entries at-will.
@@ -96,6 +97,21 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
      * @see #setThresholdBytesForTempFiles
      */
     public ZipInputStreamZipEntrySource(ZipArchiveThresholdInputStream inp) throws IOException {
+        this(inp, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Reads all the entries from the ZipInputStream
+     *  into memory, and don't close (since POI 4.0.1) the source stream.
+     * We'll then eat lots of memory, but be able to
+     *  work with the entries at-will.
+     * @throws IOException if an error occurs while reading the zip entries
+     * @throws InvalidZipException if the input file contains an entry with an empty name or more than 1 entry with the same name
+     * @see #setThresholdBytesForTempFiles
+     *
+     * @since POI 5.5.0
+     */
+    public ZipInputStreamZipEntrySource(ZipArchiveThresholdInputStream inp, TempFileCreationStrategy tmpStrategy) throws IOException {
         final Set<String> filenames = new HashSet<>();
         for (;;) {
             final ZipArchiveEntry zipEntry = inp.getNextEntry();
@@ -111,7 +127,7 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
                 throw new InvalidZipException("Input file contains more than 1 entry with the name " + zipEntry.getName());
             }
             filenames.add(name);
-            zipEntries.put(name, new ZipArchiveFakeEntry(zipEntry, inp));
+            zipEntries.put(name, new ZipArchiveFakeEntry(zipEntry, inp, tmpStrategy));
         }
 
         streamToClose = inp;

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/AesZipFileZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/AesZipFileZipEntrySource.java
@@ -46,6 +46,7 @@ import org.apache.poi.util.Beta;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.RandomSingleton;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 /**
  * An example {@code ZipEntrySource} that has encrypted temp files to ensure that
@@ -106,12 +107,19 @@ public final class AesZipFileZipEntrySource implements ZipEntrySource {
     }
 
     public static AesZipFileZipEntrySource createZipEntrySource(InputStream is) throws IOException {
+        return createZipEntrySource(is, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * @since POI 5.5.0
+     */
+    public static AesZipFileZipEntrySource createZipEntrySource(InputStream is, TempFileCreationStrategy tmpStrategy) throws IOException {
         try {
             // generate session key
             byte[] ivBytes = new byte[16], keyBytes = new byte[16];
             RandomSingleton.getInstance().nextBytes(ivBytes);
             RandomSingleton.getInstance().nextBytes(keyBytes);
-            final File tmpFile = TempFile.createTempFile("protectedXlsx", ".zip");
+            final File tmpFile = tmpStrategy.createTempFile("protectedXlsx", ".zip");
             try {
                 copyToFile(is, tmpFile, keyBytes, ivBytes);
                 return fileToSource(tmpFile, keyBytes, ivBytes);

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/EncryptedTempData.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/EncryptedTempData.java
@@ -39,6 +39,7 @@ import org.apache.poi.poifs.crypt.CryptoFunctions;
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.RandomSingleton;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 /**
  * EncryptedTempData can be used to buffer binary data in a secure way, by using encrypted temp files.
@@ -55,12 +56,19 @@ public class EncryptedTempData {
     private CountingOutputStream outputStream;
 
     public EncryptedTempData() throws IOException {
+        this(TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * @since POI 5.5.0
+     */
+    public EncryptedTempData(TempFileCreationStrategy tmpStrategy) throws IOException {
         ivBytes = new byte[16];
         byte[] keyBytes = new byte[16];
         RandomSingleton.getInstance().nextBytes(ivBytes);
         RandomSingleton.getInstance().nextBytes(keyBytes);
         skeySpec = new SecretKeySpec(keyBytes, cipherAlgorithm.jceId);
-        tempFile = TempFile.createTempFile("poi-temp-data", ".tmp");
+        tempFile = tmpStrategy.createTempFile("poi-temp-data", ".tmp");
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/SXSSFWorkbookWithCustomZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/SXSSFWorkbookWithCustomZipEntrySource.java
@@ -41,11 +41,11 @@ public class SXSSFWorkbookWithCustomZipEntrySource extends SXSSFWorkbook {
         super(20);
         setCompressTempFiles(true);
     }
-    
+
     @Override
     public void write(OutputStream stream) throws IOException {
         flushSheets();
-        EncryptedTempData tempData = new EncryptedTempData();
+        EncryptedTempData tempData = new EncryptedTempData(getTempFileCreationStrategy());
         ZipEntrySource source = null;
         try {
             try (OutputStream os = tempData.getOutputStream()) {
@@ -53,7 +53,7 @@ public class SXSSFWorkbookWithCustomZipEntrySource extends SXSSFWorkbook {
             }
             // provide ZipEntrySource to poi which decrypts on the fly
             try (InputStream tempStream = tempData.getInputStream()) {
-                source = AesZipFileZipEntrySource.createZipEntrySource(tempStream);
+                source = AesZipFileZipEntrySource.createZipEntrySource(tempStream, getTempFileCreationStrategy());
             }
             injectData(source, stream);
         } finally {
@@ -61,12 +61,12 @@ public class SXSSFWorkbookWithCustomZipEntrySource extends SXSSFWorkbook {
             IOUtils.closeQuietly(source);
         }
     }
-    
+
     @Override
     protected SheetDataWriter createSheetDataWriter() throws IOException {
         //log values to ensure these values are accessible to subclasses
         LOG.atInfo().log("isCompressTempFiles: {}", box(isCompressTempFiles()));
         LOG.atInfo().log("SharedStringSource: {}", getSharedStringSource());
-        return new SheetDataWriterWithDecorator();
+        return new SheetDataWriterWithDecorator(getTempFileCreationStrategy());
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/SheetDataWriterWithDecorator.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/SheetDataWriterWithDecorator.java
@@ -35,6 +35,7 @@ import org.apache.poi.poifs.crypt.CipherAlgorithm;
 import org.apache.poi.poifs.crypt.CryptoFunctions;
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.RandomSingleton;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.streaming.SheetDataWriter;
 
 @Beta
@@ -44,7 +45,11 @@ public class SheetDataWriterWithDecorator extends SheetDataWriter {
     byte[] ivBytes;
 
     public SheetDataWriterWithDecorator() throws IOException {
-        super();
+        this(TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    public SheetDataWriterWithDecorator(TempFileCreationStrategy tmpStrategy) throws IOException {
+        super(tmpStrategy);
     }
 
     void init() {

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/GZIPSheetDataWriter.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/GZIPSheetDataWriter.java
@@ -30,22 +30,39 @@ import java.util.zip.GZIPOutputStream;
 
 import org.apache.poi.util.Removal;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.model.SharedStringsTable;
 
 /**
  * Sheet writer that supports gzip compression of the temp files.
  */
 public class GZIPSheetDataWriter extends SheetDataWriter {
-
     public GZIPSheetDataWriter() throws IOException {
-        super();
+        this(TempFileCreationStrategy.getDefaultStrategy());
     }
-    
+
+    /**
+     * @since POI 5.5.0
+     */
+    public GZIPSheetDataWriter(TempFileCreationStrategy tmpStrategy) throws IOException {
+        super(tmpStrategy);
+    }
+
     /**
      * @param sharedStringsTable the shared strings table, or null if inline text is used
      */
     public GZIPSheetDataWriter(SharedStringsTable sharedStringsTable) throws IOException {
-        super(sharedStringsTable);
+        this(sharedStringsTable, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * @param sharedStringsTable the shared strings table, or null if inline text is used
+     * @param tmpStrategy the strategy to create temporary files, may not be null
+     *
+     * @since POI 5.5.0
+     */
+    public GZIPSheetDataWriter(SharedStringsTable sharedStringsTable, TempFileCreationStrategy tmpStrategy) throws IOException {
+        super(sharedStringsTable, tmpStrategy);
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFWorkbook.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Spliterator;
 
 import org.apache.commons.compress.archivers.zip.Zip64Mode;
@@ -68,7 +69,7 @@ import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.Internal;
 import org.apache.poi.util.NotImplemented;
 import org.apache.poi.util.Removal;
-import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.model.SharedStringsTable;
 import org.apache.poi.xssf.usermodel.XSSFChartSheet;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
@@ -130,6 +131,8 @@ public class SXSSFWorkbook implements Workbook {
      * whether temp files should be compressed.
      */
     private boolean _compressTmpFiles;
+
+    private TempFileCreationStrategy _tmpStrategy;
 
     /**
      * shared string table - a cache of strings in this workbook
@@ -264,6 +267,8 @@ public class SXSSFWorkbook implements Workbook {
      * @param useSharedStringsTable whether to use a shared strings table
      */
     public SXSSFWorkbook(XSSFWorkbook workbook, int rowAccessWindowSize, boolean compressTmpFiles, boolean useSharedStringsTable) {
+        _tmpStrategy = TempFileCreationStrategy.getDefaultStrategy();
+
         setRandomAccessWindowSize(rowAccessWindowSize);
         setCompressTempFiles(compressTmpFiles);
         if (workbook == null) {
@@ -360,6 +365,31 @@ public class SXSSFWorkbook implements Workbook {
     }
 
     /**
+     * Sets the strategy to create temporary files required for this workbook. Setting the
+     * strategy will not affect already created sheets, so it is highly recommended to set
+     * this strategy right after creating the workbook.
+     * <p>
+     * The default strategy is {@link TempFileCreationStrategy#getDefaultStrategy()}.
+     *
+     * @param tmpStrategy the strategy to create temporary files, may not be null
+     *
+     * @since POI 5.5.0
+     */
+    public void setTempFileCreationStrategy(TempFileCreationStrategy tmpStrategy) {
+        _tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
+    }
+
+    /**
+     * Returns the currently set strategy to create temporary files.
+     * See {@link #setTempFileCreationStrategy(TempFileCreationStrategy)}.
+     *
+     * @return the currently set strategy to create temporary files. This method never returns {@code null}.
+     */
+    public TempFileCreationStrategy getTempFileCreationStrategy() {
+        return _tmpStrategy;
+    }
+
+    /**
      * @param shouldCalculateSheetDimensions defaults to <code>true</code>, set to <code>false</code> if
      *                                       the calculated dimensions are causing trouble
      * @since POI 5.2.3
@@ -384,10 +414,10 @@ public class SXSSFWorkbook implements Workbook {
 
     protected SheetDataWriter createSheetDataWriter() throws IOException {
         if(_compressTmpFiles) {
-            return new GZIPSheetDataWriter(_sharedStringSource);
+            return new GZIPSheetDataWriter(_sharedStringSource, _tmpStrategy);
         }
 
-        return new SheetDataWriter(_sharedStringSource);
+        return new SheetDataWriter(_sharedStringSource, _tmpStrategy);
     }
 
     XSSFSheet getXSSFSheet(SXSSFSheet sheet) {
@@ -949,7 +979,7 @@ public class SXSSFWorkbook implements Workbook {
         flushSheets();
 
         //Save the template
-        File tmplFile = TempFile.createTempFile("poi-sxssf-template", ".xlsx");
+        File tmplFile = _tmpStrategy.createTempFile("poi-sxssf-template", ".xlsx");
         boolean deleted;
         try {
             try (OutputStream os = Files.newOutputStream(tmplFile.toPath())) {
@@ -993,7 +1023,7 @@ public class SXSSFWorkbook implements Workbook {
                     InputStream is = bos.toInputStream();
                     ZipArchiveInputStream zis = new ZipArchiveInputStream(is);
                     ZipInputStreamZipEntrySource source = new ZipInputStreamZipEntrySource(
-                        new ZipArchiveThresholdInputStream(zis))
+                        new ZipArchiveThresholdInputStream(zis), _tmpStrategy)
             ) {
                 injectData(source, stream);
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SheetDataWriter.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SheetDataWriter.java
@@ -31,6 +31,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.PrimitiveIterator;
 
 import org.apache.poi.ss.usermodel.Cell;
@@ -42,6 +43,7 @@ import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.util.CodepointsUtil;
 import org.apache.poi.util.Removal;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.model.SharedStringsTable;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.STCellType;
 
@@ -67,18 +69,39 @@ public class SheetDataWriter implements Closeable {
      */
     private SharedStringsTable _sharedStringSource;
 
+    // We are only creating a field for this to maintain backwards compatibility
+    // with code overriding the createTempFile method. Once that method is
+    // unavailable in POI 6.0.0, this field can be removed.
+    private final TempFileCreationStrategy _tmpStrategy;
+
     public SheetDataWriter() throws IOException {
+        this(TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * @since POI 5.5.0
+     */
+    public SheetDataWriter(TempFileCreationStrategy tmpStrategy) throws IOException {
+        _tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
         _fd = createTempFile();
         _out = createWriter(_fd);
     }
 
     public SheetDataWriter(Writer writer) throws IOException {
+        _tmpStrategy = TempFileCreationStrategy.getDefaultStrategy();
         _fd = null;
         _out = writer;
     }
 
     public SheetDataWriter(SharedStringsTable sharedStringsTable) throws IOException {
-        this();
+        this(sharedStringsTable, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * @since POI 5.5.0
+     */
+    public SheetDataWriter(SharedStringsTable sharedStringsTable, TempFileCreationStrategy tmpStrategy) throws IOException {
+        this(tmpStrategy);
         this._sharedStringSource = sharedStringsTable;
     }
 
@@ -94,7 +117,7 @@ public class SheetDataWriter implements Closeable {
     @Removal(version = "6.0.0")
     //make this protected or private in POI 6.0.0 - no need for this to be public
     public File createTempFile() throws IOException {
-        return TempFile.createTempFile("poi-sxssf-sheet", ".xml");
+        return _tmpStrategy.createTempFile("poi-sxssf-sheet", ".xml");
     }
 
     /**

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestPackage.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestPackage.java
@@ -83,6 +83,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.XSSFTestDataSamples;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFRelation;
@@ -1051,8 +1052,8 @@ public final class TestPackage {
         try (final InputStream is = (useStream) ? xlsSamples.openResourceAsStream(name) : null) {
             assertThrows(NotOfficeXmlFileException.class, () -> {
                 try (final ZipPackage pkg = (useStream)
-                    ? new ZipPackage(is, PackageAccess.READ)
-                    : new ZipPackage(xlsSamples.getFile(name), PackageAccess.READ)) {
+                    ? new ZipPackage(is, PackageAccess.READ, TempFileCreationStrategy.getDefaultStrategy())
+                    : new ZipPackage(xlsSamples.getFile(name), PackageAccess.READ, TempFileCreationStrategy.getDefaultStrategy())) {
                     pkgTest[0] = pkg;
                     assertNotNull(pkg.getZipArchive());
                     assertFalse(pkg.getZipArchive().isClosed());

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
@@ -41,10 +41,12 @@ import org.apache.poi.openxml4j.opc.internal.InvalidZipException;
 import org.apache.poi.openxml4j.opc.internal.MemoryPackagePart;
 import org.apache.poi.openxml4j.opc.internal.PackagePropertiesPart;
 import org.apache.poi.openxml4j.util.ZipInputStreamZipEntrySource;
+import org.apache.poi.ss.tests.TestWorkbookFactory;
 import org.apache.poi.ss.tests.usermodel.BaseTestXWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellReferenceType;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Font;
@@ -59,16 +61,23 @@ import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.AreaReference;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.util.DefaultTempFileCreationStrategy;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xddf.usermodel.chart.XDDFBarChartData;
 import org.apache.poi.xddf.usermodel.chart.XDDFChartData;
 import org.apache.poi.xssf.XSSFITestDataProvider;
 import org.apache.poi.xssf.model.StylesTable;
+import org.apache.poi.xssf.streaming.DeferredSXSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTCalcPr;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTExternalLink;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTExternalSheetData;
@@ -77,18 +86,24 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorkbook;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTWorkbookPr;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.STCalcMode;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.CRC32;
 
 import static org.apache.poi.hssf.HSSFTestDataSamples.openSampleFileStream;
@@ -1544,6 +1559,98 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
         } finally {
             assertTrue(tempFile.delete());
         }
+    }
+
+    private static TempFileCreationStrategy newTempFileCreationStrategy(Path tmpDir) throws IOException {
+        Files.createDirectories(tmpDir);
+        return new DefaultTempFileCreationStrategy(tmpDir.toFile());
+    }
+
+    private static void createDummySheet(
+            Workbook workbook,
+            String sheetName,
+            int rows,
+            int columns
+    ) {
+        Sheet sheet = workbook.createSheet(sheetName);
+        for (int i = 0; i < rows; i++) {
+            Row row = sheet.createRow(i);
+            for (int j = 0; j < columns; j++) {
+                Cell cell = row.createCell(j + 1, CellType.STRING);
+                cell.setCellValue("Dummy " + sheetName + "-" + i + "," + j);
+            }
+        }
+    }
+
+    private static void populateDummyWorkbook(Workbook workbook) {
+        createDummySheet(workbook, "sheet1", 3, 5);
+        createDummySheet(workbook, "sheet2", 7, 2);
+    }
+
+    private static void assertEmptyDir(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+
+        try (Stream<Path> childrenStream = Files.list(dir)) {
+            List<Path> children = childrenStream.collect(Collectors.toList());
+            assertEquals(Collections.emptyList(), children);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    public void testOverriddenTempDirectory(
+            TestWorkbookFactory workbookFactory,
+            @TempDir Path tmpDir
+    ) throws IOException {
+        try {
+            Path globalTmpDir = tmpDir.resolve("global-test-tmp");
+            TempFile.setTempFileCreationStrategy(newTempFileCreationStrategy(globalTmpDir));
+
+            Path localTmpDir = tmpDir.resolve("local-test-tmp");
+
+            Path outputDir = Files.createDirectories(tmpDir.resolve("test-output-dir"));
+            Path outputFile = outputDir.resolve("test.xlsx");
+
+            try (OutputStream output = Files.newOutputStream(outputFile);
+                 BufferedOutputStream bufferedOutput = new BufferedOutputStream(output);
+                 Workbook workbook = workbookFactory.createWorkbook(newTempFileCreationStrategy(localTmpDir))
+            ) {
+                assertEmptyDir(globalTmpDir);
+                populateDummyWorkbook(workbook);
+                assertEmptyDir(globalTmpDir);
+                workbook.write(bufferedOutput);
+                assertEmptyDir(globalTmpDir);
+            }
+            assertTrue(Files.isRegularFile(outputFile));
+            assertEmptyDir(globalTmpDir);
+            assertEmptyDir(localTmpDir);
+        } finally {
+            // Restore the default temp directory.
+            TempFile.setTempFileCreationStrategy(new DefaultTempFileCreationStrategy());
+        }
+    }
+
+    public enum TestWorkbookFactory {
+        SXSSF {
+            @Override
+            public Workbook createWorkbook(TempFileCreationStrategy tmpStrategy) {
+                SXSSFWorkbook workbook = new SXSSFWorkbook();
+                workbook.setTempFileCreationStrategy(tmpStrategy);
+                return workbook;
+            }
+        },
+        DEFERRED_SXSSF {
+            @Override
+            public Workbook createWorkbook(TempFileCreationStrategy tmpStrategy) {
+                SXSSFWorkbook workbook = new DeferredSXSSFWorkbook();
+                workbook.setTempFileCreationStrategy(tmpStrategy);
+                return workbook;
+            }
+        };
+
+        public abstract Workbook createWorkbook(TempFileCreationStrategy tmpStrategy);
     }
 
     private static void expectFormattedContent(Cell cell, String value) {

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/ChunkedCipherOutputStream.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/ChunkedCipherOutputStream.java
@@ -39,6 +39,7 @@ import org.apache.poi.util.Internal;
 import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.LittleEndianConsts;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 @Internal
 public abstract class ChunkedCipherOutputStream extends FilterOutputStream {
@@ -64,13 +65,17 @@ public abstract class ChunkedCipherOutputStream extends FilterOutputStream {
     private boolean isClosed;
 
     public ChunkedCipherOutputStream(DirectoryNode dir, int chunkSize) throws IOException, GeneralSecurityException {
+        this(dir, chunkSize, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    public ChunkedCipherOutputStream(DirectoryNode dir, int chunkSize, TempFileCreationStrategy tmpStrategy) throws IOException, GeneralSecurityException {
         super(null);
         this.chunkSize = chunkSize;
         int cs = chunkSize == STREAMING ? 4096 : chunkSize;
         this.chunk = IOUtils.safelyAllocate(cs, CryptoFunctions.MAX_RECORD_LENGTH);
         this.plainByteFlags = new SparseBitSet(cs);
         this.chunkBits = Integer.bitCount(cs-1);
-        this.fileOut = TempFile.createTempFile("encrypted_package", "crypt");
+        this.fileOut = tmpStrategy.createTempFile("encrypted_package", "crypt");
         this.out = Files.newOutputStream(fileOut.toPath());
         this.dir = dir;
         this.cipher = initCipherForBlock(null, 0, false);

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/Encryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/Encryptor.java
@@ -29,6 +29,7 @@ import org.apache.poi.common.usermodel.GenericRecord;
 import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.GenericRecordUtil;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 public abstract class Encryptor implements GenericRecord {
 
@@ -46,12 +47,34 @@ public abstract class Encryptor implements GenericRecord {
 
     /**
      * Return an output stream for encrypted data.
+     * <p>
+     * Note for implementors: Implementations must override {@link #getDataStream(DirectoryNode, TempFileCreationStrategy)}
      *
      * @param dir the node to write to
      * @return encrypted stream
      */
-    public abstract OutputStream getDataStream(DirectoryNode dir)
-        throws IOException, GeneralSecurityException;
+    public OutputStream getDataStream(DirectoryNode dir)
+        throws IOException, GeneralSecurityException {
+        return getDataStream(dir, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * Return an output stream for encrypted data.
+     * <p>
+     * Note for implementors: Implementations of {@code Encryptor} must treat this method as abstract. This
+     * method has a default implementation for backwards compatibility only. The default implementation ignores
+     * the {@code tmpStrategy} parameter and calls {@link #getDataStream(DirectoryNode)}.
+     *
+     * @param dir the node to write to
+     * @param tmpStrategy the strategy to create temporary files (if needed), may not be null
+     * @return encrypted stream
+     *
+     * @since POI 5.5.0
+     */
+    public OutputStream getDataStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy)
+            throws IOException, GeneralSecurityException {
+        return getDataStream(dir);
+    }
 
     // for tests
     public abstract void confirmPassword(String password, byte[] keySpec, byte[] keySalt, byte[] verifier, byte[] verifierSalt, byte[] integritySalt);
@@ -63,7 +86,11 @@ public abstract class Encryptor implements GenericRecord {
     }
 
     public OutputStream getDataStream(POIFSFileSystem fs) throws IOException, GeneralSecurityException {
-        return getDataStream(fs.getRoot());
+        return getDataStream(fs, TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    public OutputStream getDataStream(POIFSFileSystem fs, TempFileCreationStrategy tmpStrategy) throws IOException, GeneralSecurityException {
+        return getDataStream(fs.getRoot(), tmpStrategy);
     }
 
     public ChunkedCipherOutputStream getDataStream(OutputStream stream, int initialOffset)

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/agile/AgileEncryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/agile/AgileEncryptor.java
@@ -62,6 +62,7 @@ import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.LittleEndianByteArrayOutputStream;
 import org.apache.poi.util.LittleEndianConsts;
 import org.apache.poi.util.RandomSingleton;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.util.XMLHelper;
 import org.w3c.dom.Document;
 
@@ -207,10 +208,10 @@ public class AgileEncryptor extends Encryptor {
     }
 
     @Override
-    public OutputStream getDataStream(DirectoryNode dir)
+    public OutputStream getDataStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy)
             throws IOException, GeneralSecurityException {
         // TODO: initialize headers
-        return new AgileCipherOutputStream(dir);
+        return new AgileCipherOutputStream(dir, tmpStrategy);
     }
 
     /**
@@ -342,8 +343,8 @@ public class AgileEncryptor extends Encryptor {
      * unencrypted data as specified in section 2.3.4.4.
      */
     private class AgileCipherOutputStream extends ChunkedCipherOutputStream {
-        public AgileCipherOutputStream(DirectoryNode dir) throws IOException, GeneralSecurityException {
-            super(dir, 4096);
+        public AgileCipherOutputStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy) throws IOException, GeneralSecurityException {
+            super(dir, 4096, tmpStrategy);
         }
 
         @Override

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/binaryrc4/BinaryRC4Encryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/binaryrc4/BinaryRC4Encryptor.java
@@ -37,6 +37,7 @@ import org.apache.poi.poifs.crypt.HashAlgorithm;
 import org.apache.poi.poifs.crypt.standard.EncryptionRecord;
 import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.util.RandomSingleton;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 public class BinaryRC4Encryptor extends Encryptor {
 
@@ -85,9 +86,9 @@ public class BinaryRC4Encryptor extends Encryptor {
     }
 
     @Override
-    public OutputStream getDataStream(DirectoryNode dir)
+    public OutputStream getDataStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy)
     throws IOException, GeneralSecurityException {
-        return new BinaryRC4CipherOutputStream(dir);
+        return new BinaryRC4CipherOutputStream(dir, tmpStrategy);
     }
 
     @Override
@@ -132,8 +133,13 @@ public class BinaryRC4Encryptor extends Encryptor {
         }
 
         public BinaryRC4CipherOutputStream(DirectoryNode dir)
+                throws IOException, GeneralSecurityException {
+            this(dir, TempFileCreationStrategy.getDefaultStrategy());
+        }
+
+        public BinaryRC4CipherOutputStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy)
         throws IOException, GeneralSecurityException {
-            super(dir, BinaryRC4Encryptor.this.chunkSize);
+            super(dir, BinaryRC4Encryptor.this.chunkSize, tmpStrategy);
         }
 
         @Override

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/cryptoapi/CryptoAPIEncryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/cryptoapi/CryptoAPIEncryptor.java
@@ -44,6 +44,7 @@ import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.RandomSingleton;
 import org.apache.poi.util.StringUtil;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 public class CryptoAPIEncryptor extends Encryptor {
 
@@ -105,7 +106,7 @@ public class CryptoAPIEncryptor extends Encryptor {
     }
 
     @Override
-    public ChunkedCipherOutputStream getDataStream(DirectoryNode dir) throws IOException {
+    public ChunkedCipherOutputStream getDataStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy) throws IOException {
         throw new IOException("not supported");
     }
 

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/standard/StandardEncryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/standard/StandardEncryptor.java
@@ -50,7 +50,7 @@ import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LittleEndianConsts;
 import org.apache.poi.util.LittleEndianOutputStream;
 import org.apache.poi.util.RandomSingleton;
-import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 public class StandardEncryptor extends Encryptor {
     private static final Logger LOG = PoiLogManager.getLogger(StandardEncryptor.class);
@@ -119,11 +119,11 @@ public class StandardEncryptor extends Encryptor {
     }
 
     @Override
-    public OutputStream getDataStream(final DirectoryNode dir)
+    public OutputStream getDataStream(final DirectoryNode dir, TempFileCreationStrategy tmpStrategy)
     throws IOException, GeneralSecurityException {
         createEncryptionInfoEntry(dir);
         DataSpaceMapUtils.addDefaultDataSpace(dir);
-        return new StandardCipherOutputStream(dir);
+        return new StandardCipherOutputStream(dir, tmpStrategy);
     }
 
     protected class StandardCipherOutputStream extends FilterOutputStream implements POIFSWriterListener {
@@ -153,7 +153,11 @@ public class StandardEncryptor extends Encryptor {
         }
 
         protected StandardCipherOutputStream(DirectoryNode dir) throws IOException {
-            this(dir, TempFile.createTempFile("encrypted_package", "crypt"), true);
+            this(dir, TempFileCreationStrategy.getDefaultStrategy());
+        }
+
+        protected StandardCipherOutputStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy) throws IOException {
+            this(dir, tmpStrategy.createTempFile("encrypted_package", "crypt"), true);
         }
 
         @Override

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/xor/XOREncryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/xor/XOREncryptor.java
@@ -32,6 +32,7 @@ import org.apache.poi.poifs.crypt.CryptoFunctions;
 import org.apache.poi.poifs.crypt.Encryptor;
 import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.util.LittleEndian;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 public class XOREncryptor extends Encryptor {
     protected XOREncryptor() {}
@@ -63,9 +64,9 @@ public class XOREncryptor extends Encryptor {
     }
 
     @Override
-    public OutputStream getDataStream(DirectoryNode dir)
+    public OutputStream getDataStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy)
     throws IOException, GeneralSecurityException {
-        return new XORCipherOutputStream(dir);
+        return new XORCipherOutputStream(dir, tmpStrategy);
     }
 
     @Override
@@ -96,8 +97,8 @@ public class XOREncryptor extends Encryptor {
             super(stream, -1);
         }
 
-        public XORCipherOutputStream(DirectoryNode dir) throws IOException, GeneralSecurityException {
-            super(dir, -1);
+        public XORCipherOutputStream(DirectoryNode dir, TempFileCreationStrategy tmpStrategy) throws IOException, GeneralSecurityException {
+            super(dir, -1, tmpStrategy);
         }
 
         @Override

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSFileSystem.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSFileSystem.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.logging.log4j.Logger;
@@ -110,7 +111,9 @@ public class POIFSFileSystem extends BlockStore
         return MAX_RECORD_LENGTH;
     }
 
-    private POIFSFileSystem(boolean newFS) {
+    private POIFSFileSystem(Void unused, Consumer<? super POIFSFileSystem> initializer) {
+        // The unused argument is only to allow us to declare a protected constructor
+        // with initializer only.
         _header = new HeaderBlock(bigBlockSize);
         _property_table = new PropertyTable(_header);
         _mini_store = new POIFSMiniStore(this, _property_table.getRoot(), new ArrayList<>(), _header);
@@ -118,9 +121,7 @@ public class POIFSFileSystem extends BlockStore
         _bat_blocks = new ArrayList<>();
         _root = null;
 
-        if (newFS) {
-            createNewDataSource();
-        }
+        initializer.accept(this);
     }
 
     protected void createNewDataSource() {
@@ -134,7 +135,16 @@ public class POIFSFileSystem extends BlockStore
      * Constructor, intended for writing
      */
     public POIFSFileSystem() {
-        this(true);
+        this(POIFSFileSystem::createNewDataSource);
+    }
+
+    /**
+     * Constructor, intended for writing
+     *
+     * @since POI 5.5.0
+     */
+    protected POIFSFileSystem(Consumer<? super POIFSFileSystem> initializer) {
+        this(null, initializer);
 
         // Reserve block 0 for the start of the Properties Table
         // Create a single empty BAT, at pop that at offset 1
@@ -247,7 +257,7 @@ public class POIFSFileSystem extends BlockStore
     @SuppressWarnings("java:S2095")
     private POIFSFileSystem(FileChannel channel, File srcFile, boolean readOnly, boolean closeChannelOnError,
                             boolean closeChannelOnClose) throws IOException {
-        this(false);
+        this(null, fs -> { });
 
         try {
             // Initialize the datasource
@@ -312,7 +322,7 @@ public class POIFSFileSystem extends BlockStore
 
     public POIFSFileSystem(InputStream stream)
             throws IOException {
-        this(false);
+        this(null, fs -> { });
 
         boolean success = false;
         try (ReadableByteChannel channel = Channels.newChannel(stream)) {

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/TempFilePOIFSFileSystem.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/TempFilePOIFSFileSystem.java
@@ -20,10 +20,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.poifs.nio.FileBackedDataSource;
 import org.apache.poi.util.Beta;
-import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * An experimental POIFSFileSystem to support the encryption of large files
@@ -33,16 +34,38 @@ import java.io.IOException;
 @Beta
 public class TempFilePOIFSFileSystem extends POIFSFileSystem {
     private static final Logger LOG = PoiLogManager.getLogger(TempFilePOIFSFileSystem.class);
+
+    private final TempFileCreationStrategy tmpStrategy;
+
     File tempFile;
 
-    @Override
-    protected void createNewDataSource() {
+    public TempFilePOIFSFileSystem() {
+        this(TempFileCreationStrategy.getDefaultStrategy());
+    }
+
+    /**
+     * @since POI 5.5.0
+     */
+    public TempFilePOIFSFileSystem(TempFileCreationStrategy tmpStrategy) {
+        super(fs -> init((TempFilePOIFSFileSystem) fs, tmpStrategy));
+        this.tmpStrategy = Objects.requireNonNull(tmpStrategy, "tmpStrategy");
+    }
+
+    private static void init(
+            TempFilePOIFSFileSystem fs,
+            TempFileCreationStrategy tmpStrategy
+    ) {
         try {
-            tempFile = TempFile.createTempFile("poifs", ".tmp");
-            _data = new FileBackedDataSource(tempFile, false);
+            fs.tempFile = tmpStrategy.createTempFile("poifs", ".tmp");
+            fs._data = new FileBackedDataSource(fs.tempFile, false);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create data source", e);
         }
+    }
+
+    @Override
+    protected void createNewDataSource() {
+        init(this, tmpStrategy);
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/util/GlobalTempFileCreationStrategy.java
+++ b/poi/src/main/java/org/apache/poi/util/GlobalTempFileCreationStrategy.java
@@ -1,0 +1,35 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.util;
+
+import java.io.File;
+import java.io.IOException;
+
+enum GlobalTempFileCreationStrategy implements TempFileCreationStrategy {
+    GLOBAL_TEMP_FILE_CREATION_STRATEGY;
+
+    @Override
+    public File createTempFile(String prefix, String suffix) throws IOException {
+        return TempFile.createTempFile(prefix, suffix);
+    }
+
+    @Override
+    public File createTempDirectory(String prefix) throws IOException {
+        return TempFile.createTempDirectory(prefix);
+    }
+}

--- a/poi/src/main/java/org/apache/poi/util/TempFileCreationStrategy.java
+++ b/poi/src/main/java/org/apache/poi/util/TempFileCreationStrategy.java
@@ -62,6 +62,19 @@ import java.io.IOException;
  */
 public interface TempFileCreationStrategy {
     /**
+     * Returns the strategy relying on the
+     * {@link TempFile#setTempFileCreationStrategy(TempFileCreationStrategy) currently set} temporary
+     * file creation strategy. That is, using the returned strategy is equivalent to
+     * directly using the {@link TempFile#createTempFile(String, String)} and
+     * {@link TempFile#createTempDirectory(String)} methods.
+     *
+     * @since POI 5.5.0
+     */
+    static TempFileCreationStrategy getDefaultStrategy() {
+        return GlobalTempFileCreationStrategy.GLOBAL_TEMP_FILE_CREATION_STRATEGY;
+    }
+
+    /**
      * Creates a new and empty temporary file.
      *
      * @param prefix The prefix to be used to generate the name of the temporary file.


### PR DESCRIPTION
As is now, we can only set a global `TempFileCreationStrategy` which assumes that all documents within the same process has the same security profile (and quota) which may or may not be the case. Currently it is not possible to workaround this limitation in a multithreaded application.

This PR intends to fix this issue by allowing to set a `TempFileCreationStrategy` for `SXSSFWorkbook` and `ZipPackage` instances.

Implementation notes:

- I have not deleted the `BinaryRC4Encryptor.BinaryRC4CipherOutputStream(DirectoryNode)` constructor because it is protected and in theory might be used (though given that other implementations have the counterparts of this class private, I'm guessing this visibility is unintended).
- When adjusting the `OPCPackage.open` methods (to avoid duplicating logic), I'm relying on a new `OPCPackageOpener` class. However, strictly speaking my implementation is not 100% backward compatible (can be adjusted of course if needed), because the new `OPCPackageOpener` immediately throws NPE when it receives null `PackageAccess` or `OPCComplianceFlags`, while the original implementation does not. Rather, the original implementation will simply store the nulls, and will (likely) throw an exception on first use. Should I adjust my changes to be 100% backward compatible, or is this an acceptable risk for this project?
- Not directly related to this PR, but while making the adjustments, I have noticed that `DefaultTempFileCreationStrategy` is buggy (at least I doubt its behavior is intended): When it detects that the temporary directory does not exist, then it will reset the directory to what is in `java.io.tmpdir` even if a different directory was specified in the constructor. I'm mentioning this only, because this issue can be a security risk (if someone changed the tmp dir due to security reasons), and this PR might make this issue more visible.