### PR TITLE
make getCachedResultType return enum

### DIFF
--- a/poi/src/main/java/org/apache/poi/hssf/extractor/OldExcelExtractor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/extractor/OldExcelExtractor.java
@@ -286,12 +286,12 @@ public class OldExcelExtractor implements POITextExtractor {
                     // Biff 2 and 5+ share the same SID, due to a bug...
                     if (biffVersion == 5) {
                         FormulaRecord fr = new FormulaRecord(ris);
-                        if (fr.getCachedResultTypeEnum() == CellType.NUMERIC) {
+                        if (fr.getCachedResultType() == CellType.NUMERIC) {
                             handleNumericCell(text, fr.getValue());
                         }
                     } else {
                         OldFormulaRecord fr = new OldFormulaRecord(ris);
-                        if (fr.getCachedResultTypeEnum() == CellType.NUMERIC) {
+                        if (fr.getCachedResultType() == CellType.NUMERIC) {
                             handleNumericCell(text, fr.getValue());
                         }
                     }

--- a/poi/src/main/java/org/apache/poi/hssf/record/FormulaRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/FormulaRecord.java
@@ -123,28 +123,25 @@ public final class FormulaRecord extends CellRecord {
     /**
      * @return The type of the cached value or CellType.NUMERIC.getCode() if the cached value is empty
      *
-     * @deprecated POI 5.0.0, will be removed in 6.0, use getCachedResultTypeEnum until switch to enum is fully done
+     * @since POI 6.0.0
      */
-    @Deprecated
-    @Removal(version = "6.0.0")
-    public int getCachedResultType() {
+    public CellType getCachedResultType() {
         if (specialCachedValue == null) {
-            return CellType.NUMERIC.getCode();
+            return CellType.NUMERIC;
         }
-        return specialCachedValue.getValueType();
+        return specialCachedValue.getValueTypeEnum();
     }
 
     /**
      * Returns the type of the cached result
      *
      * @return The type of the cached value or CellType.NUMERIC if the cached value is empty
-     * @since POI 5.0.0
+     * @deprecated POI 6.0.0, use {@link #getCachedResultType()} instead
      */
+    @Deprecated
+    @Removal(version="7.0.0")
     public CellType getCachedResultTypeEnum() {
-        if (specialCachedValue == null) {
-            return CellType.NUMERIC;
-        }
-        return specialCachedValue.getValueTypeEnum();
+        return getCachedResultType();
     }
 
     public boolean getCachedBooleanValue() {

--- a/poi/src/main/java/org/apache/poi/hssf/record/OldFormulaRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/OldFormulaRecord.java
@@ -24,6 +24,7 @@ import org.apache.poi.ss.formula.Formula;
 import org.apache.poi.ss.formula.ptg.Ptg;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.util.GenericRecordUtil;
+import org.apache.poi.util.Removal;
 
 /**
  * Formula Record (0x0006 / 0x0206 / 0x0406) - holds a formula in
@@ -65,26 +66,27 @@ public final class OldFormulaRecord extends OldCellRecord {
     }
 
     /**
-     * @deprecated POI 5.0.0, will be removed in 5.0, use getCachedResultTypeEnum until switch to enum is fully done
+     * Returns the type of the cached result
+     * @return A CellType
+     * @since POI 6.0.0
      */
-    @Deprecated
-    public int getCachedResultType() {
+    public CellType getCachedResultType() {
         if (specialCachedValue == null) {
-            return CellType.NUMERIC.getCode();
+            return CellType.NUMERIC;
         }
-        return specialCachedValue.getValueType();
+        return specialCachedValue.getValueTypeEnum();
     }
 
     /**
      * Returns the type of the cached result
      * @return A CellType
      * @since POI 5.0.0
+     * @deprecated POI 6.0.0, use {@link #getCachedResultType()} instead
      */
+    @Deprecated
+    @Removal(version="7.0.0")
     public CellType getCachedResultTypeEnum() {
-        if (specialCachedValue == null) {
-            return CellType.NUMERIC;
-        }
-        return specialCachedValue.getValueTypeEnum();
+        return getCachedResultType();
     }
 
     public boolean getCachedBooleanValue() {

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCell.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCell.java
@@ -649,7 +649,7 @@ public class HSSFCell extends CellBase {
     }
 
     private static void checkFormulaCachedValueType(CellType expectedTypeCode, FormulaRecord fr) {
-        CellType cachedValueType = fr.getCachedResultTypeEnum();
+        CellType cachedValueType = fr.getCachedResultType();
         if (cachedValueType != expectedTypeCode) {
             throw typeMismatch(expectedTypeCode, cachedValueType, true);
         }
@@ -885,7 +885,7 @@ public class HSSFCell extends CellBase {
         }
         FormulaRecordAggregate fra = ((FormulaRecordAggregate)_record);
         FormulaRecord fr = fra.getFormulaRecord();
-        switch (fr.getCachedResultTypeEnum()) {
+        switch (fr.getCachedResultType()) {
             case BOOLEAN:
                 return fr.getCachedBooleanValue() ? "TRUE" : "FALSE";
             case STRING:
@@ -1188,7 +1188,7 @@ public class HSSFCell extends CellBase {
             throw new IllegalStateException("Only formula cells have cached results");
         }
 
-        return ((FormulaRecordAggregate)_record).getFormulaRecord().getCachedResultTypeEnum();
+        return ((FormulaRecordAggregate)_record).getFormulaRecord().getCachedResultType();
     }
 
     void setCellArrayFormula(CellRangeAddress range) {

--- a/poi/src/test/java/org/apache/poi/hssf/record/TestFormulaRecord.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/TestFormulaRecord.java
@@ -87,8 +87,7 @@ final class TestFormulaRecord {
         assertEquals(0, record.getRow(), "Row");
         assertEquals(0, record.getColumn(), "Column");
         //noinspection deprecation
-        assertEquals(CellType.ERROR.getCode(), record.getCachedResultType());
-        assertEquals(CellType.ERROR, record.getCachedResultTypeEnum());
+        assertEquals(CellType.ERROR, record.getCachedResultType());
 
         byte[] output = record.serialize();
         // includes sid+recordlength


### PR DESCRIPTION
* was deprecated and due for removal and not in 6.0.0, we can switch it to return an enum value instead of int
* deprecated the temporary getCachedResultTypeEnum method that returned an enum