### PR TITLE
Add getter for body elements in XWPFSDTContent.

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContent.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContent.java
@@ -111,7 +111,7 @@ public class XWPFSDTContent implements ISDTContent {
     /**
      * Get the body elements inside this SDT content element.
      * @return Unmodifiable list containing body elements.
-     * @since 5.5.2
+     * @since 6.0.0
      */
     public List<ISDTContents> getBodyElements() {
         return Collections.unmodifiableList(bodyElements);

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContent.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContent.java
@@ -17,6 +17,7 @@
 package org.apache.poi.xwpf.usermodel;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.poi.util.Beta;
@@ -105,6 +106,15 @@ public class XWPFSDTContent implements ISDTContent {
                 }
             }
         }
+    }
+
+    /**
+     * Get the body elements inside this SDT content element.
+     * @return Unmodifiable list containing body elements.
+     * @since 5.5.2
+     */
+    public List<ISDTContents> getBodyElements() {
+        return Collections.unmodifiableList(bodyElements);
     }
 
     @Override

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
@@ -95,6 +95,29 @@ public final class TestXWPFSDT {
         }
     }
 
+    @Test
+    void testGetSDTContentBodyElements() throws Exception {
+        try (XWPFDocument doc =XWPFTestDataSamples.openSampleDocument("Bug54849.docx")) {
+            IBodyElement sdtBodyElement = doc.getBodyElements().get(2);
+            assert(sdtBodyElement instanceof XWPFSDT);
+            XWPFSDTContent content = (XWPFSDTContent) ((XWPFSDT) sdtBodyElement).getContent();
+            assertEquals(3, content.getBodyElements().size());
+
+            ISDTContents c1 = content.getBodyElements().get(0);
+            assert(c1 instanceof XWPFParagraph);
+            assertEquals("Rich_text_pre_table", ((XWPFParagraph) c1).getText());
+
+            ISDTContents c2 = content.getBodyElements().get(1);
+            assert(c2 instanceof XWPFTable);
+            assertEquals(3, ((XWPFTable) c2).getNumberOfRows());
+            assertEquals("Rich_text_cell1", ((XWPFTable) c2).getRow(0).getCell(0).getText());
+
+            ISDTContents c3 = content.getBodyElements().get(2);
+            assert(c3 instanceof XWPFParagraph);
+            assertEquals("Rich_text_post_table", ((XWPFParagraph) c3).getText());
+        }
+    }
+
     /**
      * POI-54771 and TIKA-1317
      */

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
@@ -97,23 +97,23 @@ public final class TestXWPFSDT {
 
     @Test
     void testGetSDTContentBodyElements() throws Exception {
-        try (XWPFDocument doc =XWPFTestDataSamples.openSampleDocument("Bug54849.docx")) {
+        try (XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug54849.docx")) {
             IBodyElement sdtBodyElement = doc.getBodyElements().get(2);
-            assert(sdtBodyElement instanceof XWPFSDT);
+            assertTrue(sdtBodyElement instanceof XWPFSDT, "sdtBodyElement instance of XWPFSDT");
             XWPFSDTContent content = (XWPFSDTContent) ((XWPFSDT) sdtBodyElement).getContent();
-            assertEquals(3, content.getBodyElements().size());
+            assertEquals(3, content.getBodyElements().size(), "elements inside SDT");
 
             ISDTContents c1 = content.getBodyElements().get(0);
-            assert(c1 instanceof XWPFParagraph);
+            assertTrue(c1 instanceof XWPFParagraph, "c1 instance of XWPFParagraph");
             assertEquals("Rich_text_pre_table", ((XWPFParagraph) c1).getText());
 
             ISDTContents c2 = content.getBodyElements().get(1);
-            assert(c2 instanceof XWPFTable);
-            assertEquals(3, ((XWPFTable) c2).getNumberOfRows());
+            assertTrue(c2 instanceof XWPFTable, "c2 instance of XWPFTable");
+            assertEquals(3, ((XWPFTable) c2).getNumberOfRows(), "rows in table inside SDT");
             assertEquals("Rich_text_cell1", ((XWPFTable) c2).getRow(0).getCell(0).getText());
 
             ISDTContents c3 = content.getBodyElements().get(2);
-            assert(c3 instanceof XWPFParagraph);
+            assertTrue(c3 instanceof XWPFParagraph, "c3 instance of XWPFParagraph");
             assertEquals("Rich_text_post_table", ((XWPFParagraph) c3).getText());
         }
     }


### PR DESCRIPTION
This getter allows to navigate the POI objects stored inside a XWPFSDTContent object without resorting to navigating XML.