### PR TITLE
Add getters for CTSdt(Content)Cell objects.

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTCell.java
@@ -29,9 +29,11 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSdtCell;
  */
 public class XWPFSDTCell extends XWPFAbstractSDT implements ICell {
     private final XWPFSDTContentCell cellContent;
+    private final CTSdtCell sdtCell;
 
     public XWPFSDTCell(CTSdtCell sdtCell, XWPFTableRow xwpfTableRow, IBody part) {
         super(sdtCell.getSdtPr(), part);
+        this.sdtCell = sdtCell;
         cellContent = new XWPFSDTContentCell(sdtCell.getSdtContent(), xwpfTableRow, part);
     }
 
@@ -40,4 +42,7 @@ public class XWPFSDTCell extends XWPFAbstractSDT implements ICell {
         return cellContent;
     }
 
+    public CTSdtCell getSdtCell() {
+        return sdtCell;
+    }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTCell.java
@@ -42,7 +42,12 @@ public class XWPFSDTCell extends XWPFAbstractSDT implements ICell {
         return cellContent;
     }
 
-    public CTSdtCell getSdtCell() {
+    /**
+     * Return the underlying XML bean.
+     * @return the underlying CTSdtCell bean.
+     * @since POI 5.4.2
+     */
+    public CTSdtCell getCTSdtCell() {
         return sdtCell;
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContentCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContentCell.java
@@ -40,14 +40,19 @@ public class XWPFSDTContentCell implements ISDTContent {
 
     //private List<ICell> cells = new ArrayList<ICell>().
 
-    private String text = "";
+    private final CTSdtContentCell sdtContentCell;
+    private String text;
 
     public XWPFSDTContentCell(CTSdtContentCell sdtContentCell,
                               XWPFTableRow xwpfTableRow, IBody part) {
         super();
+        this.sdtContentCell = sdtContentCell;
+    }
+
+    private String extractTextFromSdtContentCell() {
         //sdtContentCell is allowed to be null:  minOccurs="0" maxOccurs="1"
         if (sdtContentCell == null) {
-            return;
+            return "";
         }
         StringBuilder sb = new StringBuilder();
         try (final XmlCursor cursor = sdtContentCell.newCursor()) {
@@ -87,7 +92,7 @@ public class XWPFSDTContentCell implements ISDTContent {
                     depth--;
                 }
             }
-            text = sb.toString();
+            return sb.toString();
         }
     }
 
@@ -103,12 +108,20 @@ public class XWPFSDTContentCell implements ISDTContent {
         return false;
     }
 
-
+    @Override
     public String getText() {
+        if (text == null) {
+            text = extractTextFromSdtContentCell();
+        }
         return text;
     }
 
+    @Override
     public String toString() {
         return getText();
+    }
+
+    public CTSdtContentCell getCTSdtContentCell() {
+        return sdtContentCell;
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContentCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContentCell.java
@@ -121,6 +121,11 @@ public class XWPFSDTContentCell implements ISDTContent {
         return getText();
     }
 
+    /**
+     * Return the underlying XML bean.
+     * @return the underlying CTSdtContentCell bean.
+     * @since POI 5.4.2
+     */
     public CTSdtContentCell getCTSdtContentCell() {
         return sdtContentCell;
     }


### PR DESCRIPTION
Currently the XWPFSdt(Content)Cell object just produces a text equivalent of the content. There is no way to access the inner XML node for further inspection; instead, one needs to go to the parent object and iterate over its XML children.

This would allow users to use the XWPFRow.getICells() to obtain XWPFTableCell or XWPFSDTCell objects, and then access the latter's inner XML node to get access to its full data.

We also defer the parsing of the text in XWPFContentCell until the getter is called. A user who will work with the inner XML is unlikely to need the text parsing done.