### PR TITLE
Fix Bug 69855 bug: Ensure at least one paragraph for OOXML compliance

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
@@ -115,7 +115,8 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
     public void clearText() {
         _paragraphs.clear();
         CTTextBody txBody = getTextBody(true);
-        txBody.setPArray(null); // remove any existing paragraphs
+        txBody.setPArray(new CTTextParagraph[0]);
+        addNewTextParagraph();
     }
 
     @Override

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/TestXSLFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/TestXSLFBugs.java
@@ -236,7 +236,7 @@ class TestXSLFBugs {
             try (XMLSlideShow ppt3 = writeOutAndReadBack(dest)) {
                 XSLFSlide slide3 = ppt3.getSlides().get(0);
                 XSLFTextBox shape3 = (XSLFTextBox) slide3.getShapes().get(0);
-                XSLFTextParagraph p3 = shape3.getTextParagraphs().get(1);
+                XSLFTextParagraph p3 = shape3.getTextParagraphs().get(2);
                 XSLFHyperlink h1 = p3.getTextRuns().get(0).getHyperlink();
                 assertNotNull(h1);
                 assertEquals("https://poi.apache.org", h1.getAddress());

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/TestXSLFSlideShow.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/TestXSLFSlideShow.java
@@ -165,7 +165,7 @@ class TestXSLFSlideShow {
             XSLFSlide copySlide = ppt.createSlide();
             copySlide.importContent(templateSlide);
             XSLFTextShape copyTextShape = (XSLFTextShape) copySlide.getShapes().get(0);
-            XmlObject copyTextRunXmlObject = copyTextShape.getTextParagraphs().get(0).getTextRuns().get(0).getXmlObject();
+            XmlObject copyTextRunXmlObject = copyTextShape.getTextParagraphs().get(1).getTextRuns().get(0).getXmlObject();
             assertNotEquals(templateTextRunXmlObject, copyTextRunXmlObject);
         }
     }

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlide.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlide.java
@@ -131,7 +131,7 @@ class TestXSLFSlide {
 
         XSLFTextShape sh1 = (XSLFTextShape)shapes1.get(0);
         assertEquals("Austin Theme", sh1.getText());
-        XSLFTextRun r1 = sh1.getTextParagraphs().get(0).getTextRuns().get(0);
+        XSLFTextRun r1 = sh1.getTextParagraphs().get(1).getTextRuns().get(0);
         assertEquals("Century Gothic", r1.getFontFamily());
         assertEquals(40.0, r1.getFontSize(), 0);
         assertTrue(r1.isBold());
@@ -144,7 +144,7 @@ class TestXSLFSlide {
         assertEquals(
                 "Text in a autoshape is white\n" +
                 "Fill: RGB(148, 198,0)", sh2.getText());
-        XSLFTextRun r2 = sh2.getTextParagraphs().get(0).getTextRuns().get(0);
+        XSLFTextRun r2 = sh2.getTextParagraphs().get(1).getTextRuns().get(0);
         assertEquals("Century Gothic", r2.getFontFamily());
         assertEquals(18.0, r2.getFontSize(), 0);
         assertFalse(r2.isBold());
@@ -160,7 +160,7 @@ class TestXSLFSlide {
 
         XSLFTextShape sh3 = (XSLFTextShape)shapes2.get(0);
         assertEquals("This slide overrides master background with a texture fill", sh3.getText());
-        XSLFTextRun r3 = sh3.getTextParagraphs().get(0).getTextRuns().get(0);
+        XSLFTextRun r3 = sh3.getTextParagraphs().get(1).getTextRuns().get(0);
         assertEquals("Century Gothic", r3.getFontFamily());
         //assertEquals(32.4.0, r3.getFontSize());
         assertTrue(r3.isBold());

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTextShape.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTextShape.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.POIDataSamples;
 import org.apache.poi.sl.usermodel.MasterSheet;
 import org.apache.poi.sl.usermodel.Placeholder;
@@ -980,6 +981,38 @@ class TestXSLFTextShape {
             String textExp = " ___ ___ ___ ________ __  _______ ___  ___________  __________ __ _____ ___ ___ ___ _______ ____ ______ ___________  _____________ ___ _______ ______  ____ ______ __ ___________  __________ ___ _________  _____ ________ __________  ___ _______ __________ ";
             textAct = xsh.getText();
             assertEquals(textExp, textAct);
+        }
+    }
+
+    @Test
+    void testClearTextMaintainOneParagraph() throws IOException {
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            XSLFSlide slide = ppt.createSlide();
+            XSLFAutoShape shape = slide.createAutoShape();
+
+            XSLFTextParagraph p = shape.addNewTextParagraph();
+            p.addNewTextRun().setText("This text will be cleared");
+
+            shape.clearText();
+
+            assertEquals(1, shape.getTextParagraphs().size(),
+              "After clearText(), there should be exactly one empty paragraph for OOXML compliance.");
+
+            try (UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get()) {
+                ppt.write(baos);
+
+                try (InputStream is = baos.toInputStream();
+                     XMLSlideShow reopened = new XMLSlideShow(is)) {
+
+                    XSLFTextShape reopenedShape = (XSLFTextShape) reopened.getSlides().get(0).getShapes().get(0);
+
+                    assertEquals(1, reopenedShape.getTextParagraphs().size(),
+                      "The re-loaded presentation should also have one empty paragraph.");
+
+                    assertTrue(reopenedShape.getTextParagraphs().get(0).getTextRuns().isEmpty(),
+                      "The paragraph should have no text runs.");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#919 

**Description**
Currently `XSLFTextShape.clearText()` removes all paragraphs, leaving the `txBody` empty.

according to the OOXML specification, a text body must contain at least one paragraph. 
This inconsistency causes PPT to report the file as corrupted when opening a PPTX file generated after calling `clearText()`.

**Changes**
Modified `clearText()` to ensure at least one empty paragraph is maintained using `addNewTextParagraph()`.

**Why update existing tests?**
Since a mandatory empty paragraph is now inserted at Index 0, subsequent content is appended at Index 1.
I have updated the assertions in the exisiting tests to reflect this required structural change for XML compliance.

**Additional Notes**
I am resubmitting this Pull Request because my previous submission was incomplete. This PR provides the correct fix and includes all necessary test adjustments. I apologize for the previous confusion.