### PR TITLE
allow option to limit acceptable size for style table input

### DIFF
--- a/legal/LICENSE
+++ b/legal/LICENSE
@@ -261,6 +261,10 @@ which was released under the Apache 2.0 license.
 Copyright (c) 2002-2023 EPFL
 Copyright (c) 2011-2023 Lightbend, Inc.
 
+LimitInputStream is based on code from the Guava project which was released under
+the Apache 2.0 license.
+Copyright (C) 2007 The Guava Authors
+
 The POI Source Release bundles the Gradle Wrapper. (https://docs.gradle.org/current/userguide/gradle_wrapper.html)
 This is released under the Apache License, v2.0.
 Copyright © 2015-2021 the original authors.

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/ReadOnlySharedStringsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/ReadOnlySharedStringsTable.java
@@ -16,6 +16,7 @@
 ==================================================================== */
 package org.apache.poi.xssf.eventusermodel;
 
+import static org.apache.poi.xssf.model.SharedStringsTable.getInputStreamReadLimit;
 import static org.apache.poi.xssf.usermodel.XSSFRelation.NS_SPREADSHEETML;
 
 import java.io.IOException;
@@ -23,14 +24,17 @@ import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.util.XMLHelper;
 import org.apache.poi.xssf.model.SharedStrings;
+import org.apache.poi.xssf.model.SharedStringsTable;
 import org.apache.poi.xssf.usermodel.XSSFRelation;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.xml.sax.Attributes;
@@ -155,6 +159,13 @@ public class ReadOnlySharedStringsTable extends DefaultHandler implements Shared
     public ReadOnlySharedStringsTable(PackagePart part, boolean includePhoneticRuns)
         throws IOException, SAXException {
         this.includePhoneticRuns = includePhoneticRuns;
+        if (getInputStreamReadLimit() >= 0 && part.getSize() > getInputStreamReadLimit()) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "SharedStrings part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    getInputStreamReadLimit()));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
@@ -184,9 +195,12 @@ public class ReadOnlySharedStringsTable extends DefaultHandler implements Shared
      * @throws IOException if an error occurs while reading.
      * @throws SAXException if parsing the XML data fails.
      */
-    public void readFrom(InputStream is) throws IOException, SAXException {
+    public void readFrom(final InputStream is) throws IOException, SAXException {
+        final InputStream stream = getInputStreamReadLimit() >= 0
+                ? new LimitInputStream(is, getInputStreamReadLimit())
+                : is;
         // test if the file is empty, otherwise parse it
-        PushbackInputStream pis = new PushbackInputStream(is, 1);
+        final PushbackInputStream pis = new PushbackInputStream(stream, 1);
         int emptyTest = pis.read();
         if (emptyTest > -1) {
             pis.unread(emptyTest);

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/CalculationChain.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/CalculationChain.java
@@ -17,13 +17,16 @@
 package org.apache.poi.xssf.model;
 
 import static org.apache.poi.ooxml.POIXMLTypeLoader.DEFAULT_XML_OPTIONS;
+import static org.apache.poi.xssf.model.SharedStringsTable.getInputStreamReadLimit;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.xmlbeans.XmlException;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTCalcCell;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTCalcChain;
@@ -34,6 +37,29 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.CalcChainDocument;
  * dependencies. The calculation chain object specifies the order in which the cells in a workbook were last calculated.
  */
 public class CalculationChain extends POIXMLDocumentPart {
+
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read calculation chain data.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     * @since POI 5.4.2
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     * @since POI 5.4.2
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
+
     private CTCalcChain chain;
 
     public CalculationChain() {
@@ -46,14 +72,24 @@ public class CalculationChain extends POIXMLDocumentPart {
      */
     public CalculationChain(PackagePart part) throws IOException {
         super(part);
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "Calculation Chain part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    INPUT_STREAM_READ_LIMIT));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
     }
 
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0
+                ? new LimitInputStream(is, INPUT_STREAM_READ_LIMIT)
+                : is;
         try {
-            CalcChainDocument doc = CalcChainDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            CalcChainDocument doc = CalcChainDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
             chain = doc.getCalcChain();
         } catch (XmlException e) {
             throw new IOException(e.getLocalizedMessage());

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/CommentsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/CommentsTable.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 import com.microsoft.schemas.vml.CTShape;
@@ -32,6 +33,7 @@ import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.util.Internal;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.util.Removal;
 import org.apache.poi.util.Units;
 import org.apache.poi.xssf.usermodel.OoxmlSheetExtensions;
@@ -49,6 +51,28 @@ public class CommentsTable extends POIXMLDocumentPart implements Comments {
 
     public static final String DEFAULT_AUTHOR = "";
     public static final int DEFAULT_AUTHOR_ID = 0;
+
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read comments table.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     * @since POI 5.4.2
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     * @since POI 5.4.2
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
 
     private Sheet sheet;
     private XSSFVMLDrawing vmlDrawing;
@@ -76,14 +100,24 @@ public class CommentsTable extends POIXMLDocumentPart implements Comments {
      */
     public CommentsTable(PackagePart part) throws IOException {
         super(part);
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "SharedStrings part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    INPUT_STREAM_READ_LIMIT));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
     }
     
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0
+                ? new LimitInputStream(is, INPUT_STREAM_READ_LIMIT)
+                : is;
         try {
-            CommentsDocument doc = CommentsDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            CommentsDocument doc = CommentsDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
             comments = doc.getComments();
         } catch (XmlException e) {
             throw new IOException(e.getLocalizedMessage());

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/CommentsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/CommentsTable.java
@@ -103,7 +103,7 @@ public class CommentsTable extends POIXMLDocumentPart implements Comments {
         if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
             throw new IOException(String.format(
                     Locale.ROOT,
-                    "SharedStrings part size (%s) exceeds the read limit (%s)",
+                    "Comments Table part size (%s) exceeds the read limit (%s)",
                     part.getSize(),
                     INPUT_STREAM_READ_LIMIT));
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/ExternalLinksTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/ExternalLinksTable.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
@@ -31,6 +32,7 @@ import org.apache.poi.openxml4j.opc.PackageRelationshipTypes;
 import org.apache.poi.openxml4j.opc.TargetMode;
 import org.apache.poi.ss.usermodel.Name;
 import org.apache.poi.util.Internal;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.util.Removal;
 import org.apache.xmlbeans.XmlException;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTExternalBook;
@@ -49,6 +51,29 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.ExternalLinkDocument;
  *  along with the most recently seen values for what they point to.
  */
 public class ExternalLinksTable extends POIXMLDocumentPart {
+
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read external links table.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     * @since POI 5.4.2
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     * @since POI 5.4.2
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
+
     private CTExternalLink link;
 
     public ExternalLinksTable() {
@@ -62,14 +87,24 @@ public class ExternalLinksTable extends POIXMLDocumentPart {
      */
     public ExternalLinksTable(PackagePart part) throws IOException {
         super(part);
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "SharedStrings part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    INPUT_STREAM_READ_LIMIT));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
     }
 
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0
+                ? new LimitInputStream(is, INPUT_STREAM_READ_LIMIT)
+                : is;
         try {
-            ExternalLinkDocument doc = ExternalLinkDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            ExternalLinkDocument doc = ExternalLinkDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
             link = doc.getExternalLink();
         } catch (XmlException e) {
             throw new IOException(e.getLocalizedMessage());

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/ExternalLinksTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/ExternalLinksTable.java
@@ -90,7 +90,7 @@ public class ExternalLinksTable extends POIXMLDocumentPart {
         if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
             throw new IOException(String.format(
                     Locale.ROOT,
-                    "SharedStrings part size (%s) exceeds the read limit (%s)",
+                    "External Links Table part size (%s) exceeds the read limit (%s)",
                     part.getSize(),
                     INPUT_STREAM_READ_LIMIT));
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/SharedStringsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/SharedStringsTable.java
@@ -28,12 +28,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.util.Internal;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.apache.xmlbeans.XmlException;
 import org.apache.xmlbeans.XmlOptions;
@@ -63,6 +65,28 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.SstDocument;
  * </p>
  */
 public class SharedStringsTable extends POIXMLDocumentPart implements SharedStrings, Closeable {
+
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read shared strings.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     * @since POI 5.4.2
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     * @since POI 5.4.2
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
 
     /**
      *  Array of individual string items in the Shared String table.
@@ -108,6 +132,13 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
      */
     public SharedStringsTable(PackagePart part) throws IOException {
         super(part);
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "SharedStrings part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    INPUT_STREAM_READ_LIMIT));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
@@ -119,10 +150,12 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
      * @param is The input stream containing the XML document.
      * @throws IOException if an error occurs while reading.
      */
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0 ?
+                new LimitInputStream(is, INPUT_STREAM_READ_LIMIT) : is;
         try {
             int cnt = 0;
-            _sstDoc = SstDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            _sstDoc = SstDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
             CTSst sst = _sstDoc.getSst();
             count = (int)sst.getCount();
             uniqueCount = (int)sst.getUniqueCount();

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/SingleXmlCells.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/SingleXmlCells.java
@@ -23,10 +23,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Locale;
 import java.util.Vector;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.helpers.XSSFSingleXmlCell;
 import org.apache.xmlbeans.XmlException;
@@ -42,13 +44,33 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.SingleXmlCellsDocumen
  */
 public class SingleXmlCells extends POIXMLDocumentPart {
 
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read Single Cell Tables.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     * @since POI 5.4.2
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     * @since POI 5.4.2
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
 
     private CTSingleXmlCells singleXMLCells;
 
     public SingleXmlCells() {
         super();
         singleXMLCells = CTSingleXmlCells.Factory.newInstance();
-
     }
 
     /**
@@ -56,14 +78,24 @@ public class SingleXmlCells extends POIXMLDocumentPart {
      */
     public SingleXmlCells(PackagePart part) throws IOException {
         super(part);
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "Single Cell Tables part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    INPUT_STREAM_READ_LIMIT));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
     }
 
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0
+                ? new LimitInputStream(is, INPUT_STREAM_READ_LIMIT)
+                : is;
         try {
-            SingleXmlCellsDocument doc = SingleXmlCellsDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            SingleXmlCellsDocument doc = SingleXmlCellsDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
             singleXMLCells = doc.getSingleXmlCells();
         } catch (XmlException e) {
             throw new IOException(e.getLocalizedMessage());

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
@@ -171,7 +171,7 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      */
     public StylesTable(PackagePart part) throws IOException {
         super(part);
-        if (part.getSize() > getInputStreamReadLimit()) {
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
             throw new IOException(String.format(
                     Locale.ROOT,
                     "StylesTable part size (%s) exceeds the read limit (%s)",
@@ -238,8 +238,8 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      * @throws IOException if an error occurs while reading.
      */
     public void readFrom(final InputStream is) throws IOException {
-        final InputStream stream = getInputStreamReadLimit() >= 0 ?
-                new LimitInputStream(is, getInputStreamReadLimit()) : is;
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0 ?
+                new LimitInputStream(is, INPUT_STREAM_READ_LIMIT) : is;
         try {
             doc = StyleSheetDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
@@ -22,16 +22,8 @@ import static org.apache.poi.ooxml.POIXMLTypeLoader.DEFAULT_XML_OPTIONS;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
@@ -177,6 +169,13 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      */
     public StylesTable(PackagePart part) throws IOException {
         super(part);
+        if (part.getSize() > getInputStreamReadLimit()) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "StylesTable part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    getInputStreamReadLimit()));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
@@ -77,6 +77,7 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      * Sets the read limit for input streams used to read styles.
      * Negative values mean no limit. The default is -1 (no limit).
      * @param limit
+     * @since POI 5.4.2
      */
     public static void setInputStreamReadLimit(long limit) {
         INPUT_STREAM_READ_LIMIT = limit;
@@ -86,6 +87,7 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      * Gets the read limit for input streams used to read styles.
      * Negative values mean no limit. The default is -1 (no limit).
      * @return the read limit
+     * @since POI 5.4.2
      */
     public static long getInputStreamReadLimit() {
         return INPUT_STREAM_READ_LIMIT;
@@ -236,8 +238,8 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      * @throws IOException if an error occurs while reading.
      */
     public void readFrom(final InputStream is) throws IOException {
-        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0 ?
-                new LimitInputStream(is, INPUT_STREAM_READ_LIMIT) : is;
+        final InputStream stream = getInputStreamReadLimit() >= 0 ?
+                new LimitInputStream(is, getInputStreamReadLimit()) : is;
         try {
             doc = StyleSheetDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
@@ -42,6 +42,7 @@ import org.apache.poi.ss.usermodel.FontFamily;
 import org.apache.poi.ss.usermodel.FontScheme;
 import org.apache.poi.ss.usermodel.TableStyle;
 import org.apache.poi.util.Internal;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.xssf.usermodel.CustomIndexedColorMap;
 import org.apache.poi.xssf.usermodel.DefaultIndexedColorMap;
 import org.apache.poi.xssf.usermodel.IndexedColorMap;
@@ -77,6 +78,27 @@ import org.openxmlformats.schemas.spreadsheetml.x2006.main.StyleSheetDocument;
  * Table of styles shared across all sheets in a workbook.
  */
 public class StylesTable extends POIXMLDocumentPart implements Styles {
+
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
+
     private final SortedMap<Short, String> numberFormats = new TreeMap<>();
     private final List<XSSFFont> fonts = new ArrayList<>();
     private final List<XSSFCellFill> fills = new ArrayList<>();
@@ -214,9 +236,11 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
      * @param is The input stream containing the XML document.
      * @throws IOException if an error occurs while reading.
      */
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0 ?
+                new LimitInputStream(is, INPUT_STREAM_READ_LIMIT) : is;
         try {
-            doc = StyleSheetDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            doc = StyleSheetDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
 
             CTStylesheet styleSheet = doc.getStyleSheet();
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/StylesTable.java
@@ -176,7 +176,7 @@ public class StylesTable extends POIXMLDocumentPart implements Styles {
                     Locale.ROOT,
                     "StylesTable part size (%s) exceeds the read limit (%s)",
                     part.getSize(),
-                    getInputStreamReadLimit()));
+                    INPUT_STREAM_READ_LIMIT));
         }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/ThemesTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/ThemesTable.java
@@ -21,9 +21,11 @@ import static org.apache.poi.ooxml.POIXMLTypeLoader.DEFAULT_XML_OPTIONS;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Locale;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.util.LimitInputStream;
 import org.apache.poi.xssf.usermodel.IndexedColorMap;
 import org.apache.poi.xssf.usermodel.XSSFColor;
 import org.apache.xmlbeans.XmlException;
@@ -65,6 +67,28 @@ public class ThemesTable extends POIXMLDocumentPart implements Themes {
         public final String name;
     }
 
+    private static long INPUT_STREAM_READ_LIMIT = -1; // negative means no limit
+
+    /**
+     * Sets the read limit for input streams used to read themes table.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @param limit
+     * @since POI 5.4.2
+     */
+    public static void setInputStreamReadLimit(long limit) {
+        INPUT_STREAM_READ_LIMIT = limit;
+    }
+
+    /**
+     * Gets the read limit for input streams used to read styles.
+     * Negative values mean no limit. The default is -1 (no limit).
+     * @return the read limit
+     * @since POI 5.4.2
+     */
+    public static long getInputStreamReadLimit() {
+        return INPUT_STREAM_READ_LIMIT;
+    }
+
     private IndexedColorMap colorMap;
     private ThemeDocument theme;
 
@@ -85,6 +109,13 @@ public class ThemesTable extends POIXMLDocumentPart implements Themes {
      */
     public ThemesTable(PackagePart part) throws IOException {
         super(part);
+        if (INPUT_STREAM_READ_LIMIT >= 0 && part.getSize() > INPUT_STREAM_READ_LIMIT) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "Themes Table part size (%s) exceeds the read limit (%s)",
+                    part.getSize(),
+                    INPUT_STREAM_READ_LIMIT));
+        }
         try (InputStream stream = part.getInputStream()) {
             readFrom(stream);
         }
@@ -116,9 +147,12 @@ public class ThemesTable extends POIXMLDocumentPart implements Themes {
      * @throws IOException if an error occurs while reading.
      * @since POI 5.2.0
      */
-    public void readFrom(InputStream is) throws IOException {
+    public void readFrom(final InputStream is) throws IOException {
+        final InputStream stream = INPUT_STREAM_READ_LIMIT >= 0
+                ? new LimitInputStream(is, INPUT_STREAM_READ_LIMIT)
+                : is;
         try {
-            theme = ThemeDocument.Factory.parse(is, DEFAULT_XML_OPTIONS);
+            theme = ThemeDocument.Factory.parse(stream, DEFAULT_XML_OPTIONS);
         } catch(XmlException e) {
             throw new IOException(e.getLocalizedMessage(), e);
         }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.POIDataSamples;
 import org.apache.poi.hssf.HSSFTestDataSamples;
+import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.ooxml.POIXMLProperties;
 import org.apache.poi.ooxml.TrackingInputStream;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
@@ -1545,6 +1546,21 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
             assertTrue(tempFile.delete());
         }
     }
+
+    @Test
+    void testStylesTableLimit() throws Exception {
+        StylesTable.setInputStreamReadLimit(100);
+        try {
+            // This file has a styles table that is larger than the limit set above
+            // It should throw a POIXMLException when trying to read it
+            assertThrows(POIXMLException.class, () ->
+                   new XSSFWorkbook(openSampleFileStream("github-321.xlsx")));
+        } finally {
+            // reset the limit to default value
+            StylesTable.setInputStreamReadLimit(-1);
+        }
+    }
+
 
     private static void expectFormattedContent(Cell cell, String value) {
         assertEquals(value, new DataFormatter().formatCellValue(cell),

--- a/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
+++ b/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
@@ -19,20 +19,21 @@ package org.apache.poi.util;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 
 /**
  * Copied from guava source code v15 (LimitedInputStream)
- * Guava deprecated LimitInputStream in v14 and removed it in v15. Copying this class here
- * allows to be compatible with guava 11 to 15+.
+ * This version is modified to throw an IOException when the limit is reached.
  * Internal use only, do not use in new code.
  * @since POI 5.4.2
  */
 @Internal
 public final class LimitInputStream extends FilterInputStream {
+    private final long limit;
     private long left;
     private long mark = -1;
 
-    public LimitInputStream(InputStream in, long limit) {
+    public LimitInputStream(final InputStream in, final long limit) {
         super(in);
         if (in == null) {
             throw new NullPointerException("InputStream must not be null");
@@ -40,6 +41,7 @@ public final class LimitInputStream extends FilterInputStream {
         if (limit < 0) {
             throw new IllegalArgumentException("limit must be non-negative");
         }
+        this.limit = limit;
         left = limit;
     }
 
@@ -59,7 +61,7 @@ public final class LimitInputStream extends FilterInputStream {
     @Override
     public int read() throws IOException {
         if (left == 0) {
-            return -1;
+            throw new IOException(String.format(Locale.ROOT, "Limit of %d bytes reached", limit));
         }
 
         int result = in.read();
@@ -75,7 +77,7 @@ public final class LimitInputStream extends FilterInputStream {
             return 0;
         }
         if (left == 0) {
-            return -1;
+            throw new IOException(String.format(Locale.ROOT, "Limit of %d bytes reached", limit));
         }
 
         len = (int) Math.min(len, left);

--- a/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
+++ b/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
@@ -43,6 +43,7 @@ public final class LimitInputStream extends FilterInputStream {
         left = limit;
     }
 
+    @SuppressForbidden
     @Override
     public int available() throws IOException {
         return (int) Math.min(in.available(), left);

--- a/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
+++ b/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
  * Internal use only, do not use in new code.
  * @since POI 5.4.2
  */
+@Internal
 public final class LimitInputStream extends FilterInputStream {
     private long left;
     private long mark = -1;

--- a/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
+++ b/poi/src/main/java/org/apache/poi/util/LimitInputStream.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.poi.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Copied from guava source code v15 (LimitedInputStream)
+ * Guava deprecated LimitInputStream in v14 and removed it in v15. Copying this class here
+ * allows to be compatible with guava 11 to 15+.
+ * Internal use only, do not use in new code.
+ * @since POI 5.4.2
+ */
+public final class LimitInputStream extends FilterInputStream {
+    private long left;
+    private long mark = -1;
+
+    public LimitInputStream(InputStream in, long limit) {
+        super(in);
+        if (in == null) {
+            throw new NullPointerException("InputStream must not be null");
+        }
+        if (limit < 0) {
+            throw new IllegalArgumentException("limit must be non-negative");
+        }
+        left = limit;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return (int) Math.min(in.available(), left);
+    }
+
+    // it's okay to mark even if mark isn't supported, as reset won't work
+    @Override
+    public synchronized void mark(int readLimit) {
+        in.mark(readLimit);
+        mark = left;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (left == 0) {
+            return -1;
+        }
+
+        int result = in.read();
+        if (result != -1) {
+            --left;
+        }
+        return result;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
+        if (left == 0) {
+            return -1;
+        }
+
+        len = (int) Math.min(len, left);
+        int result = in.read(b, off, len);
+        if (result != -1) {
+            left -= result;
+        }
+        return result;
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        if (!in.markSupported()) {
+            throw new IOException("Mark not supported");
+        }
+        if (mark == -1) {
+            throw new IOException("Mark not set");
+        }
+
+        in.reset();
+        left = mark;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        n = Math.min(n, left);
+        long skipped = in.skip(n);
+        left -= skipped;
+        return skipped;
+    }
+}

--- a/poi/src/test/java/org/apache/poi/util/TestLimitInputStream.java
+++ b/poi/src/test/java/org/apache/poi/util/TestLimitInputStream.java
@@ -1,0 +1,47 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TestLimitInputStream {
+    @Test
+    void testLimitInputStream() throws IOException {
+        String text = "test1234567890";
+        ByteArrayInputStream bis = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        try (LimitInputStream lis = new LimitInputStream(bis, 1024)) {
+            assertEquals(text, new String(IOUtils.toByteArray(lis), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void testLimitReached() throws IOException {
+        String text = "test1234567890";
+        ByteArrayInputStream bis = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+        try (LimitInputStream lis = new LimitInputStream(bis, 5)) {
+            assertThrows(IOException.class, () -> IOUtils.toByteArray(lis));
+        }
+    }
+}


### PR DESCRIPTION
OOXML files can embed files that are large and once we parse the XML with XMLBeans and wrap the content classes with POI helper classes, there can be a lot of memory used. This option would allow users to have POI fail with an exception if the input for Styles Table was unexpectedly large. The default limit is unlimited.