### PR TITLE
Support SVGs in XSSF

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFPictureData.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFPictureData.java
@@ -57,7 +57,7 @@ public class XSSFPictureData extends POIXMLDocumentPart implements PictureData {
      */
     protected static final POIXMLRelation[] RELATIONS;
     static {
-        RELATIONS = new POIXMLRelation[13];
+        RELATIONS = new POIXMLRelation[15];
         RELATIONS[Workbook.PICTURE_TYPE_EMF] = XSSFRelation.IMAGE_EMF;
         RELATIONS[Workbook.PICTURE_TYPE_WMF] = XSSFRelation.IMAGE_WMF;
         RELATIONS[Workbook.PICTURE_TYPE_PICT] = XSSFRelation.IMAGE_PICT;
@@ -69,6 +69,7 @@ public class XSSFPictureData extends POIXMLDocumentPart implements PictureData {
         RELATIONS[XSSFWorkbook.PICTURE_TYPE_EPS] = XSSFRelation.IMAGE_EPS;
         RELATIONS[XSSFWorkbook.PICTURE_TYPE_BMP] = XSSFRelation.IMAGE_BMP;
         RELATIONS[XSSFWorkbook.PICTURE_TYPE_WPG] = XSSFRelation.IMAGE_WPG;
+		RELATIONS[XSSFWorkbook.PICTURE_TYPE_SVG] = XSSFRelation.IMAGE_SVG;
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRelation.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRelation.java
@@ -239,6 +239,13 @@ public final class XSSFRelation extends POIXMLRelation {
             XSSFPictureData::new, XSSFPictureData::new
     );
 
+	public static final XSSFRelation IMAGE_SVG = new XSSFRelation(
+			PictureData.PictureType.SVG.contentType,
+			PackageRelationshipTypes.IMAGE_PART,
+			"/xl/media/image#.svg",
+			XSSFPictureData::new, XSSFPictureData::new
+	);
+
     public static final XSSFRelation HDPHOTO_WDP = new XSSFRelation(
             PictureData.PictureType.WDP.contentType,
             PackageRelationshipTypes.HDPHOTO_PART,

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSignatureLine.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSignatureLine.java
@@ -126,6 +126,8 @@ public class XSSFSignatureLine extends SignatureLine {
                 return XSSFRelation.IMAGE_WMF;
             case WPG:
                 return XSSFRelation.IMAGE_WPG;
+			case SVG:
+				return XSSFRelation.IMAGE_SVG;
             default:
                 throw new InvalidFormatException("Unsupported picture format "+type);
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
@@ -122,6 +122,7 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
     public static final int PICTURE_TYPE_EPS = 10;
     public static final int PICTURE_TYPE_BMP = 11;
     public static final int PICTURE_TYPE_WPG = 12;
+	public static final int PICTURE_TYPE_SVG = 14;
 
     /**
      * The underlying XML bean
@@ -592,6 +593,12 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
      * @see Workbook#PICTURE_TYPE_JPEG
      * @see Workbook#PICTURE_TYPE_PNG
      * @see Workbook#PICTURE_TYPE_DIB
+	 * @see #PICTURE_TYPE_GIF
+	 * @see #PICTURE_TYPE_TIFF
+	 * @see #PICTURE_TYPE_EPS
+	 * @see #PICTURE_TYPE_BMP
+	 * @see #PICTURE_TYPE_WPG
+	 * @see #PICTURE_TYPE_SVG
      * @see #getAllPictures()
      */
     @Override
@@ -620,6 +627,12 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
      * @see Workbook#PICTURE_TYPE_JPEG
      * @see Workbook#PICTURE_TYPE_PNG
      * @see Workbook#PICTURE_TYPE_DIB
+	 * @see #PICTURE_TYPE_GIF
+	 * @see #PICTURE_TYPE_TIFF
+	 * @see #PICTURE_TYPE_EPS
+	 * @see #PICTURE_TYPE_BMP
+	 * @see #PICTURE_TYPE_WPG
+	 * @see #PICTURE_TYPE_SVG
      * @see #getAllPictures()
      */
     public int addPicture(InputStream is, int format) throws IOException {

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
@@ -122,6 +122,7 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
     public static final int PICTURE_TYPE_EPS = 10;
     public static final int PICTURE_TYPE_BMP = 11;
     public static final int PICTURE_TYPE_WPG = 12;
+	// Picture Type WDP has ooxmlId 13 but is currently not implemented
 	public static final int PICTURE_TYPE_SVG = 14;
 
     /**

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFPictureData.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFPictureData.java
@@ -148,8 +148,10 @@ public final class TestXSSFPictureData {
 		try (XSSFWorkbook wb = new XSSFWorkbook()) {
 			XSSFSheet sheet = wb.createSheet();
 			XSSFDrawing drawing = sheet.createDrawingPatriarch();
-
-			byte[] data = "test svg data".getBytes(LocaleUtil.CHARSET_1252);
+			String svg = "<svg viewBox='0 0 125 80' xmlns='http://www.w3.org/2000/svg'>"
+					+ "<text y=\"75\" font-size=\"100\" font-family=\"serif\"><![CDATA[10]]></text>"
+					+ "</svg>";
+			byte[] data = svg.getBytes(LocaleUtil.CHARSET_1252);
 
 			List<XSSFPictureData> pictures = wb.getAllPictures();
 			assertEquals(0, pictures.size());

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFPictureData.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFPictureData.java
@@ -143,6 +143,37 @@ public final class TestXSSFPictureData {
         }
     }
 
+	@Test
+	void testNewSvgFormat() throws IOException {
+		try (XSSFWorkbook wb = new XSSFWorkbook()) {
+			XSSFSheet sheet = wb.createSheet();
+			XSSFDrawing drawing = sheet.createDrawingPatriarch();
+
+			byte[] data = "test svg data".getBytes(LocaleUtil.CHARSET_1252);
+
+			List<XSSFPictureData> pictures = wb.getAllPictures();
+			assertEquals(0, pictures.size());
+
+			int idx = wb.addPicture(data, XSSFWorkbook.PICTURE_TYPE_SVG);
+			assertEquals(1, pictures.size());
+			assertEquals("svg", pictures.get(idx).suggestFileExtension());
+			assertArrayEquals(data, pictures.get(idx).getData());
+
+			//TODO finish usermodel API for XSSFPicture
+			XSSFPicture p1 = drawing.createPicture(new XSSFClientAnchor(), idx);
+			assertNotNull(p1);
+
+			//check that the added pictures are accessible after write
+			try (XSSFWorkbook wbBack = XSSFTestDataSamples.writeOutAndReadBack(wb)) {
+				List<XSSFPictureData> pictures2 = wbBack.getAllPictures();
+				assertEquals(1, pictures2.size());
+
+				assertEquals("svg", pictures2.get(idx).suggestFileExtension());
+				assertArrayEquals(data, pictures2.get(idx).getData());
+			}
+		}
+	}
+
     /**
      * Bug 53568:  XSSFPicture.getPictureData() can return null.
      */


### PR DESCRIPTION
Currently, adding SVGs to a XSSF Workbook is not supported.

I added this feature similarly to #607 (Support SVGs in XWPF) with a basic test.
Do you have any tipps / suggestions to write a better test for this feature?

I have locally tried it out, generating [svg_sample.xlsx](https://github.com/user-attachments/files/23775300/svg_sample.xlsx).

I have read [here](https://stackoverflow.com/questions/67666241/how-to-add-svg-image-to-xssfworkbook) that for full backwards compatibility, one would have to convert the SVG to a PNG, as Excel does it.
From my undestanding, the same should apply to the added feature in #607, so I decided to give it a try and open the PR similarly. Any thoughts on this?