### PR TITLE
Add methods to manage first slide number(firstSlideNum)

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
@@ -748,4 +748,48 @@ public class XMLSlideShow extends POIXMLDocument
         RelationPart rp = target.addRelation(null, XSLFRelation.IMAGES, pictureData);
         return rp.getRelationship().getId();
     }
+
+    /**
+     * Returns the number that shall be displayed on the first slide of the presentation.
+     * Subsequent slides will be numbered sequentially from this number.
+     * The default value is 1 if the property is not set in the presentation file.
+     *
+     * @return The starting number for the first slide (default is 1).
+     */
+    public int getFirstSlideNumber() {
+        // CTPresentation.getFirstSlideNum() returns the default value of 1
+        // if the 'firstSlideNum' attribute is not set, as per OOXML standard.
+        return getCTPresentation().getFirstSlideNum();
+    }
+
+    /**
+     * Sets the custom number that shall be displayed on the first slide of the presentation.
+     * Subsequent slides will be numbered sequentially from this number.
+     *
+     * The value is restricted to the range [0, 9999] as defined in the Microsoft Office
+     * Implementation Information for ISO/IEC 29500 (MS-OI29500), specifically in
+     * Part 1, Section 19.2.1.26, presentation (Presentation), which restricts the
+     * XML Schema int datatype.
+     *
+     * @param num The starting number for the first slide (must be between 0 and 9999).
+     * @throws IllegalArgumentException if the provided number is outside the allowed range [0, 9999].
+     */
+    public void setFirstSlideNumber(int num) {
+        // We enforce the PowerPoint application constraint (0 <= num <= 9999)
+        // to ensure that a valid file, as rendered by PowerPoint, is created.
+        if (num < 0 || num > 9999) {
+            throw new IllegalArgumentException(
+                    "First slide number must be between 0 and 9999 (inclusive), as required by MS-OI29500 (Part 1, Section 19.2.1.26).");
+        }
+        // Sets the attribute on the underlying CTPresentation object.
+        getCTPresentation().setFirstSlideNum(num);
+    }
+
+    /**
+     * Unsets the custom first slide number, reverting the numbering to the default (1).
+     * This removes the 'firstSlideNum' attribute from presentation.xml.
+     */
+    public void unsetFirstSlideNumber() {
+        getCTPresentation().unsetFirstSlideNum();
+    }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
@@ -755,6 +755,7 @@ public class XMLSlideShow extends POIXMLDocument
      * The default value is 1 if the property is not set in the presentation file.
      *
      * @return The starting number for the first slide (default is 1).
+     * @since 6.0.0
      */
     public int getFirstSlideNumber() {
         // CTPresentation.getFirstSlideNum() returns the default value of 1
@@ -773,6 +774,7 @@ public class XMLSlideShow extends POIXMLDocument
      *
      * @param num The starting number for the first slide (must be between 0 and 9999).
      * @throws IllegalArgumentException if the provided number is outside the allowed range [0, 9999].
+     * @since 6.0.0
      */
     public void setFirstSlideNumber(int num) {
         // We enforce the PowerPoint application constraint (0 <= num <= 9999)
@@ -788,6 +790,7 @@ public class XMLSlideShow extends POIXMLDocument
     /**
      * Unsets the custom first slide number, reverting the numbering to the default (1).
      * This removes the 'firstSlideNum' attribute from presentation.xml.
+     * @since 6.0.0
      */
     public void unsetFirstSlideNumber() {
         getCTPresentation().unsetFirstSlideNum();

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
@@ -16,10 +16,6 @@
 ==================================================================== */
 package org.apache.poi.xslf.usermodel;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.io.ByteArrayInputStream;
@@ -33,6 +29,8 @@ import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.sl.usermodel.Placeholder;
 import org.apache.poi.xslf.XSLFTestDataSamples;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class TestXSLFSlideShow {
     @Test
@@ -325,6 +323,98 @@ class TestXSLFSlideShow {
             for (SlideLayout sl : layTypes){
                 assertNotNull(ppt.getSlideMasters().get(0).getLayout(sl));
             }
+        }
+    }
+
+    /**
+     * Test getting the first slide number, which defaults to 1.
+     * The first slide number is stored in the presentation.xml part.
+     */
+    @Test
+    void testGetFirstSlideNumberDefault() throws IOException {
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            // Default value when attribute is not present should be 1 (as per OOXML standard and CTPresentation logic)
+            assertEquals(1, ppt.getFirstSlideNumber());
+        }
+    }
+
+    /**
+     * Test setting, getting, and persisting the custom first slide number.
+     */
+    @Test
+    void testSetAndPersistFirstSlideNumber() throws IOException {
+        final int customStartNum = 5;
+        final int zeroStartNum = 0;
+        final int maxStartNum = 9999;
+
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            // 1. Set to a custom positive number (e.g., 5)
+            ppt.setFirstSlideNumber(customStartNum);
+            assertEquals(customStartNum, ppt.getFirstSlideNumber());
+
+            // Check persistence by writing out and reading back
+            try (XMLSlideShow ppt2 = XSLFTestDataSamples.writeOutAndReadBack(ppt)) {
+                assertEquals(customStartNum, ppt2.getFirstSlideNumber(),
+                        "The custom first slide number should persist after save/load.");
+            }
+
+            // 2. Set to minimum valid number (0)
+            ppt.setFirstSlideNumber(zeroStartNum);
+            assertEquals(zeroStartNum, ppt.getFirstSlideNumber());
+
+            // 3. Set to maximum valid number (9999)
+            ppt.setFirstSlideNumber(maxStartNum);
+            assertEquals(maxStartNum, ppt.getFirstSlideNumber());
+        }
+    }
+
+    /**
+     * Test unsetting the first slide number, which should revert it to the default (1).
+     */
+    @Test
+    void testUnsetFirstSlideNumber() throws IOException {
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            // 1. Set a custom number
+            ppt.setFirstSlideNumber(50);
+            assertEquals(50, ppt.getFirstSlideNumber());
+
+            // 2. Unset it
+            ppt.unsetFirstSlideNumber();
+
+            // It should return the default value (1) after unsetting
+            assertEquals(1, ppt.getFirstSlideNumber(),
+                    "Unsetting the first slide number should revert it to the default of 1.");
+
+            // Check persistence after unsetting
+            try (XMLSlideShow ppt2 = XSLFTestDataSamples.writeOutAndReadBack(ppt)) {
+                assertEquals(1, ppt2.getFirstSlideNumber(),
+                        "The first slide number should remain the default (1) after unset and save/load.");
+                // Ensure the attribute is actually removed from the CTPresentation object
+                // Note: We access the internal object to confirm removal, which is acceptable in test code.
+                assertFalse(ppt2.getCTPresentation().isSetFirstSlideNum(),
+                        "The 'firstSlideNum' attribute should be unset (removed) in the XML.");
+            }
+        }
+    }
+
+    /**
+     * Test that setting an invalid first slide number (outside [0, 9999]) throws an exception.
+     */
+    @Test
+    void testSetFirstSlideNumberValidation() throws IOException {
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            // Test case: Negative number
+            assertThrows(IllegalArgumentException.class, () ->
+                            ppt.setFirstSlideNumber(-1),
+                    "Negative number should throw IllegalArgumentException.");
+
+            // Test case: Number greater than 9999
+            assertThrows(IllegalArgumentException.class, () ->
+                            ppt.setFirstSlideNumber(10000),
+                    "Number greater than 9999 should throw IllegalArgumentException.");
+
+            // Ensure the value hasn't changed from the default after failed attempts
+            assertEquals(1, ppt.getFirstSlideNumber());
         }
     }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
