### PR TITLE
Remove deprecated dispose() calls from SXSSF workbook tests

### DIFF
--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestOutlining.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestOutlining.java
@@ -179,7 +179,6 @@ public final class TestOutlining {
         assertEquals(2, sxssfSheet.getRow(4).getOutlineLevel());
         assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
 
-        sxssfWorkbook.dispose();
         sxssfWorkbook.close();
     }
 
@@ -212,7 +211,6 @@ public final class TestOutlining {
         assertEquals(2, sxssfSheet.getRow(4).getOutlineLevel());
         assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
 
-        sxssfWorkbook.dispose();
         sxssfWorkbook.close();
     }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestOutlining.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestOutlining.java
@@ -36,181 +36,175 @@ import org.junit.jupiter.api.Test;
 public final class TestOutlining {
     @Test
     void testSetRowGroupCollapsed() throws IOException {
-        SXSSFWorkbook wb2 = new SXSSFWorkbook(100);
-        wb2.setCompressTempFiles(true);
-        SXSSFSheet sheet2 = wb2.createSheet("new sheet");
+        try (SXSSFWorkbook wb2 = new SXSSFWorkbook(100)) {
+            wb2.setCompressTempFiles(true);
+            SXSSFSheet sheet2 = wb2.createSheet("new sheet");
 
-        int rowCount = 20;
-        for (int i = 0; i < rowCount; i++) {
-            sheet2.createRow(i);
+            int rowCount = 20;
+            for (int i = 0; i < rowCount; i++) {
+                sheet2.createRow(i);
+            }
+
+            sheet2.groupRow(4, 9);
+            sheet2.groupRow(11, 19);
+
+            sheet2.setRowGroupCollapsed(4, true);
+
+            SXSSFRow r = sheet2.getRow(8);
+            assertTrue(r.getHidden());
+            r = sheet2.getRow(10);
+            assertTrue(r.getCollapsed());
+            r = sheet2.getRow(12);
+            assertNull(r.getHidden());
         }
-
-        sheet2.groupRow(4, 9);
-        sheet2.groupRow(11, 19);
-
-        sheet2.setRowGroupCollapsed(4, true);
-
-        SXSSFRow r = sheet2.getRow(8);
-        assertTrue(r.getHidden());
-        r = sheet2.getRow(10);
-        assertTrue(r.getCollapsed());
-        r = sheet2.getRow(12);
-        assertNull(r.getHidden());
-        wb2.dispose();
-
-        wb2.close();
     }
 
     @Test
     void testSetRowGroupCollapsedError() throws IOException {
-        SXSSFWorkbook wb2 = new SXSSFWorkbook(100);
-        wb2.setCompressTempFiles(true);
-        SXSSFSheet sheet2 = wb2.createSheet("new sheet");
+        try (SXSSFWorkbook wb2 = new SXSSFWorkbook(100)) {
+            wb2.setCompressTempFiles(true);
+            SXSSFSheet sheet2 = wb2.createSheet("new sheet");
 
-        int rowCount = 20;
-        for (int i = 0; i < rowCount; i++) {
-            sheet2.createRow(i);
+            int rowCount = 20;
+            for (int i = 0; i < rowCount; i++) {
+                sheet2.createRow(i);
+            }
+
+            sheet2.groupRow(4, 9);
+            sheet2.groupRow(11, 19);
+
+            IllegalArgumentException e;
+            e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(3, true));
+            assertTrue(e.getMessage().contains("row (3)"));
+
+            e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(10, true));
+            assertTrue(e.getMessage().contains("row (10)"));
+
+            e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(0, true));
+            assertTrue(e.getMessage().contains("row (0)"));
+
+            e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(20, true));
+            assertTrue(e.getMessage().contains("Row does not exist"), "Had: " + e.getMessage());
+
+            SXSSFRow r = sheet2.getRow(8);
+            assertNotNull(r);
+            assertNull(r.getHidden());
+            r = sheet2.getRow(10);
+            assertNull(r.getCollapsed());
+            r = sheet2.getRow(12);
+            assertNull(r.getHidden());
         }
