### PR TITLE
reduce use of setCellType

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFRow.java
@@ -111,7 +111,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
      * Use this to create new cells within the row and return it.
      * <p>
      * The cell that is returned is a {@link CellType#BLANK}. The type can be changed
-     * either through calling {@code setCellValue} or {@code setCellType}.
+     * either through calling {@code setCellValue} or {@code setCellFormula}.
      *
      * @param column - the column number this cell represents (zero-based)
      * @return Cell a high level representation of the created cell.
@@ -128,7 +128,7 @@ public class SXSSFRow implements Row, Comparable<SXSSFRow>
      * Use this to create new cells within the row and return it.
      * <p>
      * The cell that is returned is a {@link CellType#BLANK}. The type can be changed
-     * either through calling setCellValue or setCellType.
+     * either through calling setCellValue or setCellFormula.
      *
      * @param column - the column number this cell represents (zero-based)
      * @return Cell a high level representation of the created cell.

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
@@ -187,7 +187,7 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
      * Use this to create new cells within the row and return it.
      * <p>
      * The cell that is returned is a {@link CellType#BLANK}. The type can be changed
-     * either through calling {@code setCellValue} or {@code setCellType}.
+     * either through calling {@code setCellValue} or {@code setCellFormula}.
      * </p>
      * @param columnIndex - the column number this cell represents
      * @return Cell a high level representation of the created cell.

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFSheetShiftRowsAndColumns.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFSheetShiftRowsAndColumns.java
@@ -71,7 +71,6 @@ class TestXSSFSheetShiftRowsAndColumns {
             final XSSFRow row = sheet.createRow(nRow);
             for (int nCol = 0; nCol < numCols; ++nCol) {
                 final XSSFCell cell = row.createCell(nCol);
-                cell.setCellType(CellType.STRING);
                 cell.setCellValue(String.format(Locale.US, "Row %d col %d", nRow, nCol));
             }
         }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRow.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRow.java
@@ -114,7 +114,7 @@ public final class HSSFRow implements Row, Comparable<HSSFRow> {
      * Use this to create new cells within the row and return it.
      * <p>
      * The cell that is returned is a {@link CellType#BLANK}. The type can be changed
-     * either through calling <code>setCellValue</code> or <code>setCellType</code>.
+     * either through calling <code>setCellValue</code> or <code>setCellFormula</code>.
      *
      * @param column - the column number this cell represents
      *
@@ -125,7 +125,7 @@ public final class HSSFRow implements Row, Comparable<HSSFRow> {
     @Override
     public HSSFCell createCell(int column)
     {
-        return this.createCell(column,CellType.BLANK);
+        return this.createCell(column, CellType.BLANK);
     }
 
     /**
@@ -133,7 +133,7 @@ public final class HSSFRow implements Row, Comparable<HSSFRow> {
      * <p>
      * The cell that is returned will be of the requested type.
      * The type can be changed either through calling setCellValue
-     *  or setCellType, but there is a small overhead to doing this,
+     *  or setCellFormula, but there is a small overhead to doing this,
      *  so it is best to create the required type up front.
      *
      * @param columnIndex - the column number this cell represents

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Row.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Row.java
@@ -30,7 +30,7 @@ public interface Row extends Iterable<Cell> {
      * Use this to create new cells within the row and return it.
      * <p>
      * The cell that is returned is a {@link CellType#BLANK}. The type can be changed
-     * either through calling <code>setCellValue</code> or <code>setCellType</code>.
+     * either through calling <code>setCellValue</code> or <code>setCellFormula</code>.
      *
      * @param column - the column number this cell represents
      * @return Cell a high level representation of the created cell.
@@ -44,7 +44,7 @@ public interface Row extends Iterable<Cell> {
      * <p>
      * The cell that is returned will be of the requested type.
      * The type can be changed either through calling setCellValue 
-     *  or setCellType, but there is a small overhead to doing this,
+     *  or setCellFormula, but there is a small overhead to doing this,
      *  so it is best to create of the required type up front.
      *
      * @param column - the column number this cell represents


### PR DESCRIPTION
Method has been slated for removal for a while but it is still used.
Remove some references to it as a start.