@@ -30,8 +30,11 @@ import org.apache.poi.sl.usermodel.Placeholder;
 import org.apache.poi.xslf.XSLFTestDataSamples;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 class TestXSLFSlideShow {
     @Test
     void testCreateSlide() throws IOException {

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlideShow.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 class TestXSLFSlideShow {
     @Test
     void testCreateSlide() throws IOException {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2 data-path-to-node="4" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Feature(XSLF): Add Methods to Manage Custom Starting Slide Number</h2><p data-path-to-node="5" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">This Pull Request introduces new user-friendly methods within <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">XMLSlideShow</code> to manage the custom starting slide number of a PowerPoint presentation, corresponding to the <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">firstSlideNum</code> attribute in <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">ppt/presentation.xml</code>.</p><h3 data-path-to-node="6" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Changes Summary</h3>
<li><code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">getFirstSlideNumber()</code>: Retrieves the current starting slide number (default is 1).
<li><code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">setFirstSlideNumber(int num)</code>: Sets the custom starting slide number.
<li><code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">unsetFirstSlideNumber()</code>: Removes the firstSlideNum attribute, reverting to the default (1).

<h3 data-path-to-node="8" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">🔍 Rationale for Adding High-Level API</h3><p data-path-to-node="9" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Although the underlying XMLBeans class (<code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">org.openxmlformats.schemas.presentationml.x2006.main.CTPresentation</code>) already contains low-level methods to manipulate <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">firstSlideNum</code>, we propose wrapping this functionality in <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">XMLSlideShow</code> for two critical reasons, aligning with POI's core design principles:</p><h4 data-path-to-node="10" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">1. Abstraction and API Usability</h4><p data-path-to-node="11" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">The first slide number is a standard, user-facing configuration option in Microsoft PowerPoint. Providing a high-level API prevents users from needing to manually retrieve and manipulate the internal <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">CTPresentation</code> object. This promotes cleaner, more readable code and shields developers from complex OOXML schema details.</p><h4 data-path-to-node="12" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">2. Enforcing Application Constraints (Data Validation)</h4><p data-path-to-node="13" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">The low-level <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">CTPresentation</code> methods adhere strictly to the general XML Schema definition (allowing any <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">int</code> value), but they <b style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">do not</b> enforce the specific constraints required by the PowerPoint application.</p><ul data-path-to-node="14" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="14,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Constraint:</b> Microsoft PowerPoint restricts the value of the <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">firstSlideNum</code> attribute to the bounds <b style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">[0, 9999]</b>.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="14,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><b style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Official Reference:</b> This restriction is documented in the Microsoft Open Specifications: <b style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">MS-OI29500 (Part 1, Section 19.2.1.26, presentation (Presentation))</b>.</p></li></ul><p data-path-to-node="15" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">By implementing <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">setFirstSlideNumber(int num)</code> at the <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">XMLSlideShow</code> level, POI can validate the input against the <b style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">PowerPoint application constraints</b>. This ensures that the files created by POI are guaranteed to be considered valid and correctly rendered by Microsoft Office, improving data integrity and user experience.</p><h3 data-path-to-node="16" style="font-family: &quot;Google Sans&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Testing</h3><p data-path-to-node="17" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">The feature is covered by new test methods in <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">TestXSLFSlideShow.java</code> which verify:</p><ul data-path-to-node="18" style="padding-inline-start: 32px; font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="18,0,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Default value and persistence.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="18,1,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Successful setting of boundary values (0 and 9999).</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="18,2,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Correct behavior of <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">unsetFirstSlideNumber()</code>.</p></li><li style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;"><p data-path-to-node="18,3,0" style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Validation logic by throwing <code style="font-family: &quot;Google Sans Text&quot;, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">IllegalArgumentException</code> for values outside the [0, 9999] range.</p></li></ul></body></html><!--EndFragment-->
</body>
</html>