### PR TITLE
add new XSSFParser

### DIFF
--- a/poi-ooxml/build.gradle
+++ b/poi-ooxml/build.gradle
@@ -55,14 +55,14 @@ java {
 
 dependencies {
     api project(':poi')
-    api project(':poi-ooxml-full')
-    api project(path: ':poi-ooxml-full', configuration: 'archives')
+    // api project(':poi-ooxml-full')
+    // api project(path: ':poi-ooxml-full', configuration: 'archives')
 
     // Can be very useful in local testing to comment out the 2 poi-ooxml-full lines above
     // and uncomment the line below to use a pre-built version of poi-ooxml-full.
     // Try to use the last release version of poi-ooxml-full. You might be unlucky if
     // recent unreleased changes in poi-ooxml-full are needed.
-    // api "org.apache.poi:poi-ooxml-full:5.4.1"
+    api "org.apache.poi:poi-ooxml-full:5.4.1"
 
     api "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}"
     api "org.apache.commons:commons-compress:${commonsCompressVersion}"

--- a/poi-ooxml/build.gradle
+++ b/poi-ooxml/build.gradle
@@ -55,14 +55,14 @@ java {
 
 dependencies {
     api project(':poi')
-    // api project(':poi-ooxml-full')
-    // api project(path: ':poi-ooxml-full', configuration: 'archives')
+    api project(':poi-ooxml-full')
+    api project(path: ':poi-ooxml-full', configuration: 'archives')
 
     // Can be very useful in local testing to comment out the 2 poi-ooxml-full lines above
     // and uncomment the line below to use a pre-built version of poi-ooxml-full.
     // Try to use the last release version of poi-ooxml-full. You might be unlucky if
     // recent unreleased changes in poi-ooxml-full are needed.
-    api "org.apache.poi:poi-ooxml-full:5.4.1"
+    // api "org.apache.poi:poi-ooxml-full:5.4.1"
 
     api "org.apache.xmlbeans:xmlbeans:${xmlbeansVersion}"
     api "org.apache.commons:commons-compress:${commonsCompressVersion}"

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/OPCPackage.java
@@ -374,9 +374,10 @@ public abstract class OPCPackage implements RelationshipSource, Closeable {
      * @param opcComplianceFlags
      *            The level of OPC compliance to enforce when reading the package
      * @return A PackageBase object, else <b>null</b>.
+     * @throws IllegalArgumentException
+     *             If the specified file doesn't exist or is a directory.
      * @throws InvalidFormatException
-     *             If the specified file doesn't exist, and a parsing error
-     *             occur.
+     *             If a parsing error occurs.
      * @since POI 5.4.1
      */
     public static OPCPackage open(File file, PackageAccess access, OPCComplianceFlags opcComplianceFlags)

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/XSLFParser.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/XSLFParser.java
@@ -1,0 +1,160 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+package org.apache.poi.xslf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.File;
+
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.util.ExceptionUtil;
+import org.apache.poi.util.IOUtils;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+
+/**
+ * Methods that wrap {@link XMLSlideShow} parsing functionality.
+ * One difference is that the methods in this class try to
+ * throw {@link XSLFReadException} or {@link IOException} instead of {@link RuntimeException}.
+ * You can still get an {@link Error}s like an {@link OutOfMemoryError}.
+ *
+ * @since POI 5.5.0
+ */
+public final class XSLFParser {
+
+    private XSLFParser() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Parse the given InputStream and return a new {@link XMLSlideShow} instance.
+     *
+     * @param stream the data to parse (will be closed after parsing)
+     * @return a new {@link XMLSlideShow} instance
+     * @throws XSLFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XMLSlideShow parse(InputStream stream) throws XSLFReadException, IOException {
+        try {
+            return new XMLSlideShow(stream);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        } catch (Exception e) {
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        }
+    }
+
+    /**
+     * Parse the given InputStream and return a new {@link XMLSlideShow} instance.
+     *
+     * @param stream the data to parse
+     * @param closeStream whether to close the InputStream after parsing
+     * @return a new {@link XMLSlideShow} instance
+     * @throws XSLFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XMLSlideShow parse(InputStream stream, boolean closeStream) throws XSLFReadException, IOException {
+        try {
+            return new XMLSlideShow(stream, closeStream);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        } catch (Exception e) {
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        }
+    }
+
+    /**
+     * Parse the given InputStream and return a new {@link XMLSlideShow} instance.
+     *
+     * @param file to parse
+     * @return a new {@link XMLSlideShow} instance
+     * @throws XSLFReadException if an error occurs while reading the file
+     */
+    public static XMLSlideShow parse(File file) throws XSLFReadException {
+        OPCPackage pkg = null;
+        try {
+            pkg = OPCPackage.open(file);
+            return new XMLSlideShow(pkg);
+        } catch (Error | RuntimeException e) {
+            if (pkg != null) {
+                IOUtils.closeQuietly(pkg);
+            }
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        } catch (Exception e) {
+            if (pkg != null) {
+                IOUtils.closeQuietly(pkg);
+            }
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        }
+    }
+
+    /**
+     * Parse the given {@link OPCPackage} and return a new {@link XMLSlideShow} instance.
+     *
+     * @param pkg to parse
+     * @return a new {@link XMLSlideShow} instance
+     * @throws XSLFReadException if an error occurs while reading the file
+     */
+    public static XMLSlideShow parse(OPCPackage pkg) throws XSLFReadException {
+        try {
+            return new XMLSlideShow(pkg);
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        } catch (Exception e) {
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        }
+    }
+
+    /**
+     * Parse the given {@link PackagePart} and return a new {@link XMLSlideShow} instance.
+     *
+     * @param packagePart to parse
+     * @return a new {@link XMLSlideShow} instance
+     * @throws XSLFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XMLSlideShow parse(PackagePart packagePart) throws XSLFReadException, IOException {
+        try (InputStream is = packagePart.getInputStream()) {
+            return new XMLSlideShow(is);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        } catch (Exception e) {
+            throw new XSLFReadException("Exception reading XMLSlideShow", e);
+        }
+    }
+}

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/XSLFReadException.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/XSLFReadException.java
@@ -1,0 +1,56 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+package org.apache.poi.xslf;
+
+import org.apache.poi.POIException;
+
+/**
+ * An exception that indicates a problem reading a pptx file.
+ * <p>This exception is only used by some new methods.
+ * Historically, POI has used {@link RuntimeException} for most of its
+ * exceptions, but this is not a good practice. This class is a checked
+ * class that extends {@link Exception} so needs to be explicitly
+ * caught or declared in the method signature.</p>
+ * @since POI 5.5.0
+ */
+public class XSLFReadException extends POIException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new {@code XSLFReadException} with
+     * the {@code String} specified as an error message.
+     *
+     * @param msg The error message for the exception.
+     */
+    public XSLFReadException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Create a new {@code XSLFReadException} with
+     * the {@code String} specified as an error message and the cause.
+     *
+     * @param msg The error message for the exception.
+     * @param cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     */
+    public XSLFReadException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/XSSFParser.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/XSSFParser.java
@@ -1,0 +1,157 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+package org.apache.poi.xssf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.File;
+
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.util.ExceptionUtil;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+/**
+ * Methods that wrap XSSFWorkbook parsing functionality.
+ * One difference is that the methods in this class try to
+ * throw {@link XSSFReadException} or {@link IOException} instead of {@link RuntimeException}.
+ * You can still get an {@link Error}s like an {@link OutOfMemoryError}.
+ *
+ * @since POI 5.5.0
+ */
+public final class XSSFParser {
+
+    private XSSFParser() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Parse the given InputStream and return a new {@link XSSFWorkbook} instance.
+     *
+     * @param stream the data to parse (will be closed after parsing)
+     * @return a new {@link XSSFWorkbook} instance
+     * @throws XSSFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XSSFWorkbook parse(InputStream stream) throws XSSFReadException, IOException {
+        try {
+            return new XSSFWorkbook(stream);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        } catch (Exception e) {
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        }
+    }
+
+    /**
+     * Parse the given InputStream and return a new {@link XSSFWorkbook} instance.
+     *
+     * @param stream the data to parse
+     * @param closeStream whether to close the InputStream after parsing
+     * @return a new {@link XSSFWorkbook} instance
+     * @throws XSSFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XSSFWorkbook parse(InputStream stream, boolean closeStream) throws XSSFReadException, IOException {
+        try {
+            return new XSSFWorkbook(stream, closeStream);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        } catch (Exception e) {
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        }
+    }
+
+    /**
+     * Parse the given InputStream and return a new {@link XSSFWorkbook} instance.
+     *
+     * @param file to parse
+     * @return a new {@link XSSFWorkbook} instance
+     * @throws XSSFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XSSFWorkbook parse(File file) throws XSSFReadException, IOException {
+        try {
+            return new XSSFWorkbook(file);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        } catch (Exception e) {
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        }
+    }
+
+    /**
+     * Parse the given {@link OPCPackage} and return a new {@link XSSFWorkbook} instance.
+     *
+     * @param pkg to parse
+     * @return a new {@link XSSFWorkbook} instance
+     * @throws XSSFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XSSFWorkbook parse(OPCPackage pkg) throws XSSFReadException, IOException {
+        try {
+            return new XSSFWorkbook(pkg);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        } catch (Exception e) {
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        }
+    }
+
+    /**
+     * Parse the given {@link PackagePart} and return a new {@link XSSFWorkbook} instance.
+     *
+     * @param packagePart to parse
+     * @return a new {@link XSSFWorkbook} instance
+     * @throws XSSFReadException if an error occurs while reading the file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public static XSSFWorkbook parse(PackagePart packagePart) throws XSSFReadException, IOException {
+        try {
+            return new XSSFWorkbook(packagePart);
+        } catch (IOException e) {
+            throw e;
+        } catch (Error | RuntimeException e) {
+            if (ExceptionUtil.isFatal(e)) {
+                throw e;
+            }
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        } catch (Exception e) {
+            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+        }
+    }
+}

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/XSSFReadException.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/XSSFReadException.java
@@ -1,0 +1,56 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+package org.apache.poi.xssf;
+
+import org.apache.poi.POIException;
+
+/**
+ * An exception that indicates a problem reading an xlsx file.
+ * <p>This exception is only used by some new methods.
+ * Historically, POI has used {@link RuntimeException} for most of its
+ * exceptions, but this is not a good practice. This class is a checked
+ * class that extends {@link Exception} so needs to be explicitly
+ * caught or declared in the method signature.</p>
+ * @since POI 5.5.0
+ */
+public class XSSFReadException extends POIException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new {@code XSSFReadException} with
+     * the {@code String} specified as an error message.
+     *
+     * @param msg The error message for the exception.
+     */
+    public XSSFReadException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Create a new {@code XSSFReadException} with
+     * the {@code String} specified as an error message and the cause.
+     *
+     * @param msg The error message for the exception.
+     * @param cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     */
+    public XSSFReadException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/XWPFParser.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/XWPFParser.java
@@ -14,7 +14,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-package org.apache.poi.xssf;
+package org.apache.poi.xwpf;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,135 +23,147 @@ import java.io.File;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.util.ExceptionUtil;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.util.IOUtils;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
 
 /**
- * Methods that wrap {@link XSSFWorkbook} parsing functionality.
+ * Methods that wrap {@link XWPFDocument} parsing functionality.
  * One difference is that the methods in this class try to
- * throw {@link XSSFReadException} or {@link IOException} instead of {@link RuntimeException}.
+ * throw {@link XWPFReadException} or {@link IOException} instead of {@link RuntimeException}.
  * You can still get an {@link Error}s like an {@link OutOfMemoryError}.
  *
  * @since POI 5.5.0
  */
-public final class XSSFParser {
+public final class XWPFParser {
 
-    private XSSFParser() {
+    private XWPFParser() {
         // Prevent instantiation
     }
 
     /**
-     * Parse the given InputStream and return a new {@link XSSFWorkbook} instance.
+     * Parse the given InputStream and return a new {@link XWPFDocument} instance.
      *
      * @param stream the data to parse (will be closed after parsing)
-     * @return a new {@link XSSFWorkbook} instance
-     * @throws XSSFReadException if an error occurs while reading the file
+     * @return a new {@link XWPFDocument} instance
+     * @throws XWPFReadException if an error occurs while reading the file
      * @throws IOException if an I/O error occurs while reading the file
      */
-    public static XSSFWorkbook parse(InputStream stream) throws XSSFReadException, IOException {
+    public static XWPFDocument parse(InputStream stream) throws XWPFReadException, IOException {
         try {
-            return new XSSFWorkbook(stream);
+            return new XWPFDocument(stream);
         } catch (IOException e) {
             throw e;
         } catch (Error | RuntimeException e) {
             if (ExceptionUtil.isFatal(e)) {
                 throw e;
             }
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         } catch (Exception e) {
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         }
     }
 
     /**
-     * Parse the given InputStream and return a new {@link XSSFWorkbook} instance.
+     * Parse the given InputStream and return a new {@link XWPFDocument} instance.
      *
      * @param stream the data to parse
      * @param closeStream whether to close the InputStream after parsing
-     * @return a new {@link XSSFWorkbook} instance
-     * @throws XSSFReadException if an error occurs while reading the file
+     * @return a new {@link XWPFDocument} instance
+     * @throws XWPFReadException if an error occurs while reading the file
      * @throws IOException if an I/O error occurs while reading the file
      */
-    public static XSSFWorkbook parse(InputStream stream, boolean closeStream) throws XSSFReadException, IOException {
+    public static XWPFDocument parse(InputStream stream, boolean closeStream) throws XWPFReadException, IOException {
         try {
-            return new XSSFWorkbook(stream, closeStream);
+            return new XWPFDocument(stream, closeStream);
         } catch (IOException e) {
             throw e;
         } catch (Error | RuntimeException e) {
             if (ExceptionUtil.isFatal(e)) {
                 throw e;
             }
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         } catch (Exception e) {
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         }
     }
 
     /**
-     * Parse the given InputStream and return a new {@link XSSFWorkbook} instance.
+     * Parse the given InputStream and return a new {@link XWPFDocument} instance.
      *
      * @param file to parse
-     * @return a new {@link XSSFWorkbook} instance
-     * @throws XSSFReadException if an error occurs while reading the file
+     * @return a new {@link XWPFDocument} instance
+     * @throws XWPFReadException if an error occurs while reading the file
      * @throws IOException if an I/O error occurs while reading the file
      */
-    public static XSSFWorkbook parse(File file) throws XSSFReadException, IOException {
+    public static XWPFDocument parse(File file) throws XWPFReadException, IOException {
+        OPCPackage pkg = null;
         try {
-            return new XSSFWorkbook(file);
+            pkg = OPCPackage.open(file);
+            return new XWPFDocument(pkg);
         } catch (IOException e) {
+            if (pkg != null) {
+                IOUtils.closeQuietly(pkg);
+            }
             throw e;
         } catch (Error | RuntimeException e) {
+            if (pkg != null) {
+                IOUtils.closeQuietly(pkg);
+            }
             if (ExceptionUtil.isFatal(e)) {
                 throw e;
             }
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         } catch (Exception e) {
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            if (pkg != null) {
+                IOUtils.closeQuietly(pkg);
+            }
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         }
     }
 
     /**
-     * Parse the given {@link OPCPackage} and return a new {@link XSSFWorkbook} instance.
+     * Parse the given {@link OPCPackage} and return a new {@link XWPFDocument} instance.
      *
      * @param pkg to parse
-     * @return a new {@link XSSFWorkbook} instance
-     * @throws XSSFReadException if an error occurs while reading the file
+     * @return a new {@link XWPFDocument} instance
+     * @throws XWPFReadException if an error occurs while reading the file
      * @throws IOException if an I/O error occurs while reading the file
      */
-    public static XSSFWorkbook parse(OPCPackage pkg) throws XSSFReadException, IOException {
+    public static XWPFDocument parse(OPCPackage pkg) throws XWPFReadException, IOException {
         try {
-            return new XSSFWorkbook(pkg);
+            return new XWPFDocument(pkg);
         } catch (IOException e) {
             throw e;
         } catch (Error | RuntimeException e) {
             if (ExceptionUtil.isFatal(e)) {
                 throw e;
             }
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         } catch (Exception e) {
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         }
     }
 
     /**
-     * Parse the given {@link PackagePart} and return a new {@link XSSFWorkbook} instance.
+     * Parse the given {@link PackagePart} and return a new {@link XWPFDocument} instance.
      *
      * @param packagePart to parse
-     * @return a new {@link XSSFWorkbook} instance
-     * @throws XSSFReadException if an error occurs while reading the file
+     * @return a new {@link XWPFDocument} instance
+     * @throws XWPFReadException if an error occurs while reading the file
      * @throws IOException if an I/O error occurs while reading the file
      */
-    public static XSSFWorkbook parse(PackagePart packagePart) throws XSSFReadException, IOException {
-        try {
-            return new XSSFWorkbook(packagePart);
+    public static XWPFDocument parse(PackagePart packagePart) throws XWPFReadException, IOException {
+        try (InputStream is = packagePart.getInputStream()) {
+            return new XWPFDocument(is);
         } catch (IOException e) {
             throw e;
         } catch (Error | RuntimeException e) {
             if (ExceptionUtil.isFatal(e)) {
                 throw e;
             }
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         } catch (Exception e) {
-            throw new XSSFReadException("Exception reading XSSFWorkbook", e);
+            throw new XWPFReadException("Exception reading XWPFDocument", e);
         }
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/XWPFReadException.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/XWPFReadException.java
@@ -1,0 +1,56 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+package org.apache.poi.xwpf;
+
+import org.apache.poi.POIException;
+
+/**
+ * An exception that indicates a problem reading a docx file.
+ * <p>This exception is only used by some new methods.
+ * Historically, POI has used {@link RuntimeException} for most of its
+ * exceptions, but this is not a good practice. This class is a checked
+ * class that extends {@link Exception} so needs to be explicitly
+ * caught or declared in the method signature.</p>
+ * @since POI 5.5.0
+ */
+public class XWPFReadException extends POIException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create a new {@code XWPFReadException} with
+     * the {@code String} specified as an error message.
+     *
+     * @param msg The error message for the exception.
+     */
+    public XWPFReadException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Create a new {@code XWPFReadException} with
+     * the {@code String} specified as an error message and the cause.
+     *
+     * @param msg The error message for the exception.
+     * @param cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     */
+    public XWPFReadException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}


### PR DESCRIPTION
POI has lots of RuntimeExceptions and it would be too much work to change to using checked exceptions. Thousands of method signatures would change and lots of new try/catch changes would be needed in intermediate methods.

We can take some of the most used code paths and provide wrapper APIs that use checked exceptions by wrapping any non-fatal exception/error as a checked exception.