### PR TITLE
Implement XWPFRun.getEmbeddedCharts().

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -31,6 +31,7 @@ import java.util.List;
 import javax.xml.namespace.QName;
 
 import org.apache.poi.common.usermodel.PictureType;
+import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.ooxml.util.DocumentHelper;
 import org.apache.poi.ooxml.util.POIXMLUnits;
@@ -41,6 +42,7 @@ import org.apache.poi.xssf.usermodel.XSSFRelation;
 import org.apache.xmlbeans.*;
 import org.apache.xmlbeans.impl.values.XmlAnyTypeImpl;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTChart;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTRelId;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTBlip;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTBlipFillProperties;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTGraphicalObject;
@@ -75,6 +77,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
     private final String pictureText;
     private final IRunBody parent;
     private final List<XWPFPicture> pictures;
+    private final List<XWPFChart> charts;
 
     /**
      * @param r the CTR bean which holds the run attributes
@@ -122,13 +125,24 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         }
         pictureText = text.toString();
 
-        // Do we have any embedded pictures?
-        // (They're a different CTPicture, under the drawingml namespace)
+        // Do we have any embedded pictures or charts?
+        // Pictures are a different CTPicture, under the drawingml namespace.
+        // Charts are relations and use the CTRelId type.
         pictures = new ArrayList<>();
+        charts = new ArrayList<>();
         for (XmlObject o : pictTextObjs) {
             for (CTPicture pict : getCTPictures(o)) {
                 XWPFPicture picture = new XWPFPicture(pict, this);
                 pictures.add(picture);
+            }
+            XmlObject[] chartRels = o.selectPath("declare namespace c='" + CTChart.type.getName().getNamespaceURI() + "' .//*/c:chart");
+            for (XmlObject chartRel : chartRels) {
+                if (chartRel instanceof CTRelId) {
+                    POIXMLDocumentPart chart = getDocument().getRelationById(((CTRelId) chartRel).getId());
+                    if (chart instanceof XWPFChart) {
+                        charts.add((XWPFChart) chart);
+                    }
+                }
             }
         }
     }
@@ -1358,6 +1372,11 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
     @Internal
     public CTInline addChart(String chartRelId) throws InvalidFormatException, IOException {
         try {
+            POIXMLDocumentPart chart = getDocument().getRelationById(chartRelId);
+            if (chart instanceof XWPFChart) {
+                charts.add((XWPFChart) chart);
+            }
+
             CTInline inline = run.addNewDrawing().addNewInline();
 
             //xml part of chart in document
@@ -1817,4 +1836,12 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         return pr;
     }
 
+    /**
+     * Returns the charts embedded in the run.
+     * @return A list of the XWPFChart objects embedded in the run.
+     * @since POI 5.4.2
+     */
+    public List<XWPFChart> getEmbeddedCharts() {
+        return charts;
+    }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -36,6 +36,7 @@ import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.util.Units;
 import org.apache.poi.wp.usermodel.HeaderFooterType;
+import org.apache.poi.xddf.usermodel.chart.XDDFChart;
 import org.apache.poi.xwpf.XWPFTestDataSamples;
 import org.apache.poi.xwpf.model.XWPFHeaderFooterPolicy;
 import org.junit.jupiter.api.AfterEach;
@@ -908,5 +909,35 @@ class TestXWPFRun {
         assertEquals(0, run.getNumberOfTexts());
         run.setText("TEST STRING");
         assertEquals(1, run.getNumberOfTexts());
+    }
+
+    @Test
+    void testGetEmbeddedCharts() throws IOException {
+        try (XWPFDocument sampleDoc = XWPFTestDataSamples.openSampleDocument("61745.docx")) {
+            List<XWPFChart> charts = sampleDoc.getCharts();
+            assertEquals(2, charts.size());
+            List<XWPFChart> run1Charts = sampleDoc.getParagraphArray(0).getRuns().get(0).getEmbeddedCharts();
+            assertEquals(1, run1Charts.size());
+            assertEquals(charts.get(0), run1Charts.get(0));
+            List<XWPFChart> run2Charts = sampleDoc.getParagraphArray(1).getRuns().get(0).getEmbeddedCharts();
+            assertEquals(1, run2Charts.size());
+            assertEquals(charts.get(1), run2Charts.get(0));
+        }
+    }
+
+    @Test
+    void testAddChartGetEmbeddedCharts() throws InvalidFormatException, IOException {
+        XWPFRun run1 = p.createRun();
+        XWPFChart chart1 = doc.createChart(run1, XDDFChart.DEFAULT_WIDTH, XDDFChart.DEFAULT_HEIGHT);
+        assertEquals(1, run1.getEmbeddedCharts().size());
+        assertEquals(chart1, run1.getEmbeddedCharts().get(0));
+
+        XWPFRun run2 = p.createRun();
+        XWPFChart chart2 = doc.createChart(run2, XDDFChart.DEFAULT_WIDTH, XDDFChart.DEFAULT_HEIGHT);
+        assertEquals(1, run2.getEmbeddedCharts().size());
+        assertEquals(chart2, run2.getEmbeddedCharts().get(0));
+
+        XWPFRun run3 = p.createRun();
+        assertEquals(0, run3.getEmbeddedCharts().size());
     }
 }


### PR DESCRIPTION
Returns a list of XWPFChart objects embedded in the run.

Works in a similar way to getEmbeddedPictures(), maintaining a list of XWPFChart objects. They are retrieved from the XWPFDocument object through their relation id.