### PR TITLE
Workbook getsheetname logs a warning for exceeding 31 characters

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
@@ -1213,11 +1213,29 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
      * If there are multiple matches, the first sheet from the list
      * of sheets is returned.
      *
+     * <p>
+     * Note that Excel and the underlying Apache POI library limit sheet names
+     * to **31 characters**. This method will throw an exception if the
+     * provided {@code name} is longer than 31 characters, as such a sheet
+     * cannot exist in a valid Excel workbook.
+     * </p>
+     *
      * @param name of the sheet
      * @return XSSFSheet with the name provided or {@code null} if it does not exist
+     * @throws IllegalArgumentException if the sheet name is longer than 31 characters
      */
     @Override
     public XSSFSheet getSheet(String name) {
+
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+
+        if(name.length() > MAX_SENSITIVE_SHEET_NAME_LEN) {
+            throw new IllegalArgumentException("Sheet name must not be longer than " +
+                    MAX_SENSITIVE_SHEET_NAME_LEN + " characters. Otherwise it cannot exist in Excel.");
+        }
+
         for (XSSFSheet sheet : sheets) {
             if (name.equalsIgnoreCase(sheet.getSheetName())) {
                 return sheet;

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
@@ -1245,6 +1245,26 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
         }
     }
 
+    /**
+     * Getting a sheet by name that exceeds 31 characters should throw
+     * an IllegalArgumentException
+     */
+    @Test
+    void testGetSheetWithNameExceeding31Characters() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+
+            // Attempting to GET a sheet with a name > 31 chars should throw
+            String sheetName = "ThisIsAVeryLongSheetNameExceeding31Chars";
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> wb.getSheet(sheetName),
+                    "getSheet() should reject names longer than 31 characters"
+            );
+
+            assertTrue(exception.getMessage().contains("31 characters"));
+        }
+    }
+
     @Test
     void test501RC1Failure() throws Exception {
         String filename = "0-www-crossref-org.lib.rivier.edu_education-files_suffix-generator.xlsm";

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -1061,11 +1061,30 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
      * If there are multiple matches, the first sheet from the list
      * of sheets is returned.
      *
+     * <p>
+     *     Note that Excel limits sheet names to 31 characters. If you try to look up
+     *     a sheet by a name longer than that, a warning will be logged, since
+     *     such a sheet cannot exist in Excel and the lookup will likely return {@code null}.
+     * </p>
+     *
      * @param name of the sheet
      * @return HSSFSheet with the name provided or {@code null} if it does not exist
      */
     @Override
     public HSSFSheet getSheet(String name) {
+
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+
+        if(name.length() > MAX_SENSITIVE_SHEET_NAME_LEN) {
+            LOGGER.atWarn().log(
+                    "Sheet lookup requested with name '{}' which exceeds Excel's {} character limit. " +
+                            "Sheets are stored with truncated names, so this lookup will likely return null.",
+                    name, MAX_SENSITIVE_SHEET_NAME_LEN
+            );
+        }
+
         for (int k = 0; k < _sheets.size(); k++) {
             String sheetname = workbook.getSheetName(k);
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -1062,13 +1062,15 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
      * of sheets is returned.
      *
      * <p>
-     *     Note that Excel limits sheet names to 31 characters. If you try to look up
-     *     a sheet by a name longer than that, a warning will be logged, since
-     *     such a sheet cannot exist in Excel and the lookup will likely return {@code null}.
+     * Note that Excel and the underlying Apache POI library limit sheet names
+     * to **31 characters**. This method will throw an exception if the
+     * provided {@code name} is longer than 31 characters, as such a sheet
+     * cannot exist in a valid Excel workbook.
      * </p>
      *
      * @param name of the sheet
      * @return HSSFSheet with the name provided or {@code null} if it does not exist
+     * @throws IllegalArgumentException if the sheet name is longer than 31 characters
      */
     @Override
     public HSSFSheet getSheet(String name) {
@@ -1078,11 +1080,8 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
         }
 
         if(name.length() > MAX_SENSITIVE_SHEET_NAME_LEN) {
-            LOGGER.atWarn().log(
-                    "Sheet lookup requested with name '{}' which exceeds Excel's {} character limit. " +
-                            "Sheets are stored with truncated names, so this lookup will likely return null.",
-                    name, MAX_SENSITIVE_SHEET_NAME_LEN
-            );
+            throw new IllegalArgumentException("Sheet name must not be longer than " +
+                    MAX_SENSITIVE_SHEET_NAME_LEN + " characters. Otherwise it cannot exist in Excel.");
         }
 
         for (int k = 0; k < _sheets.size(); k++) {

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
@@ -395,21 +395,23 @@ public final class TestHSSFWorkbook extends BaseTestWorkbook {
         }
     }
 
+    /**
+     * Getting a sheet by name that exceeds 31 characters should throw
+     * an IllegalArgumentException
+     */
     @Test
-    void searchSheetExceed31CharactersName() throws IOException {
-        String sheetName = "ThisIsAVeryLongSheetNameExceeding31Chars";
-
+    void testGetSheetWithNameExceeding31Characters() throws IOException {
         try (HSSFWorkbook wb = new HSSFWorkbook()) {
-            wb.createSheet(sheetName);
 
-            // Sheet name is truncated to 31 characters
-            Sheet sheetByOriginalName = wb.getSheet(sheetName);
-            assertNull(sheetByOriginalName, "Sheet lookup using original name >31 chars must return null");
+            // Attempting to GET a sheet with a name > 31 chars should throw
+            String sheetName = "ThisIsAVeryLongSheetNameExceeding31Chars";
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> wb.getSheet(sheetName),
+                    "getSheet() should reject names longer than 31 characters"
+            );
 
-            // Truncated name SHOULD resolve
-            String truncated = sheetName.substring(0, 31);
-            Sheet sheetByTruncatedName = wb.getSheet(truncated);
-            assertNotNull(sheetByTruncatedName, "Sheet lookup using truncated name must return the sheet");
+            assertTrue(exception.getMessage().contains("31 characters"));
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
@@ -395,6 +395,24 @@ public final class TestHSSFWorkbook extends BaseTestWorkbook {
         }
     }
 
+    @Test
+    void searchSheetExceed31CharactersName() throws IOException {
+        String sheetName = "ThisIsAVeryLongSheetNameExceeding31Chars";
+
+        try (HSSFWorkbook wb = new HSSFWorkbook()) {
+            wb.createSheet(sheetName);
+
+            // Sheet name is truncated to 31 characters
+            Sheet sheetByOriginalName = wb.getSheet(sheetName);
+            assertNull(sheetByOriginalName, "Sheet lookup using original name >31 chars must return null");
+
+            // Truncated name SHOULD resolve
+            String truncated = sheetName.substring(0, 31);
+            Sheet sheetByTruncatedName = wb.getSheet(truncated);
+            assertNotNull(sheetByTruncatedName, "Sheet lookup using truncated name must return the sheet");
+        }
+    }
+
     /**
      * Checks that us and HSSFName play nicely with named ranges
      *  that point to deleted sheets


### PR DESCRIPTION
### Summary

This PR addresses the issue of silent sheet name truncation caused by the **Apache POI 31-character limit** (referenced in #966). This limit applies to sheet names in both **HSSF (.xls)** and **XSSF (.xlsx)** workbooks.

The primary goal is to **strictly enforce** the 31-character limit by throwing an `IllegalArgumentException` immediately when a user attempts to retrieve a sheet using an excessively long name. This prevents unexpected behavior (like silent truncation and potential `null` returns) by forcing users to adhere to the Excel standard.

### Changes Implemented

* **Behavior Change (API Enforcement):** The sheet retrieval methods (`getSheet(String name)`) for both **HSSF** and **XSSF** implementations have been updated to **throw an `IllegalArgumentException`** if the provided sheet name exceeds 31 characters. This prevents invalid input from proceeding across both formats.
* **Documentation Update:** Updated the Javadoc/method comments for the affected method(s) in both HSSF and XSSF layers to clearly document the 31-character limitation and explicitly state the new **`@throws IllegalArgumentException`** clause.
* **Test Case Included:** Updated the unit test (`testGetSheetWithNameExceeding31Characters`) to use `assertThrows` and **verify that the `IllegalArgumentException` is correctly thrown** when a name longer than 31 characters is used (ideally with tests covering both HSSF and XSSF contexts).

### Testing

I have validated these changes locally and included a dedicated test case to verify the new exception behavior. The core functionality of retrieving sheets with valid names remains unchanged across both formats.

### Feedback Requested

This change represents a move toward stricter API input validation. Please review the updated Javadoc and the structure of the `IllegalArgumentException` for both the HSSF and XSSF implementations to ensure they align with the project's standards. I am ready to implement any further changes required before merging.