### PR TITLE
decouple xlsb from xmlbeans

### DIFF
--- a/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/XLSX2CSV.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xssf/eventusermodel/XLSX2CSV.java
@@ -39,7 +39,7 @@ import org.apache.poi.xssf.extractor.XSSFEventBasedExcelExtractor;
 import org.apache.poi.xssf.model.SharedStrings;
 import org.apache.poi.xssf.model.Styles;
 import org.apache.poi.xssf.model.StylesTable;
-import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.apache.poi.ss.usermodel.Comment;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -110,7 +110,7 @@ public class XLSX2CSV {
 
         @Override
         public void cell(String cellReference, String formattedValue,
-                XSSFComment comment) {
+                Comment comment) {
             if (firstCellOfRow) {
                 firstCellOfRow = false;
             } else {

--- a/poi-examples/src/main/java/org/apache/poi/examples/xssf/streaming/HybridStreaming.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/xssf/streaming/HybridStreaming.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler.SheetContentsHandler;
-import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheet;
@@ -71,7 +71,7 @@ public class HybridStreaming {
             }
 
             @Override
-            public void cell(String cellReference, String formattedValue, XSSFComment comment) {
+            public void cell(String cellReference, String formattedValue, Comment comment) {
             }
         };
     }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBComment.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBComment.java
@@ -19,16 +19,16 @@ package org.apache.poi.xssf.binary;
 
 
 import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.util.Internal;
-import org.apache.poi.xssf.usermodel.XSSFComment;
 
 /**
  * @since 3.16-beta3
  */
 @Internal
-class XSSFBComment extends XSSFComment {
+public class XSSFBComment implements Comment {
 
     private final CellAddress cellAddress;
     private final String author;
@@ -36,7 +36,6 @@ class XSSFBComment extends XSSFComment {
     private boolean visible = true;
 
     XSSFBComment(CellAddress cellAddress, String author, String comment) {
-        super(null, null, null);
         this.cellAddress = cellAddress;
         this.author = author;
         this.comment = new XSSFBRichTextString(comment);

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBRichTextString.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBRichTextString.java
@@ -18,9 +18,9 @@
 package org.apache.poi.xssf.binary;
 
 import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.util.Internal;
 import org.apache.poi.util.NotImplemented;
-import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 
 /**
  * Wrapper class around String so that we can use it in Comment.
@@ -29,7 +29,7 @@ import org.apache.poi.xssf.usermodel.XSSFRichTextString;
  * @since 3.16-beta3
  */
 @Internal
-class XSSFBRichTextString extends XSSFRichTextString {
+public class XSSFBRichTextString implements RichTextString {
 
     private final String string;
 
@@ -63,6 +63,11 @@ class XSSFBRichTextString extends XSSFRichTextString {
 
     @Override
     public String getString() {
+        return string;
+    }
+
+    @Override
+    public String toString() {
         return string;
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBSharedStringsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBSharedStringsTable.java
@@ -28,7 +28,6 @@ import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.util.Internal;
 import org.apache.poi.util.LittleEndian;
 import org.apache.poi.xssf.model.SharedStrings;
-import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.xml.sax.SAXException;
 
 /**
@@ -90,7 +89,7 @@ public class XSSFBSharedStringsTable implements SharedStrings {
 
     @Override
     public RichTextString getItemAt(int idx) {
-        return new XSSFRichTextString(strings.get(idx));
+        return new XSSFBRichTextString(strings.get(idx));
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBSheetHandler.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBSheetHandler.java
@@ -31,8 +31,10 @@ import org.apache.poi.util.Internal;
 import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.StringUtil;
 import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.util.Removal;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
 import org.apache.poi.xssf.model.SharedStrings;
+import org.apache.poi.xssf.usermodel.XSSFComment;
 
 /**
  * @since 3.16-beta3
@@ -590,7 +592,23 @@ public class XSSFBSheetHandler extends XSSFBParser {
         /**
          * A cell, with the given formatted value (may be null),
          * a url (may be null), a toolTip (may be null)
-         *  and possibly a comment (may be null), was encountered */
+         * and possibly a comment (may be null), was encountered.
+         *
+         * @deprecated use {@link #hyperlinkCell(String, String, String, String, Comment)}
+         */
+        @Deprecated
+        @Removal(version = "7.0.0")
+        default void hyperlinkCell(String cellReference, String formattedValue, String url, String toolTip, XSSFComment comment) {
+            hyperlinkCell(cellReference, formattedValue, url, toolTip, (Comment) comment);
+        }
+
+        /**
+         * A cell, with the given formatted value (may be null),
+         * a url (may be null), a toolTip (may be null)
+         * and possibly a comment (may be null), was encountered.
+         *
+         * @since 6.0.0
+         */
         void hyperlinkCell(String cellReference, String formattedValue, String url, String toolTip, Comment comment);
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBSheetHandler.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/binary/XSSFBSheetHandler.java
@@ -30,9 +30,9 @@ import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.util.Internal;
 import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.StringUtil;
+import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
 import org.apache.poi.xssf.model.SharedStrings;
-import org.apache.poi.xssf.usermodel.XSSFComment;
 
 /**
  * @since 3.16-beta3
@@ -447,9 +447,9 @@ public class XSSFBSheetHandler extends XSSFBParser {
          *     </code>. See the code in <code>
          * poi-examples/src/main/java/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java</code> for an
          *     example of how to handle this scenario.
-         * @see #doubleCell(String, double, XSSFComment, ExcelNumberFormat)
+         * @see #doubleCell(String, double, Comment, ExcelNumberFormat)
          */
-        void stringCell(String cellReference, String value, XSSFComment comment);
+        void stringCell(String cellReference, String value, Comment comment);
 
         /**
          * Handles a numeric cell while providing the corresponding {@link ExcelNumberFormat}.
@@ -462,9 +462,9 @@ public class XSSFBSheetHandler extends XSSFBParser {
          *     </code>. See the code in <code>
          * poi-examples/src/main/java/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java</code> for an
          *     example of how to handle this scenario.
-         * @see #stringCell(String, String, XSSFComment)
+         * @see #stringCell(String, String, Comment)
          */
-        void doubleCell(String cellReference, double value, XSSFComment comment, ExcelNumberFormat nf);
+        void doubleCell(String cellReference, double value, Comment comment, ExcelNumberFormat nf);
 
         /**
          * Handles a boolean cell.
@@ -476,9 +476,9 @@ public class XSSFBSheetHandler extends XSSFBParser {
          *     </code>. See the code in <code>
          * poi-examples/src/main/java/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java</code> for an
          *     example of how to handle this scenario.
-         * @see #stringCell(String, String, XSSFComment)
+         * @see #stringCell(String, String, Comment)
          */
-        void booleanCell(String cellReference, boolean value, XSSFComment comment);
+        void booleanCell(String cellReference, boolean value, Comment comment);
 
         /**
          * Handles a cell that evaluates to an error.
@@ -492,7 +492,7 @@ public class XSSFBSheetHandler extends XSSFBParser {
          *     example of how to handle this scenario.
          * @see FormulaError
          */
-        void errorCell(String cellReference, FormulaError fe, XSSFComment comment);
+        void errorCell(String cellReference, FormulaError fe, Comment comment);
 
         /**
          * Receives header or footer text encountered in the sheet.
@@ -546,25 +546,25 @@ public class XSSFBSheetHandler extends XSSFBParser {
         }
 
         @Override
-        public void stringCell(String cellReference, String value, XSSFComment comment) {
+        public void stringCell(String cellReference, String value, Comment comment) {
             delegate.cell(cellReference, value, comment);
         }
 
         @Override
         public void doubleCell(
-            String cellReference, double value, XSSFComment comment, ExcelNumberFormat nf) {
+            String cellReference, double value, Comment comment, ExcelNumberFormat nf) {
             String formattedValue =
                 dataFormatter.formatRawCellContents(value, nf.getIdx(), nf.getFormat());
             delegate.cell(cellReference, formattedValue, comment);
         }
 
         @Override
-        public void booleanCell(String cellReference, boolean value, XSSFComment comment) {
+        public void booleanCell(String cellReference, boolean value, Comment comment) {
             delegate.cell(cellReference, Boolean.toString(value), comment);
         }
 
         @Override
-        public void errorCell(String cellReference, FormulaError fe, XSSFComment comment) {
+        public void errorCell(String cellReference, FormulaError fe, Comment comment) {
             // For backward compatibility, we pass "ERROR" as the cell value.
             // If you need the actual error code, you should implement
             // XSSFBSheetContentsHandler directly
@@ -591,6 +591,6 @@ public class XSSFBSheetHandler extends XSSFBParser {
          * A cell, with the given formatted value (may be null),
          * a url (may be null), a toolTip (may be null)
          *  and possibly a comment (may be null), was encountered */
-        void hyperlinkCell(String cellReference, String formattedValue, String url, String toolTip, XSSFComment comment);
+        void hyperlinkCell(String cellReference, String formattedValue, String url, String toolTip, Comment comment);
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFSheetXMLHandler.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFSheetXMLHandler.java
@@ -28,6 +28,7 @@ import org.apache.poi.ss.usermodel.BuiltinFormats;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.util.Removal;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.xssf.model.*;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
@@ -566,6 +567,25 @@ public class XSSFSheetXMLHandler extends DefaultHandler {
          * sparse calls to <code>cell</code>. See the code in
          * <code>poi-examples/src/main/java/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java</code>
          * for an example of how to handle this scenario.
+         *
+         * @deprecated use {@link #cell(String, String, Comment)}
+         */
+        @Deprecated
+        @Removal(version = "7.0.0")
+        default void cell(String cellReference, String formattedValue, XSSFComment comment) {
+            cell(cellReference, formattedValue, (Comment) comment);
+        }
+
+        /**
+         * A cell, with the given formatted value (may be null),
+         * and possibly a comment (may be null), was encountered.
+         * <p>
+         * Sheets that have missing or empty cells may result in
+         * sparse calls to <code>cell</code>. See the code in
+         * <code>poi-examples/src/main/java/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java</code>
+         * for an example of how to handle this scenario.
+         *
+         * @since 6.0.0
          */
         void cell(String cellReference, String formattedValue, Comment comment);
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFSheetXMLHandler.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFSheetXMLHandler.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.ss.usermodel.BuiltinFormats;
 import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.xssf.model.*;
@@ -566,7 +567,7 @@ public class XSSFSheetXMLHandler extends DefaultHandler {
          * <code>poi-examples/src/main/java/org/apache/poi/xssf/eventusermodel/XLSX2CSV.java</code>
          * for an example of how to handle this scenario.
          */
-        void cell(String cellReference, String formattedValue, XSSFComment comment);
+        void cell(String cellReference, String formattedValue, Comment comment);
 
         /**
          * A header or footer has been encountered

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFEventBasedExcelExtractor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFEventBasedExcelExtractor.java
@@ -47,7 +47,7 @@ import org.apache.poi.xssf.model.Comments;
 import org.apache.poi.xssf.model.SharedStrings;
 import org.apache.poi.xssf.model.Styles;
 import org.apache.poi.xssf.model.StylesTable;
-import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.xssf.usermodel.XSSFShape;
 import org.apache.poi.xssf.usermodel.XSSFSimpleShape;
 import org.apache.xmlbeans.XmlException;
@@ -350,7 +350,7 @@ public class XSSFEventBasedExcelExtractor
         }
 
         @Override
-        public void cell(String cellRef, String formattedValue, XSSFComment comment) {
+        public void cell(String cellRef, String formattedValue, Comment comment) {
             if (firstCellOfRow) {
                 firstCellOfRow = false;
             } else {

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/binary/TestXSSFBSheetParser.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/binary/TestXSSFBSheetParser.java
@@ -32,7 +32,7 @@ import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.xssf.eventusermodel.XSSFBReader;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler;
-import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.apache.poi.ss.usermodel.Comment;
 import org.junit.jupiter.api.Test;
 
 class TestXSSFBSheetParser {
@@ -127,7 +127,7 @@ class TestXSSFBSheetParser {
         }
 
         @Override
-        public void cell(String cellReference, String formattedValue, XSSFComment comment) {
+        public void cell(String cellReference, String formattedValue, Comment comment) {
             if (cellReference == null)
                 cellReference = new CellAddress(currentRow, currentCol+1).formatAsString();
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFBReader.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFBReader.java
@@ -29,7 +29,7 @@ import org.apache.poi.ss.usermodel.FormulaError;
 import org.apache.poi.xssf.binary.XSSFBSharedStringsTable;
 import org.apache.poi.xssf.binary.XSSFBSheetHandler;
 import org.apache.poi.xssf.binary.XSSFBStylesTable;
-import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.apache.poi.ss.usermodel.Comment;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
@@ -201,7 +201,7 @@ class TestXSSFBReader {
         }
 
         @Override
-        public void cell(String cellReference, String formattedValue, XSSFComment comment) {
+        public void cell(String cellReference, String formattedValue, Comment comment) {
             formattedValue = (formattedValue == null) ? "" : formattedValue;
             if (comment == null) {
                 sb.append("\n\t<td ref=\"").append(cellReference).append("\">").append(formattedValue).append("</td>");
@@ -237,7 +237,7 @@ class TestXSSFBReader {
                 withSettings().strictness(Strictness.STRICT_STUBS));
     }
 
-    private static ArgumentMatcher<XSSFComment> commentWith(String author, String text) {
+    private static ArgumentMatcher<Comment> commentWith(String author, String text) {
         return comment -> comment != null
                 && author.equals(comment.getAuthor())
                 && comment.getString() != null

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFReader.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFReader.java
@@ -38,6 +38,7 @@ import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.poifs.crypt.CryptoFunctions;
 import org.apache.poi.poifs.crypt.HashAlgorithm;
+import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Name;
 import org.apache.poi.ss.usermodel.Row;
@@ -47,7 +48,6 @@ import org.apache.poi.util.XMLHelper;
 import org.apache.poi.xssf.XSSFTestDataSamples;
 import org.apache.poi.xssf.model.*;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
-import org.apache.poi.xssf.usermodel.XSSFComment;
 import org.apache.poi.xssf.usermodel.XSSFShape;
 import org.apache.poi.xssf.usermodel.XSSFSimpleShape;
 import org.junit.jupiter.api.Disabled;
@@ -392,7 +392,7 @@ public final class TestXSSFReader {
                 @Override public void startRow(int rowNum) {}
                 @Override public void endRow(int rowNum) {}
                 @Override public void cell(String cellReference,
-                                           String formattedValue, XSSFComment comment) {
+                                           String formattedValue, Comment comment) {
                     if (cellReference.equals("A1")) {
                         assertEquals("1.2", formattedValue);
                     } else if (cellReference.equals("B1")) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFSheetXMLHandler.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFSheetXMLHandler.java
@@ -20,7 +20,7 @@ import org.apache.poi.POIDataSamples;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.util.XMLHelper;
 import org.apache.poi.xssf.eventusermodel.XSSFSheetXMLHandler.SheetContentsHandler;
-import org.apache.poi.xssf.usermodel.XSSFComment;
+import org.apache.poi.ss.usermodel.Comment;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
@@ -61,7 +61,7 @@ class TestXSSFSheetXMLHandler {
 
                     @Override
                     public void cell(final String cellReference, final String formattedValue,
-                                     final XSSFComment comment) {
+                                     final Comment comment) {
                         assertEquals("\uD83D\uDE1Cmore text", formattedValue);
                         assertEquals(0, cellCount++);
                     }
@@ -94,7 +94,7 @@ class TestXSSFSheetXMLHandler {
 
                     @Override
                     public void cell(final String cellReference, final String formattedValue,
-                                     final XSSFComment comment) {
+                                     final Comment comment) {
                     }
                 }, false));
 
@@ -125,7 +125,7 @@ class TestXSSFSheetXMLHandler {
 
                     @Override
                     public void cell(final String cellReference, final String formattedValue,
-                                     final XSSFComment comment) {
+                                     final Comment comment) {
                         cellValues.put(cellReference, formattedValue);
                     }
                 }, false));


### PR DESCRIPTION
This attempts to decouple xmlbeans from xlsb.

The one area of concern I have is the public api change:

XSSFSheetXMLHandler.SheetContentsHandler.cell(String, String, XSSFComment) → cell(String, String, Comment)
   
This is:
* Source-compatible: Comment is a supertype of XSSFComment, so existing implementations that reference XSSFComment just need to change their parameter type and recompile
* Binary-incompatible: Any compiled code implementing SheetContentsHandler will need recompilation against the new version

If this is a bridge too far, we can try to refactor in another way.