### PR TITLE
remove pre-existing inline strings when updating value

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFCell.java
@@ -219,6 +219,7 @@ public final class XSSFCell extends CellBase {
      */
     @Override
     public void setCellValue(boolean value) {
+        removeInlineString();
         _cell.setT(STCellType.B);
         _cell.setV(value ? TRUE_AS_STRING : FALSE_AS_STRING);
     }
@@ -263,6 +264,7 @@ public final class XSSFCell extends CellBase {
 
     @Override
     public void setCellValueImpl(double value) {
+        removeInlineString();
         _cell.setT(STCellType.N);
         _cell.setV(String.valueOf(value));
     }
@@ -356,27 +358,23 @@ public final class XSSFCell extends CellBase {
 
     @Override
     protected void setCellValueImpl(RichTextString str) {
+        removeInlineString();
         CellType cellType = getCellType();
         if (cellType == CellType.FORMULA) {
             _cell.setV(str.getString());
             _cell.setT(STCellType.STR);
+        } else if (str instanceof XSSFRichTextString) {
+            _cell.setT(STCellType.S);
+            XSSFRichTextString rt = (XSSFRichTextString)str;
+            rt.setStylesTableReference(_stylesSource);
+            int sRef = _sharedStringSource.addSharedStringItem(rt);
+            _cell.setV(Integer.toString(sRef));
         } else {
-            if(_cell.getT() == STCellType.INLINE_STR) {
-                //set the 'pre-evaluated result
-                _cell.setV(str.getString());
-            } else if (str instanceof XSSFRichTextString) {
-                _cell.setT(STCellType.S);
-                XSSFRichTextString rt = (XSSFRichTextString)str;
-                rt.setStylesTableReference(_stylesSource);
-                int sRef = _sharedStringSource.addSharedStringItem(rt);
-                _cell.setV(Integer.toString(sRef));
-            } else {
-                _cell.setT(STCellType.S);
-                XSSFRichTextString rt = new XSSFRichTextString(str.getString());
-                rt.setStylesTableReference(_stylesSource);
-                int sRef = _sharedStringSource.addSharedStringItem(rt);
-                _cell.setV(Integer.toString(sRef));
-            }
+            _cell.setT(STCellType.S);
+            XSSFRichTextString rt = new XSSFRichTextString(str.getString());
+            rt.setStylesTableReference(_stylesSource);
+            int sRef = _sharedStringSource.addSharedStringItem(rt);
+            _cell.setV(Integer.toString(sRef));
         }
     }
 
@@ -518,6 +516,12 @@ public final class XSSFCell extends CellBase {
         if (_cell.isSetF()) {
             _row.getSheet().onDeleteFormula(this, null);
             _cell.unsetF();
+        }
+    }
+
+    private void removeInlineString() {
+        if (_cell.isSetIs()) {
+            _cell.unsetIs();
         }
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFCell.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFCell.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.apache.poi.common.usermodel.HyperlinkType;
@@ -776,16 +777,48 @@ public final class TestXSSFCell extends BaseTestXCell {
     }
 
     @Test
+    void setInlineStringToNewStringValue() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFSheet sheet = wb.createSheet();
+            XSSFCell cell = sheet.createRow(0).createCell(0);
+            setInlineString(cell, "text123");
+            cell.setCellValue("newValue");
+            assertEquals("newValue", cell.getStringCellValue());
+            assertFalse(cell.getCTCell().isSetIs(), "cell has InlineString XML struct still?");
+        }
+    }
+
+    @Test
+    void setInlineStringToNewNumberValue() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFSheet sheet = wb.createSheet();
+            XSSFCell cell = sheet.createRow(0).createCell(0);
+            setInlineString(cell, "text123");
+            cell.setCellValue(123.456d);
+            assertEquals(123.456d, cell.getNumericCellValue());
+            assertFalse(cell.getCTCell().isSetIs(), "cell has InlineString XML struct still?");
+        }
+    }
+
+    @Test
+    void setInlineStringToNewLocalDateValue() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFSheet sheet = wb.createSheet();
+            XSSFCell cell = sheet.createRow(0).createCell(0);
+            setInlineString(cell, "text123");
+            LocalDateTime ldt = LocalDateTime.parse("2025-12-18T19:01:34");
+            cell.setCellValue(ldt);
+            assertEquals(ldt, cell.getLocalDateTimeCellValue());
+            assertFalse(cell.getCTCell().isSetIs(), "cell has InlineString XML struct still?");
+        }
+    }
+
+    @Test
     void setInlineStringToBlank() throws IOException {
         try (XSSFWorkbook wb = new XSSFWorkbook()) {
             XSSFSheet sheet = wb.createSheet();
             XSSFCell cell = sheet.createRow(0).createCell(0);
-            cell.setCellType(CellType.STRING);
-            CTRst rst = CTRst.Factory.newInstance();
-            rst.setT("text123");
-            cell.getCTCell().setT(STCellType.INLINE_STR);
-            cell.getCTCell().setIs(rst);
-            assertEquals("text123", cell.getStringCellValue());
+            setInlineString(cell, "text123");
             cell.setCellType(CellType.BLANK);
             assertEquals("", cell.getStringCellValue());
             assertFalse(cell.getCTCell().isSetIs(), "cell has InlineString XML struct still?");
@@ -806,5 +839,14 @@ public final class TestXSSFCell extends BaseTestXCell {
             assertEquals("", cell.getStringCellValue());
             assertFalse(cell.getCTCell().isSetF(), "cell has formula XML struct still?");
         }
+    }
+
+    private static void setInlineString(XSSFCell cell, String text) {
+        cell.setCellType(CellType.STRING);
+        CTRst rst = CTRst.Factory.newInstance();
+        rst.setT(text);
+        cell.getCTCell().setT(STCellType.INLINE_STR);
+        cell.getCTCell().setIs(rst);
+        assertEquals(text, cell.getStringCellValue());
     }
 }


### PR DESCRIPTION
* relates to https://bz.apache.org/bugzilla/show_bug.cgi?id=69896
* we don't really support setting the cell value as an inline string for XSSFCell (this might be useful but noone is requesting it)
* the new string/rich-string values are stored as Shared Strings
* this change tries to ensure that we don't leave behind any stray inline strings when we update cell values