### PR TITLE
Remove redundant stripe style settings in CreateTable

### DIFF
--- a/poi-examples/src/main/java/org/apache/poi/examples/xssf/usermodel/CreateTable.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xssf/usermodel/CreateTable.java
@@ -58,8 +58,6 @@ public class CreateTable {
             style.setShowRowStripes(true);
             style.setFirstColumn(false);
             style.setLastColumn(false);
-            style.setShowRowStripes(true);
-            style.setShowColumnStripes(true);
 
             // Set the values for the table
             XSSFRow row;


### PR DESCRIPTION
Removed redundant calls to setShowRowStripes and setShowColumnStripes.