### PR TITLE
Bug 69935: Add short-based column setters to ClientAnchor

### DIFF
--- a/poi/src/main/java/org/apache/poi/ss/usermodel/ClientAnchor.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/ClientAnchor.java
@@ -125,7 +125,7 @@ public interface ClientAnchor {
      * Sets the column (0 based) of the first cell.
      *
      * @param col1 0-based column of the first cell.
-     * @since TBD
+     * @since 6.0.0
      */
     default void setCol1(short col1) {
         setCol1((int) col1);
@@ -151,7 +151,7 @@ public interface ClientAnchor {
      * Sets the column (0 based) of the second cell.
      *
      * @param col2 0-based column of the second cell.
-     * @since TBD
+     * @since 6.0.0
      */
     default void setCol2(short col2) {
         setCol2((int) col2);

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/ClientAnchor.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/ClientAnchor.java
@@ -122,6 +122,16 @@ public interface ClientAnchor {
     public void setCol1(int col1);
 
     /**
+     * Sets the column (0 based) of the first cell.
+     *
+     * @param col1 0-based column of the first cell.
+     * @since TBD
+     */
+    default void setCol1(short col1) {
+        setCol1((int) col1);
+    }
+
+    /**
      * Returns the column (0 based) of the second cell, or -1 if there is no bottom-right anchor cell.
      * This is the case for absolute positioning ({@link AnchorType#DONT_MOVE_AND_RESIZE})
      * and absolute sizing ({@link AnchorType#MOVE_DONT_RESIZE}.
@@ -138,11 +148,22 @@ public interface ClientAnchor {
     public void setCol2(int col2);
 
     /**
+     * Sets the column (0 based) of the second cell.
+     *
+     * @param col2 0-based column of the second cell.
+     * @since TBD
+     */
+    default void setCol2(short col2) {
+        setCol2((int) col2);
+    }
+
+    /**
      * Returns the row (0 based) of the first cell, or -1 if there is no bottom-right anchor cell.
      * This is the case for absolute positioning ({@link AnchorType#DONT_MOVE_AND_RESIZE}).
      *
      * @return 0-based row of the first cell or -1 if none.
      */
+
     public int getRow1();
 
     /**

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/TestClientAnchorShortSetter.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/TestClientAnchorShortSetter.java
@@ -1,3 +1,19 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
 package org.apache.poi.ss.usermodel;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/TestClientAnchorShortSetter.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/TestClientAnchorShortSetter.java
@@ -1,0 +1,50 @@
+package org.apache.poi.ss.usermodel;
+
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for the short-based ClientAnchor column setters introduced for Bug 69935.
+ */
+public class TestClientAnchorShortSetter {
+
+    @Test
+    void shortSettersDelegateToIntSetters() throws Exception {
+        try (Workbook wb = new HSSFWorkbook()) {
+            CreationHelper helper = wb.getCreationHelper();
+
+            // The actual implementation returned here is HSSFClientAnchor
+            ClientAnchor anchor = helper.createClientAnchor();
+
+            // Use the new short-based overloads
+            anchor.setCol1((short) 2);
+            anchor.setCol2((short) 5);
+
+            // Setting rows is not strictly required, but keeps the anchor fully initialized
+            anchor.setRow1(1);
+            anchor.setRow2(3);
+
+            // getColX() still returns short; compare using int for convenience
+            assertEquals(2, anchor.getCol1());
+            assertEquals(5, anchor.getCol2());
+        }
+    }
+
+    @Test
+    void intSettersStillWorkAsBefore() throws Exception {
+        try (Workbook wb = new HSSFWorkbook()) {
+            CreationHelper helper = wb.getCreationHelper();
+
+            ClientAnchor anchor = helper.createClientAnchor();
+
+            // Verify that the existing int-based setters still behave as before
+            anchor.setCol1(3);
+            anchor.setCol2(7);
+
+            assertEquals(3, anchor.getCol1());
+            assertEquals(7, anchor.getCol2());
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses [Bug 69935](https://bz.apache.org/bugzilla/show_bug.cgi?id=69935),
where `ClientAnchor` exposes `short`-returning getters for the column indices (`getCol1()`, `getCol2()`) but only `int`-based setters (`setCol1(int)`, `setCol2(int)`).

This mismatch makes it difficult to use Kotlin property syntax, which expects matching getter/setter types for a property.

### What is changed

- Add default short-based setters on `ClientAnchor`:
  - `default void setCol1(short col1)` delegating to `setCol1(int)`.
  - `default void setCol2(short col2)` delegating to `setCol2(int)`.

  This keeps the existing `int`-based setters intact and binary compatible, while exposing a `short`-typed getter/setter pair that works better with Kotlin properties.

- Add `TestClientAnchorShortSetter` to cover:
  - The new short-based setters delegate correctly to the existing int-based setters.
  - The existing int-based setters still behave as before.

### Notes

- The `@since` tag on the new methods is left as `TBD` and can be adjusted by the committer to the appropriate release version.

### Testing

Locally ran:

```bash
./gradlew :poi:test --tests 'org.apache.poi.ss.usermodel.TestClientAnchorShortSetter'
