### PR TITLE
XWPF Themes: allow public access of theme and add helpers for theme fonts

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
@@ -29,6 +29,7 @@ import org.openxmlformats.schemas.drawingml.x2006.main.CTColor;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTColorScheme;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTFontCollection;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTOfficeStyleSheet;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTSupplementalFont;
 import org.openxmlformats.schemas.drawingml.x2006.main.ThemeDocument;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.*;
 
@@ -146,8 +147,10 @@ public class XWPFTheme extends POIXMLDocumentPart {
      *
      */
     @SuppressWarnings("WeakerAccess")
-    public String getMajorFont(){
-        return _theme.getThemeElements().getFontScheme().getMajorFont().getLatin().getTypeface();
+    public String getMajorFont() {
+        CTFontCollection majorFonts = getMajorFonts();
+        return majorFonts == null || majorFonts.getLatin() == null ?
+                null : majorFonts.getLatin().getTypeface();
     }
 
     /**
@@ -156,8 +159,10 @@ public class XWPFTheme extends POIXMLDocumentPart {
      *
      */
     @SuppressWarnings("WeakerAccess")
-    public String getMinorFont(){
-        return _theme.getThemeElements().getFontScheme().getMinorFont().getLatin().getTypeface();
+    public String getMinorFont() {
+        CTFontCollection minorFonts = getMinorFonts();
+        return minorFonts == null || minorFonts.getLatin() == null ?
+                null : minorFonts.getLatin().getTypeface();
     }
 
     /**
@@ -166,14 +171,8 @@ public class XWPFTheme extends POIXMLDocumentPart {
      * @since 6.0.0
      */
     public String getMajorFontForScript(String script) {
-        if (_theme == null
-            || _theme.getThemeElements() == null
-            || _theme.getThemeElements().getFontScheme() == null
-            || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
-            return null;
-        }
-        String majorFonts = _theme.getThemeElements().getFontScheme().getMajorFont();
-        return getFontTypeface(majorFonts, script);
+        CTFontCollection majorFonts = getMajorFonts();
+        return majorFonts == null ? null : getFontTypeface(majorFonts, script);
     }
 
     /**
@@ -182,20 +181,34 @@ public class XWPFTheme extends POIXMLDocumentPart {
      * @since 6.0.0
      */
     public String getMinorFontForScript(String script) {
+        CTFontCollection minorFonts = getMinorFonts();
+        return minorFonts == null ? null : getFontTypeface(minorFonts, script);
+    }
+
+    private CTFontCollection getMajorFonts() {
         if (_theme == null
-            || _theme.getThemeElements() == null
-            || _theme.getThemeElements().getFontScheme() == null
-            || _theme.getThemeElements().getFontScheme().getMinorFont() == null) {
+                || _theme.getThemeElements() == null
+                || _theme.getThemeElements().getFontScheme() == null
+                || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
             return null;
         }
-        String minorFonts = _theme.getThemeElements().getFontScheme().getMinorFont();
-        return getFontTypeface(minorFonts, script);
+        return _theme.getThemeElements().getFontScheme().getMajorFont();
+    }
+
+    private CTFontCollection getMinorFonts() {
+        if (_theme == null
+                || _theme.getThemeElements() == null
+                || _theme.getThemeElements().getFontScheme() == null
+                || _theme.getThemeElements().getFontScheme().getMinorFont() == null) {
+            return null;
+        }
+        return _theme.getThemeElements().getFontScheme().getMinorFont();
     }
 
     private static String getFontTypeface(CTFontCollection fontCollection, String script) {
-        var fonts = fontCollection.getFontArray();
+        CTSupplementalFont[] fonts = fontCollection.getFontArray();
         if (fonts != null) {
-            for (var font : fonts) {
+            for (CTSupplementalFont font : fonts) {
                 if (font.getScript() != null && font.getScript().equals(script)) {
                     return font.getTypeface();
                 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
@@ -165,7 +165,7 @@ public class XWPFTheme extends POIXMLDocumentPart {
      * @return typeface of the major font for the given script
      * @since 6.0.0
      */
-    public String getMajorFontForScript(String script){
+    public String getMajorFontForScript(String script) {
     if (_theme == null
         || _theme.getThemeElements() == null
         || _theme.getThemeElements().getFontScheme() == null

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
@@ -27,6 +27,7 @@ import org.apache.xmlbeans.XmlOptions;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTBaseStyles;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTColor;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTColorScheme;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTFontCollection;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTOfficeStyleSheet;
 import org.openxmlformats.schemas.drawingml.x2006.main.ThemeDocument;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.*;
@@ -65,6 +66,42 @@ public class XWPFTheme extends POIXMLDocumentPart {
     @SuppressWarnings("WeakerAccess")
     public void importTheme(XSLFTheme theme) {
         _theme = theme.getXmlObject();
+    }
+
+    public CTOfficeStyleSheet getCTStyleSheet() {
+        return _theme;
+    }
+
+    public String getMajorFontForScript(String script){
+        if (_theme == null
+            || _theme.getThemeElements() == null
+            || _theme.getThemeElements().getFontScheme() == null
+            || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
+            return null;
+        }
+        var majorFonts = _theme.getThemeElements().getFontScheme().getMajorFont();
+        return getFontTypeface(majorFonts, script);
+    }
+
+    public String getMinorFontForScript(String script){
+        if (_theme == null
+            || _theme.getThemeElements() == null
+            || _theme.getThemeElements().getFontScheme() == null
+            || _theme.getThemeElements().getFontScheme().getMinorFont() == null) {
+            return null;
+        }
+        var minorFonts = _theme.getThemeElements().getFontScheme().getMinorFont();
+        return getFontTypeface(minorFonts, script);
+    }
+
+    private static String getFontTypeface(CTFontCollection fontCollection, String script) {
+        var fonts = fontCollection.getFontArray();
+        for (var font : fonts) {
+            if (font.getScript() != null && font.getScript().equals(script)) {
+                return font.getTypeface();
+            }
+        }
+        return null;
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
@@ -68,40 +68,12 @@ public class XWPFTheme extends POIXMLDocumentPart {
         _theme = theme.getXmlObject();
     }
 
+    /**
+     * @return the underlying CTOfficeStyleSheet instance.
+     * @since 6.0.0
+     */
     public CTOfficeStyleSheet getCTOfficeStyleSheet() {
         return _theme;
-    }
-
-    public String getMajorFontForScript(String script){
-        if (_theme == null
-            || _theme.getThemeElements() == null
-            || _theme.getThemeElements().getFontScheme() == null
-            || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
-            return null;
-        }
-        var majorFonts = _theme.getThemeElements().getFontScheme().getMajorFont();
-        return getFontTypeface(majorFonts, script);
-    }
-
-    public String getMinorFontForScript(String script){
-        if (_theme == null
-            || _theme.getThemeElements() == null
-            || _theme.getThemeElements().getFontScheme() == null
-            || _theme.getThemeElements().getFontScheme().getMinorFont() == null) {
-            return null;
-        }
-        var minorFonts = _theme.getThemeElements().getFontScheme().getMinorFont();
-        return getFontTypeface(minorFonts, script);
-    }
-
-    private static String getFontTypeface(CTFontCollection fontCollection, String script) {
-        var fonts = fontCollection.getFontArray();
-        for (var font : fonts) {
-            if (font.getScript() != null && font.getScript().equals(script)) {
-                return font.getTypeface();
-            }
-        }
-        return null;
     }
 
     /**
@@ -186,6 +158,48 @@ public class XWPFTheme extends POIXMLDocumentPart {
     @SuppressWarnings("WeakerAccess")
     public String getMinorFont(){
         return _theme.getThemeElements().getFontScheme().getMinorFont().getLatin().getTypeface();
+    }
+
+    /**
+     * @param script a 4-letter script code, e.g. "Latn", "Jpan"
+     * @return typeface of the major font for the given script
+     * @since 6.0.0
+     */
+    public String getMajorFontForScript(String script){
+    if (_theme == null
+        || _theme.getThemeElements() == null
+        || _theme.getThemeElements().getFontScheme() == null
+        || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
+        return null;
+    }
+    var majorFonts = _theme.getThemeElements().getFontScheme().getMajorFont();
+    return getFontTypeface(majorFonts, script);
+    }
+
+    /**
+     * @param script a 4-letter script code, e.g. "Latn", "Jpan"
+     * @return typeface of the minor font for the given script
+     * @since 6.0.0
+     */
+    public String getMinorFontForScript(String script){
+        if (_theme == null
+            || _theme.getThemeElements() == null
+            || _theme.getThemeElements().getFontScheme() == null
+            || _theme.getThemeElements().getFontScheme().getMinorFont() == null) {
+            return null;
+        }
+        var minorFonts = _theme.getThemeElements().getFontScheme().getMinorFont();
+        return getFontTypeface(minorFonts, script);
+    }
+
+    private static String getFontTypeface(CTFontCollection fontCollection, String script) {
+        var fonts = fontCollection.getFontArray();
+        for (var font : fonts) {
+            if (font.getScript() != null && font.getScript().equals(script)) {
+                return font.getTypeface();
+            }
+        }
+        return null;
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
@@ -166,14 +166,14 @@ public class XWPFTheme extends POIXMLDocumentPart {
      * @since 6.0.0
      */
     public String getMajorFontForScript(String script) {
-    if (_theme == null
-        || _theme.getThemeElements() == null
-        || _theme.getThemeElements().getFontScheme() == null
-        || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
-        return null;
-    }
-    var majorFonts = _theme.getThemeElements().getFontScheme().getMajorFont();
-    return getFontTypeface(majorFonts, script);
+        if (_theme == null
+            || _theme.getThemeElements() == null
+            || _theme.getThemeElements().getFontScheme() == null
+            || _theme.getThemeElements().getFontScheme().getMajorFont() == null) {
+            return null;
+        }
+        String majorFonts = _theme.getThemeElements().getFontScheme().getMajorFont();
+        return getFontTypeface(majorFonts, script);
     }
 
     /**
@@ -181,22 +181,24 @@ public class XWPFTheme extends POIXMLDocumentPart {
      * @return typeface of the minor font for the given script
      * @since 6.0.0
      */
-    public String getMinorFontForScript(String script){
+    public String getMinorFontForScript(String script) {
         if (_theme == null
             || _theme.getThemeElements() == null
             || _theme.getThemeElements().getFontScheme() == null
             || _theme.getThemeElements().getFontScheme().getMinorFont() == null) {
             return null;
         }
-        var minorFonts = _theme.getThemeElements().getFontScheme().getMinorFont();
+        String minorFonts = _theme.getThemeElements().getFontScheme().getMinorFont();
         return getFontTypeface(minorFonts, script);
     }
 
     private static String getFontTypeface(CTFontCollection fontCollection, String script) {
         var fonts = fontCollection.getFontArray();
-        for (var font : fonts) {
-            if (font.getScript() != null && font.getScript().equals(script)) {
-                return font.getTypeface();
+        if (fonts != null) {
+            for (var font : fonts) {
+                if (font.getScript() != null && font.getScript().equals(script)) {
+                    return font.getTypeface();
+                }
             }
         }
         return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTheme.java
@@ -68,7 +68,7 @@ public class XWPFTheme extends POIXMLDocumentPart {
         _theme = theme.getXmlObject();
     }
 
-    public CTOfficeStyleSheet getCTStyleSheet() {
+    public CTOfficeStyleSheet getCTOfficeStyleSheet() {
         return _theme;
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFTheme.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFTheme.java
@@ -21,11 +21,13 @@ import org.apache.poi.xslf.usermodel.XSLFColor;
 import org.apache.poi.xwpf.XWPFTestDataSamples;
 import org.junit.jupiter.api.Test;
 import org.openxmlformats.schemas.drawingml.x2006.main.CTColor;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTOfficeStyleSheet;
 
 import java.awt.*;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class TestXWPFTheme {
 
@@ -36,6 +38,11 @@ public final class TestXWPFTheme {
             assertEquals("Office Theme", theme.getName());
             assertEquals("Cambria", theme.getMajorFont());
             assertEquals("Calibri", theme.getMinorFont());
+            assertEquals("Angsana New", theme.getMajorFontForScript("Thai"));
+            assertEquals("Cordia New", theme.getMinorFontForScript("Thai"));
+            CTOfficeStyleSheet styleSheet = theme.getCTOfficeStyleSheet();
+            assertNotNull(styleSheet);
+            assertEquals("Office", styleSheet.getThemeElements().getFontScheme().getName());
             CTColor accent1 = theme.getCTColor("accent1");
             XSLFColor color = new XSLFColor(accent1, null, null, null);
             assertEquals(new Color(79, 129, 189), color.getColor());


### PR DESCRIPTION
# Context
I'd like to better support DOCX theme fonts, but currently they are inaccessible.

For anyone interested, a run can define fonts either
- directly `w:ascii="Times New Roman"`
- indirectly via a theme for example `w:asciiTheme="majorBidi"`

Currently the XWPFTheme doesn't expose major/minor fonts to resolve theme fonts, so I am fixing that in this PR.



Note: I spent a bit of time figuring out how the theme fonts are resolved and although it isn't implemented in this PR I thought I'd write it down somewhere. So for anyone interested, a run might look like this:
```xml
    <w:r>
      <w:rPr>
        <w:rFonts w:asciiTheme="majorBidi" w:hAnsiTheme="majorBidi" w:cstheme="majorBidi"/>
      </w:rPr>
      <w:t>This text uses Times New Roman via themes</w:t>
    </w:r>
```

With settings containing 
```xml
  <w:themeFontLang w:val="en-AU" w:bidi="ar-SA"/>
```

And a Theme like this:

```xml
    <a:fontScheme name="Office">
      <a:majorFont>
        <a:latin typeface="Aptos Display" panose="02110004020202020204"/>
        <a:ea typeface=""/>
        <a:cs typeface="Segoe UI"/>
        <a:font script="Jpan" typeface="游ゴシック Light"/>
        <a:font script="Arab" typeface="Times New Roman"/>
    </a:majorFont>
    <a:minorFont>
        <a:latin typeface="Aptos" panose="02110004020202020204"/>
        <a:ea typeface=""/>
        <a:cs typeface=""/>
        <a:font script="Jpan" typeface="游明朝"/>
        <a:font script="Arab" typeface="Arial"/>
    </a:minorFont>
```

This theme font can be interpreted by combining info from the document settings (`themeFontLang`) and themes. There is an explanation of that in the spec at `17.15.1.88 themeFontLang (Theme Font Languages)`. However that explanation doesn't really tell you how to map the locale code (for example `ar-SA`) from setting's `themeFontLang` to a script (for example `Arab`) used by the theme definition.

I found that:
- POI's `LocaleID.lookupByLanguageTag(localeName)` can read the locale.
- Then the logic from Libreoffice [here](https://github.com/LibreOffice/core/blob/master/sw/source/writerfilter/dmapper/ThemeHandler.cxx#L21) can easily be ported to java to map a `localeID.getLcid()` to a script. We can then lookup the major/minor theme font with that script
