### PR TITLE
Bump commons-compress from 1.27.1 to 1.28.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ subprojects {
     ext {
         bouncyCastleVersion = '1.81'
         commonsCodecVersion = '1.19.0'
-        commonsCompressVersion = '1.27.1'
+        commonsCompressVersion = '1.28.0'
         commonsIoVersion = '2.20.0'
         commonsMathVersion = '3.6.1'
         junitVersion = '5.13.4'


### PR DESCRIPTION
https://github.com/apache/poi/issues/867
There is a security vulnerability in commons-lang3, with the vulnerability number CVE-2025-48924.