### PR TITLE
eager XWPF doc eval

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractSDT.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractSDT.java
@@ -30,12 +30,13 @@ public abstract class XWPFAbstractSDT implements ISDTContents {
     private final String title;
     private final String tag;
     private final IBody part;
+    private final XWPFDocument xwpfDocument;
 
     public XWPFAbstractSDT(CTSdtPr pr, IBody part) {
         title = (pr != null && pr.isSetAlias()) ? pr.getAlias().getVal() : "";
         tag = (pr != null && pr.isSetTag()) ? pr.getTag().getVal() : "";
         this.part = part;
-
+        this.xwpfDocument = part.getXWPFDocument();
     }
 
     /**
@@ -86,6 +87,6 @@ public abstract class XWPFAbstractSDT implements ISDTContents {
     }
 
     public XWPFDocument getDocument() {
-        return part.getXWPFDocument();
+        return xwpfDocument;
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
@@ -67,6 +67,7 @@ public class XWPFTableCell implements IBody, ICell {
     }
 
     private final CTTc ctTc;
+    private final XWPFDocument xwpfDocument;
     protected List<XWPFParagraph> paragraphs;
     protected List<XWPFTable> tables;
     protected List<IBodyElement> bodyElements;
@@ -81,6 +82,7 @@ public class XWPFTableCell implements IBody, ICell {
         this.ctTc = cell;
         this.part = part;
         this.tableRow = tableRow;
+        this.xwpfDocument = part.getXWPFDocument();
 
         bodyElements = new ArrayList<>();
         paragraphs = new ArrayList<>();
@@ -524,7 +526,9 @@ public class XWPFTableCell implements IBody, ICell {
 
     @Override
     public XWPFDocument getXWPFDocument() {
-        if (part instanceof XWPFTableCell) {
+        if (xwpfDocument != null) {
+            return xwpfDocument;
+        } else if (part instanceof XWPFTableCell) {
             return getCellDocument((XWPFTableCell) part, 0);
         } else {
             return part.getXWPFDocument();


### PR DESCRIPTION
we've seen evidence in deeply nested docs that it can cause recursion issues when this is lazily evaluated