### PR TITLE
Make getters public for XML beans in XWPFDefault*Style.

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDefaultParagraphStyle.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDefaultParagraphStyle.java
@@ -32,7 +32,12 @@ public class XWPFDefaultParagraphStyle {
         this.ppr = ppr;
     }
 
-    protected CTPPrGeneral getPPr() {
+    /**
+     * Return the underlying XML bean.
+     * @return underlying CTPPrGeneral bean.
+     * @since POI 5.5.0
+     */
+    public CTPPrGeneral getPPr() {
         return ppr;
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDefaultRunStyle.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDefaultRunStyle.java
@@ -36,7 +36,12 @@ public class XWPFDefaultRunStyle {
         this.rpr = rpr;
     }
 
-    protected CTRPr getRPr() {
+    /**
+     * Return the underlying XML bean.
+     * @return underlying CTRPr bean.
+     * @since POI 5.5.0
+     */
+    public CTRPr getRPr() {
         return rpr;
     }
 


### PR DESCRIPTION
The classes XWPFDefaultRunStyle and XWPFDefaultParagraphStyle only expose a subset of their possibles attributes. To let users access all the underlying data, we change the visibility of the XML bean getters to public.