-
-        sheet2.groupRow(4, 9);
-        sheet2.groupRow(11, 19);
-
-        IllegalArgumentException e;
-        e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(3, true));
-        assertTrue(e.getMessage().contains("row (3)"));
-
-        e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(10, true));
-        assertTrue(e.getMessage().contains("row (10)"));
-
-        e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(0, true));
-        assertTrue(e.getMessage().contains("row (0)"));
-
-        e = assertThrows(IllegalArgumentException.class, () -> sheet2.setRowGroupCollapsed(20, true));
-        assertTrue(e.getMessage().contains("Row does not exist"), "Had: " + e.getMessage());
-
-        SXSSFRow r = sheet2.getRow(8);
-        assertNotNull(r);
-        assertNull(r.getHidden());
-        r = sheet2.getRow(10);
-        assertNull(r.getCollapsed());
-        r = sheet2.getRow(12);
-        assertNull(r.getHidden());
-        wb2.dispose();
-
-        wb2.close();
     }
 
     @Test
     void testOutlineGettersHSSF() throws IOException {
-        HSSFWorkbook hssfWorkbook = new HSSFWorkbook();
-        HSSFSheet hssfSheet = hssfWorkbook.createSheet();
-        hssfSheet.createRow(0);
-        hssfSheet.createRow(1);
-        hssfSheet.createRow(2);
-        hssfSheet.createRow(3);
-        hssfSheet.createRow(4);
-        hssfSheet.groupRow(1, 3);
-        hssfSheet.groupRow(2, 3);
+        try (HSSFWorkbook hssfWorkbook = new HSSFWorkbook()) {
+            HSSFSheet hssfSheet = hssfWorkbook.createSheet();
+            hssfSheet.createRow(0);
+            hssfSheet.createRow(1);
+            hssfSheet.createRow(2);
+            hssfSheet.createRow(3);
+            hssfSheet.createRow(4);
+            hssfSheet.groupRow(1, 3);
+            hssfSheet.groupRow(2, 3);
 
-        assertEquals(0, hssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(1, hssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(2, hssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(2, hssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(0, hssfSheet.getRow(4).getOutlineLevel());
-        hssfWorkbook.close();
+            assertEquals(0, hssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(1, hssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(2, hssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(2, hssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(0, hssfSheet.getRow(4).getOutlineLevel());
+        }
     }
 
     @Test
     void testOutlineGettersXSSF() throws IOException {
-        XSSFWorkbook xssfWorkbook = new XSSFWorkbook();
-        XSSFSheet xssfSheet = xssfWorkbook.createSheet();
-        xssfSheet.createRow(0);
-        xssfSheet.createRow(1);
-        xssfSheet.createRow(2);
-        xssfSheet.createRow(3);
-        xssfSheet.createRow(4);
-        xssfSheet.groupRow(1, 3);
-        xssfSheet.groupRow(2, 3);
+        try (XSSFWorkbook xssfWorkbook = new XSSFWorkbook()) {
+            XSSFSheet xssfSheet = xssfWorkbook.createSheet();
+            xssfSheet.createRow(0);
+            xssfSheet.createRow(1);
+            xssfSheet.createRow(2);
+            xssfSheet.createRow(3);
+            xssfSheet.createRow(4);
+            xssfSheet.groupRow(1, 3);
+            xssfSheet.groupRow(2, 3);
 
-        assertEquals(0, xssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(1, xssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(2, xssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(2, xssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(0, xssfSheet.getRow(4).getOutlineLevel());
-        xssfWorkbook.close();
+            assertEquals(0, xssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(1, xssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(2, xssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(2, xssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(0, xssfSheet.getRow(4).getOutlineLevel());
+        }
     }
 
     @Test
     void testOutlineGettersSXSSF() throws IOException {
-        SXSSFWorkbook sxssfWorkbook = new SXSSFWorkbook();
-        SXSSFSheet sxssfSheet = sxssfWorkbook.createSheet();
-        sxssfSheet.createRow(0);
-        sxssfSheet.createRow(1);
-        sxssfSheet.createRow(2);
-        sxssfSheet.createRow(3);
-        sxssfSheet.createRow(4);
-        sxssfSheet.createRow(5);
+        try (SXSSFWorkbook sxssfWorkbook = new SXSSFWorkbook()) {
+            SXSSFSheet sxssfSheet = sxssfWorkbook.createSheet();
+            sxssfSheet.createRow(0);
+            sxssfSheet.createRow(1);
+            sxssfSheet.createRow(2);
+            sxssfSheet.createRow(3);
+            sxssfSheet.createRow(4);
+            sxssfSheet.createRow(5);
 
-        // nothing happens with empty row-area
-        sxssfSheet.groupRow(1, 0);
-        assertEquals(0, sxssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(4).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
+            // nothing happens with empty row-area
+            sxssfSheet.groupRow(1, 0);
+            assertEquals(0, sxssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(4).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
 
-        sxssfSheet.groupRow(1, 3);
-        sxssfSheet.groupRow(2, 3);
+            sxssfSheet.groupRow(1, 3);
+            sxssfSheet.groupRow(2, 3);
 
-        assertEquals(0, sxssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(1, sxssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(2, sxssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(2, sxssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(4).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(1, sxssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(2, sxssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(2, sxssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(4).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
 
-        // add tests for direct setting - add row 4 to deepest group
-        sxssfSheet.setRowOutlineLevel(4, 2);
-        assertEquals(0, sxssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(1, sxssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(2, sxssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(2, sxssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(2, sxssfSheet.getRow(4).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
-
-        sxssfWorkbook.close();
+            // add tests for direct setting - add row 4 to deepest group
+            sxssfSheet.setRowOutlineLevel(4, 2);
+            assertEquals(0, sxssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(1, sxssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(2, sxssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(2, sxssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(2, sxssfSheet.getRow(4).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
+        }
     }
 
     @Test
     void testOutlineGettersSXSSFSetOutlineLevel() throws IOException {
-        SXSSFWorkbook sxssfWorkbook = new SXSSFWorkbook();
-        SXSSFSheet sxssfSheet = sxssfWorkbook.createSheet();
-        sxssfSheet.createRow(0);
-        sxssfSheet.createRow(1);
-        sxssfSheet.createRow(2);
-        sxssfSheet.createRow(3);
-        sxssfSheet.createRow(4);
-        sxssfSheet.createRow(5);
+        try (SXSSFWorkbook sxssfWorkbook = new SXSSFWorkbook()) {
+            SXSSFSheet sxssfSheet = sxssfWorkbook.createSheet();
+            sxssfSheet.createRow(0);
+            sxssfSheet.createRow(1);
+            sxssfSheet.createRow(2);
+            sxssfSheet.createRow(3);
+            sxssfSheet.createRow(4);
+            sxssfSheet.createRow(5);
 
-        // what happens with level below 1
-        sxssfSheet.setRowOutlineLevel(0, -2);
-        assertEquals(-2, sxssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(4).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
+            // what happens with level below 1
+            sxssfSheet.setRowOutlineLevel(0, -2);
+            assertEquals(-2, sxssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(4).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
 
-        // add tests for direct setting
-        sxssfSheet.setRowOutlineLevel(4, 2);
-        assertEquals(-2, sxssfSheet.getRow(0).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(1).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(2).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(3).getOutlineLevel());
-        assertEquals(2, sxssfSheet.getRow(4).getOutlineLevel());
-        assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
-
-        sxssfWorkbook.close();
+            // add tests for direct setting
+            sxssfSheet.setRowOutlineLevel(4, 2);
+            assertEquals(-2, sxssfSheet.getRow(0).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(1).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(2).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(3).getOutlineLevel());
+            assertEquals(2, sxssfSheet.getRow(4).getOutlineLevel());
+            assertEquals(0, sxssfSheet.getRow(5).getOutlineLevel());
+        }
     }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestSXSSFWorkbookWithCustomZipEntrySource.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestSXSSFWorkbookWithCustomZipEntrySource.java
@@ -66,7 +66,6 @@ public final class TestSXSSFWorkbookWithCustomZipEntrySource {
             cell1.setCellValue(cellValue);
             workbook.write(os);
             workbook.close();
-            workbook.dispose();
         }
         try (XSSFWorkbook xwb = new XSSFWorkbook(os.toInputStream())) {
             XSSFSheet xs1 = xwb.getSheetAt(0);
@@ -90,7 +89,6 @@ public final class TestSXSSFWorkbookWithCustomZipEntrySource {
                 workbook.write(os);
             }
             workbook.close();
-            workbook.dispose();
         }
         try (InputStream is = tempData.getInputStream();
              ZipEntrySource zipEntrySource = AesZipFileZipEntrySource.createZipEntrySource(is)) {
@@ -123,9 +121,8 @@ public final class TestSXSSFWorkbookWithCustomZipEntrySource {
             String text = new String(data, UTF_8);
             assertFalse(text.contains(sheetName));
             assertFalse(text.contains(cellValue));
-        }
-        workbook.dispose();
-        assertFalse(tempFile.exists(), "tempFile deleted after dispose?");
+        }       
         workbook.close();
+        assertFalse(tempFile.exists(), "tempFile deleted after close?");
     }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestSXSSFWorkbookWithCustomZipEntrySource.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/streaming/TestSXSSFWorkbookWithCustomZipEntrySource.java
@@ -65,7 +65,6 @@ public final class TestSXSSFWorkbookWithCustomZipEntrySource {
             SXSSFCell cell1 = row1.createCell(1);
             cell1.setCellValue(cellValue);
             workbook.write(os);
-            workbook.close();
         }
         try (XSSFWorkbook xwb = new XSSFWorkbook(os.toInputStream())) {
             XSSFSheet xs1 = xwb.getSheetAt(0);
@@ -88,7 +87,6 @@ public final class TestSXSSFWorkbookWithCustomZipEntrySource {
             try (OutputStream os = tempData.getOutputStream()) {
                 workbook.write(os);
             }
-            workbook.close();
         }
         try (InputStream is = tempData.getInputStream();
              ZipEntrySource zipEntrySource = AesZipFileZipEntrySource.createZipEntrySource(is)) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestSXSSFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestSXSSFBugs.java
@@ -192,7 +192,6 @@ public final class TestSXSSFBugs extends BaseTestBugzillaIssues {
 
         try (FileOutputStream out = new FileOutputStream(File.createTempFile("test62872", ".xlsx"))) {
             workbook.write(out);
-            workbook.dispose();
             workbook.close();
             out.flush();
         }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFComment.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFComment.java
@@ -357,7 +357,7 @@ public final class TestXSSFComment extends BaseTestCellComment {
         try {
             _testMove(workbook);
         } finally {
-            workbook.dispose();
+            workbook.close();
         }
     }
 
@@ -372,7 +372,7 @@ public final class TestXSSFComment extends BaseTestCellComment {
         try {
             _testMoveCopy(workbook);
         } finally {
-            workbook.dispose();
+            workbook.close();
         }
     }
 
@@ -387,7 +387,7 @@ public final class TestXSSFComment extends BaseTestCellComment {
         try {
             _testMoveIsSaved(workbook);
         } finally {
-            workbook.dispose();
+            workbook.close();
         }
     }
 
@@ -402,7 +402,7 @@ public final class TestXSSFComment extends BaseTestCellComment {
         try {
             _testModificationIsSaved(workbook);
         } finally {
-            workbook.dispose();
+            workbook.close();
         }
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFComment.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFComment.java
@@ -353,11 +353,8 @@ public final class TestXSSFComment extends BaseTestCellComment {
 
     @Test
     void testMoveCommentSXSSF() throws Exception {
-        SXSSFWorkbook workbook = new SXSSFWorkbook();
-        try {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook()) {
             _testMove(workbook);
-        } finally {
-            workbook.close();
         }
     }
 
@@ -368,11 +365,8 @@ public final class TestXSSFComment extends BaseTestCellComment {
 
     @Test
     void testMoveCommentCopySXSSF() throws Exception {
-        SXSSFWorkbook workbook = new SXSSFWorkbook();
-        try {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook()) {
             _testMoveCopy(workbook);
-        } finally {
-            workbook.close();
         }
     }
 
@@ -383,11 +377,8 @@ public final class TestXSSFComment extends BaseTestCellComment {
 
     @Test
     void testMoveCommentIsSavedSXSSF() throws Exception {
-        SXSSFWorkbook workbook = new SXSSFWorkbook();
-        try {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook()) {
             _testMoveIsSaved(workbook);
-        } finally {
-            workbook.close();
         }
     }
 
@@ -398,11 +389,8 @@ public final class TestXSSFComment extends BaseTestCellComment {
 
     @Test
     void testModifiedCommentIsSavedSXSSF() throws Exception {
-        SXSSFWorkbook workbook = new SXSSFWorkbook();
-        try {
+        try (SXSSFWorkbook workbook = new SXSSFWorkbook()) {
             _testModificationIsSaved(workbook);
-        } finally {
-            workbook.close();
         }
     }
 


### PR DESCRIPTION
The SXSSFWorkbook.dispose() method was deprecated in https://github.com/apache/poi/pull/586

This PR removes use of it from the tests in favour of SXSSFWorkbook.close() called via try-with-resource blocks.
