### PR TITLE
add setOutputPassword for HSLFSlideShow and HWPFDocument

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShow.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShow.java
@@ -1248,9 +1248,15 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
 
     /**
      * Set the password to be used to password protect the slideshow when writing out.
+     * If {@code null} is passed any password previously set via this method is cleared;
+     * in that case the thread-level password from {@link org.apache.poi.hssf.record.crypto.Biff8EncryptionKey#getCurrentUserPassword()}
+     * is used (if set), otherwise the output will be unencrypted.
+     * <p>
+     * The password supplied to the constructor for reading an encrypted file is
+     * <em>not</em> automatically used as the output password.
+     * </p>
      *
-     * @param password as a char array (null is supported and means use {@link org.apache.poi.hssf.record.crypto.Biff8EncryptionKey}
-     *                 and no password if none set there)
+     * @param password as a char array, or {@code null} to clear
      * @since 6.0.0
      */
     public void setOutputPassword(final char[] password) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShow.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShow.java
@@ -1246,6 +1246,17 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
         getSlideShowImpl().write(newFile);
     }
 
+    /**
+     * Set the password to be used to password protect the slideshow when writing out.
+     *
+     * @param password as a char array (null is supported and means use {@link org.apache.poi.hssf.record.crypto.Biff8EncryptionKey}
+     *                 and no password if none set there)
+     * @since 6.0.0
+     */
+    public void setOutputPassword(final char[] password) {
+        getSlideShowImpl().setOutputPassword(password);
+    }
+
     @Override
     public DocumentSummaryInformation getDocumentSummaryInformation() {
         return getSlideShowImpl().getDocumentSummaryInformation();

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
@@ -395,34 +395,7 @@ public class HSLFSlideShowEncrypted implements Closeable {
      */
     protected org.apache.poi.hslf.record.Record[] updateEncryptionRecord(
             org.apache.poi.hslf.record.Record[] records, char[] password) {
-        if (password == null) {
-            if (dea == null) {
-                // no password given, no encryption record exits -> done
-                return records;
-            } else {
-                // need to remove password data
-                dea = null;
-                return removeEncryptionRecord(records);
-            }
-        } else {
-            // create password record
-            if (dea == null) {
-                dea = new DocumentEncryptionAtom();
-            }
-            EncryptionInfo ei = dea.getEncryptionInfo();
-            byte[] salt = ei.getVerifier().getSalt();
-            Encryptor enc = getEncryptionInfo().getEncryptor();
-            if (salt == null) {
-                enc.confirmPassword(password);
-            } else {
-                byte[] verifier = ei.getDecryptor().getVerifier();
-                enc.confirmPassword(password, null, null, verifier, salt, null);
-            }
-
-            // move EncryptionRecord to last slide position
-            records = normalizeRecords(records);
-            return addEncryptionRecord(records, dea);
-        }
+        return updateEncryptionRecord(records, new String(password));
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
@@ -384,8 +384,17 @@ public class HSLFSlideShowEncrypted implements Closeable {
         }
     }
 
-    protected org.apache.poi.hslf.record.Record[] updateEncryptionRecord(org.apache.poi.hslf.record.Record[] records) {
-        String password = Biff8EncryptionKey.getCurrentUserPassword();
+    /**
+     * Updates the encryption record for the given records using the supplied password.
+     * If {@code password} is {@code null} any existing encryption record is removed (decrypted output).
+     *
+     * @param records  the current record array
+     * @param password the output password, or {@code null} to remove encryption
+     * @return the updated record array
+     * @since 6.0.0
+     */
+    protected org.apache.poi.hslf.record.Record[] updateEncryptionRecord(
+            org.apache.poi.hslf.record.Record[] records, String password) {
         if (password == null) {
             if (dea == null) {
                 // no password given, no encryption record exits -> done
@@ -414,6 +423,21 @@ public class HSLFSlideShowEncrypted implements Closeable {
             records = normalizeRecords(records);
             return addEncryptionRecord(records, dea);
         }
+    }
+
+    /**
+     * Updates the encryption record for the given records, reading the password from
+     * {@link Biff8EncryptionKey#getCurrentUserPassword()}.
+     *
+     * @param records the current record array
+     * @return the updated record array
+     * @deprecated use {@link #updateEncryptionRecord(org.apache.poi.hslf.record.Record[], String)}
+     *             and pass the password explicitly
+     */
+    @Deprecated
+    protected org.apache.poi.hslf.record.Record[] updateEncryptionRecord(
+            org.apache.poi.hslf.record.Record[] records) {
+        return updateEncryptionRecord(records, Biff8EncryptionKey.getCurrentUserPassword());
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
@@ -394,7 +394,7 @@ public class HSLFSlideShowEncrypted implements Closeable {
      * @since 6.0.0
      */
     protected org.apache.poi.hslf.record.Record[] updateEncryptionRecord(
-            org.apache.poi.hslf.record.Record[] records, String password) {
+            org.apache.poi.hslf.record.Record[] records, char[] password) {
         if (password == null) {
             if (dea == null) {
                 // no password given, no encryption record exits -> done
@@ -431,13 +431,42 @@ public class HSLFSlideShowEncrypted implements Closeable {
      *
      * @param records the current record array
      * @return the updated record array
-     * @deprecated use {@link #updateEncryptionRecord(org.apache.poi.hslf.record.Record[], String)}
-     *             and pass the password explicitly
      */
-    @Deprecated
     protected org.apache.poi.hslf.record.Record[] updateEncryptionRecord(
             org.apache.poi.hslf.record.Record[] records) {
         return updateEncryptionRecord(records, Biff8EncryptionKey.getCurrentUserPassword());
+    }
+
+    private org.apache.poi.hslf.record.Record[] updateEncryptionRecord(
+            org.apache.poi.hslf.record.Record[] records, String password) {
+        if (password == null) {
+            if (dea == null) {
+                // no password given, no encryption record exits -> done
+                return records;
+            } else {
+                // need to remove password data
+                dea = null;
+                return removeEncryptionRecord(records);
+            }
+        } else {
+            // create password record
+            if (dea == null) {
+                dea = new DocumentEncryptionAtom();
+            }
+            EncryptionInfo ei = dea.getEncryptionInfo();
+            byte[] salt = ei.getVerifier().getSalt();
+            Encryptor enc = getEncryptionInfo().getEncryptor();
+            if (salt == null) {
+                enc.confirmPassword(password);
+            } else {
+                byte[] verifier = ei.getDecryptor().getVerifier();
+                enc.confirmPassword(password, null, null, verifier, salt, null);
+            }
+
+            // move EncryptionRecord to last slide position
+            records = normalizeRecords(records);
+            return addEncryptionRecord(records, dea);
+        }
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
@@ -68,6 +68,7 @@ import org.apache.poi.hslf.record.PositionDependentRecord;
 import org.apache.poi.hslf.record.Record;
 import org.apache.poi.hslf.record.RecordTypes;
 import org.apache.poi.hslf.record.UserEditAtom;
+import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.poifs.crypt.EncryptionInfo;
 import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.poifs.filesystem.DocumentEntry;
@@ -111,6 +112,9 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
     // Embedded objects stored in storage records in the document stream, lazily populated.
     private HSLFObjectData[] _objects;
 
+    // The password to use when writing out the slideshow (null = use Biff8EncryptionKey or no encryption)
+    private char[] _outputPassword;
+
     /**
      * @param length the max record length allowed for HSLFSlideShowImpl
      */
@@ -123,6 +127,17 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
      */
     public static int getMaxRecordLength() {
         return MAX_RECORD_LENGTH;
+    }
+
+    /**
+     * Set the password to be used to password protect the slideshow when writing out.
+     *
+     * @param password as a char array (null is supported and means use {@link Biff8EncryptionKey}
+     *                 and no password if none set there)
+     * @since 6.0.0
+     */
+    public void setOutputPassword(final char[] password) {
+        this._outputPassword = password;
     }
 
     /**
@@ -866,6 +881,13 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         // The list of entries we've written out
         final List<String> writtenEntries = new ArrayList<>(1);
 
+        // If an output password was set via setOutputPassword(), temporarily override the
+        // thread-local Biff8EncryptionKey so that updateEncryptionRecord() picks it up.
+        final String oldPW = Biff8EncryptionKey.getCurrentUserPassword();
+        if (_outputPassword != null) {
+            Biff8EncryptionKey.setCurrentUserPassword(new String(_outputPassword));
+        }
+        try {
         // set new encryption settings
         try (HSLFSlideShowEncrypted encryptedSS = new HSLFSlideShowEncrypted(getDocumentEncryptionAtom())) {
             _records = encryptedSS.updateEncryptionRecord(_records);
@@ -904,6 +926,11 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
                 } catch (IllegalStateException e) {
                     throw (IOException)e.getCause();
                 }
+            }
+        }
+        } finally {
+            if (_outputPassword != null) {
+                Biff8EncryptionKey.setCurrentUserPassword(oldPW);
             }
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
@@ -143,7 +143,7 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
      * @since 6.0.0
      */
     public void setOutputPassword(final char[] password) {
-        this._outputPassword = (password != null) ? password.clone() : null;
+        this._outputPassword = password == null ? null : password.clone();
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
@@ -131,13 +131,19 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
 
     /**
      * Set the password to be used to password protect the slideshow when writing out.
+     * If {@code null} is passed any password previously set via this method is cleared;
+     * in that case the thread-level password from {@link Biff8EncryptionKey#getCurrentUserPassword()}
+     * is used (if set), otherwise the output will be unencrypted.
+     * <p>
+     * The password supplied to the constructor for reading an encrypted file is
+     * <em>not</em> automatically used as the output password.
+     * </p>
      *
-     * @param password as a char array (null is supported and means use {@link Biff8EncryptionKey}
-     *                 and no password if none set there)
+     * @param password as a char array, or {@code null} to clear
      * @since 6.0.0
      */
     public void setOutputPassword(final char[] password) {
-        this._outputPassword = password;
+        this._outputPassword = (password != null) ? password.clone() : null;
     }
 
     /**
@@ -881,16 +887,16 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         // The list of entries we've written out
         final List<String> writtenEntries = new ArrayList<>(1);
 
-        // If an output password was set via setOutputPassword(), temporarily override the
-        // thread-local Biff8EncryptionKey so that updateEncryptionRecord() picks it up.
-        final String oldPW = Biff8EncryptionKey.getCurrentUserPassword();
-        if (_outputPassword != null) {
-            Biff8EncryptionKey.setCurrentUserPassword(new String(_outputPassword));
-        }
-        try {
+        // Resolve the output password: explicit setOutputPassword() takes priority,
+        // otherwise fall back to the thread-level Biff8EncryptionKey (if any).
+        // The password used to open/read this file is intentionally NOT used here.
+        final String outputPassword = _outputPassword != null
+                ? new String(_outputPassword)
+                : Biff8EncryptionKey.getCurrentUserPassword();
+
         // set new encryption settings
         try (HSLFSlideShowEncrypted encryptedSS = new HSLFSlideShowEncrypted(getDocumentEncryptionAtom())) {
-            _records = encryptedSS.updateEncryptionRecord(_records);
+            _records = encryptedSS.updateEncryptionRecord(_records, outputPassword);
 
             // Write out the Property Streams
             writeProperties(outFS, writtenEntries);
@@ -926,11 +932,6 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
                 } catch (IllegalStateException e) {
                     throw (IOException)e.getCause();
                 }
-            }
-        }
-        } finally {
-            if (_outputPassword != null) {
-                Biff8EncryptionKey.setCurrentUserPassword(oldPW);
             }
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
@@ -887,16 +887,13 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         // The list of entries we've written out
         final List<String> writtenEntries = new ArrayList<>(1);
 
-        // Resolve the output password: explicit setOutputPassword() takes priority,
-        // otherwise fall back to the thread-level Biff8EncryptionKey (if any).
-        // The password used to open/read this file is intentionally NOT used here.
-        final String outputPassword = _outputPassword != null
-                ? new String(_outputPassword)
-                : Biff8EncryptionKey.getCurrentUserPassword();
-
         // set new encryption settings
         try (HSLFSlideShowEncrypted encryptedSS = new HSLFSlideShowEncrypted(getDocumentEncryptionAtom())) {
-            _records = encryptedSS.updateEncryptionRecord(_records, outputPassword);
+            if (_outputPassword != null) {
+                _records = encryptedSS.updateEncryptionRecord(_records, _outputPassword);
+            } else {
+                _records = encryptedSS.updateEncryptionRecord(_records);
+            }
 
             // Write out the Property Streams
             writeProperties(outFS, writtenEntries);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
@@ -313,13 +313,19 @@ public abstract class HWPFDocumentCore extends POIDocument {
 
     /**
      * Set the password to be used to password protect the document when writing out.
+     * If {@code null} is passed any password previously set via this method is cleared;
+     * in that case the thread-level password from {@link Biff8EncryptionKey#getCurrentUserPassword()}
+     * is used (if set), otherwise the output will be unencrypted.
+     * <p>
+     * The password supplied to the constructor for reading an encrypted file is
+     * <em>not</em> automatically used as the output password.
+     * </p>
      *
-     * @param password as a char array (null is supported and means use {@link Biff8EncryptionKey}
-     *                 and no password if none set there)
+     * @param password as a char array, or {@code null} to clear
      * @since 6.0.0
      */
     public void setOutputPassword(final char[] password) {
-        this._outputPasswordChars = password;
+        this._outputPasswordChars = (password != null) ? password.clone() : null;
     }
 
     @Override
@@ -369,16 +375,13 @@ public abstract class HWPFDocumentCore extends POIDocument {
     protected void updateEncryptionInfo() {
         // make sure, that we've read all the streams ...
         readProperties();
-        // now check for the password
-        // Use output password if set, otherwise fall back to read password, then Biff8EncryptionKey
-        String password;
-        if (_outputPasswordChars != null) {
-            password = new String(_outputPasswordChars);
-        } else if (_password != null) {
-            password = new String(_password);
-        } else {
-            password = Biff8EncryptionKey.getCurrentUserPassword();
-        }
+        // Resolve the output password: explicit setOutputPassword() takes priority,
+        // otherwise fall back to the thread-level Biff8EncryptionKey (if any).
+        // The password supplied to the constructor (_password) is intentionally NOT
+        // used as an output password.
+        String password = _outputPasswordChars != null
+                ? new String(_outputPasswordChars)
+                : Biff8EncryptionKey.getCurrentUserPassword();
         FibBase fBase = _fib.getFibBase();
         if (password == null) {
             fBase.setLKey(0);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
@@ -229,7 +229,7 @@ public abstract class HWPFDocumentCore extends POIDocument {
     public HWPFDocumentCore(DirectoryNode directory, final char[] password) throws IOException {
         // Sort out the hpsf properties
         super(directory);
-        _password = password;
+        _password = password == null ? null : password.clone();
 
         // read in the main stream.
         _mainStream = getDocumentEntryBytes(STREAM_WORD_DOCUMENT, FIB_BASE_LEN, Integer.MAX_VALUE);
@@ -325,7 +325,7 @@ public abstract class HWPFDocumentCore extends POIDocument {
      * @since 6.0.0
      */
     public void setOutputPassword(final char[] password) {
-        this._outputPasswordChars = (password != null) ? password.clone() : null;
+        this._outputPasswordChars = password == null ? null : password.clone();
     }
 
     @Override

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
@@ -126,6 +126,8 @@ public abstract class HWPFDocumentCore extends POIDocument {
 
     private char[] _password;
 
+    private char[] _outputPasswordChars;
+
     private EncryptionInfo _encryptionInfo;
 
     protected HWPFDocumentCore() {
@@ -309,6 +311,17 @@ public abstract class HWPFDocumentCore extends POIDocument {
         return _mainStream;
     }
 
+    /**
+     * Set the password to be used to password protect the document when writing out.
+     *
+     * @param password as a char array (null is supported and means use {@link Biff8EncryptionKey}
+     *                 and no password if none set there)
+     * @since 6.0.0
+     */
+    public void setOutputPassword(final char[] password) {
+        this._outputPasswordChars = password;
+    }
+
     @Override
     public EncryptionInfo getEncryptionInfo() throws IOException {
         if (_encryptionInfo != null) {
@@ -357,8 +370,15 @@ public abstract class HWPFDocumentCore extends POIDocument {
         // make sure, that we've read all the streams ...
         readProperties();
         // now check for the password
-        String password = _password == null
-                ? Biff8EncryptionKey.getCurrentUserPassword() : new String(_password);
+        // Use output password if set, otherwise fall back to read password, then Biff8EncryptionKey
+        String password;
+        if (_outputPasswordChars != null) {
+            password = new String(_outputPasswordChars);
+        } else if (_password != null) {
+            password = new String(_password);
+        } else {
+            password = Biff8EncryptionKey.getCurrentUserPassword();
+        }
         FibBase fBase = _fib.getFibBase();
         if (password == null) {
             fBase.setLKey(0);

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestHSLFSlideShow.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestHSLFSlideShow.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
+import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.sl.usermodel.BaseTestSlideShow;
 import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.sl.usermodel.SlideShow;
@@ -46,20 +47,44 @@ public class TestHSLFSlideShow extends BaseTestSlideShow<HSLFShape, HSLFTextPara
     void setPassword() throws IOException {
         final byte[] data = slTests.readFile("clock.jpg");
         final String password = "123xyz";
-        UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get();
-        try (HSLFSlideShow show = createSlideShow()) {
-            assertEquals(0, show.getPictureData().size());
-            PictureData picture = show.addPicture(data, PictureData.PictureType.JPEG);
-            assertEquals(1, show.getPictureData().size());
-            assertSame(picture, show.getPictureData().get(0));
-            show.setOutputPassword(password.toCharArray());
-            show.write(baos);
+        try(UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get()) {
+            try (HSLFSlideShow show = createSlideShow()) {
+                assertEquals(0, show.getPictureData().size());
+                PictureData picture = show.addPicture(data, PictureData.PictureType.JPEG);
+                assertEquals(1, show.getPictureData().size());
+                assertSame(picture, show.getPictureData().get(0));
+                show.setOutputPassword(password.toCharArray());
+                show.write(baos);
+            }
+            try (HSLFSlideShow show = new HSLFSlideShow(baos.toInputStream(), password.toCharArray())) {
+                assertEquals(1, show.getPictureData().size());
+                assertArrayEquals(data, show.getPictureData().get(0).getData());
+            }
         }
-        try (HSLFSlideShow show = new HSLFSlideShow(baos.toInputStream(), password.toCharArray())) {
-            assertEquals(1, show.getPictureData().size());
-            assertArrayEquals(data, show.getPictureData().get(0).getData());
+    }
+
+    @Test
+    void setPasswordBiff8() throws IOException {
+        final byte[] data = slTests.readFile("clock.jpg");
+        final String password = "123xyz";
+        // kept for legacy testing, prefer to set the password like the `setPassword` test does
+        try(UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get()) {
+            try (HSLFSlideShow show = createSlideShow()) {
+                assertEquals(0, show.getPictureData().size());
+                PictureData picture = show.addPicture(data, PictureData.PictureType.JPEG);
+                assertEquals(1, show.getPictureData().size());
+                assertSame(picture, show.getPictureData().get(0));
+                Biff8EncryptionKey.setCurrentUserPassword(password);
+                show.write(baos);
+            }
+            Biff8EncryptionKey.setCurrentUserPassword(password);
+            try (HSLFSlideShow show = new HSLFSlideShow(baos.toInputStream())) {
+                assertEquals(1, show.getPictureData().size());
+                assertArrayEquals(data, show.getPictureData().get(0).getData());
+            }
+        } finally {
+            Biff8EncryptionKey.setCurrentUserPassword(null);
         }
-        baos.close();
     }
 
     @Override

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestHSLFSlideShow.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestHSLFSlideShow.java
@@ -16,13 +16,17 @@
 ==================================================================== */
 package org.apache.poi.hslf.usermodel;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.sl.usermodel.BaseTestSlideShow;
+import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.sl.usermodel.SlideShow;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +42,26 @@ public class TestHSLFSlideShow extends BaseTestSlideShow<HSLFShape, HSLFTextPara
         assertNotNull(createSlideShow());
     }
 
+    @Test
+    void setPassword() throws IOException {
+        final byte[] data = slTests.readFile("clock.jpg");
+        final String password = "123xyz";
+        UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get();
+        try (HSLFSlideShow show = createSlideShow()) {
+            assertEquals(0, show.getPictureData().size());
+            PictureData picture = show.addPicture(data, PictureData.PictureType.JPEG);
+            assertEquals(1, show.getPictureData().size());
+            assertSame(picture, show.getPictureData().get(0));
+            show.setOutputPassword(password.toCharArray());
+            show.write(baos);
+        }
+        try (HSLFSlideShow show = new HSLFSlideShow(baos.toInputStream(), password.toCharArray())) {
+            assertEquals(1, show.getPictureData().size());
+            assertArrayEquals(data, show.getPictureData().get(0).getData());
+        }
+        baos.close();
+    }
+
     @Override
     public HSLFSlideShow reopen(SlideShow<HSLFShape, HSLFTextParagraph> show) throws IOException {
         try (UnsynchronizedByteArrayOutputStream bos = UnsynchronizedByteArrayOutputStream.builder().get()) {
@@ -47,4 +71,5 @@ public class TestHSLFSlideShow extends BaseTestSlideShow<HSLFShape, HSLFTextPara
             }
         }
     }
+
 }

--- a/poi-scratchpad/src/test/java/org/apache/poi/hwpf/usermodel/TestHWPFWrite.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hwpf/usermodel/TestHWPFWrite.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.POIDataSamples;
+import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.hwpf.HWPFDocument;
 import org.apache.poi.hwpf.HWPFTestCase;
 import org.apache.poi.hwpf.HWPFTestDataSamples;
@@ -139,4 +140,45 @@ public final class TestHWPFWrite extends HWPFTestCase {
             assertThrows(IllegalStateException.class, doc::write);
         }
     }
+
+    @Test
+    void testPassword() throws IOException {
+        final String password = "password123";
+        UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get();
+        try (HWPFDocument doc = HWPFTestDataSamples.openSampleFile("SampleDoc.doc")) {
+            Range r = doc.getRange();
+            assertEquals("I am a test document\r", r.getParagraph(0).text());
+            doc.setOutputPassword(password.toCharArray());
+            doc.write(baos);
+        }
+
+        try (HWPFDocument doc = new HWPFDocument(baos.toInputStream(), password.toCharArray())) {
+            Range r = doc.getRange();
+            assertEquals("I am a test document\r", r.getParagraph(0).text());
+        }
+    }
+
+    @Test
+    void testPasswordBiff8() throws IOException {
+        final String password = "password123";
+        // this tests the legacy way to use a password when writing or reading a file
+        // prefer the 6.0.0+ supported approach in `testPassword` test above
+        try(UnsynchronizedByteArrayOutputStream baos = UnsynchronizedByteArrayOutputStream.builder().get()) {
+            try (HWPFDocument doc = HWPFTestDataSamples.openSampleFile("SampleDoc.doc")) {
+                Range r = doc.getRange();
+                assertEquals("I am a test document\r", r.getParagraph(0).text());
+                Biff8EncryptionKey.setCurrentUserPassword(password);
+                doc.write(baos);
+            }
+
+            Biff8EncryptionKey.setCurrentUserPassword(password);
+            try (HWPFDocument doc = new HWPFDocument(baos.toInputStream())) {
+                Range r = doc.getRange();
+                assertEquals("I am a test document\r", r.getParagraph(0).text());
+            }
+        } finally {
+            Biff8EncryptionKey.setCurrentUserPassword(null);
+        }
+    }
+
 }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -1577,7 +1577,7 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
      * @since 6.0.0
      */
     public void setOutputPassword(final char[] password) {
-        this.outputPasswordChars = password;
+        this.outputPasswordChars = password == null ? null : password.clone();
     }
 
     /**

--- a/poi/src/test/java/org/apache/poi/extractor/TestMainExtractorFactory.java
+++ b/poi/src/test/java/org/apache/poi/extractor/TestMainExtractorFactory.java
@@ -31,8 +31,7 @@ import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link MainExtractorFactory} password support introduced in
- * commit eacd5f9bb6169ac90a5b899e41062048d6b9bb03.
+ * Tests for {@link MainExtractorFactory} password support.
  */
 class TestMainExtractorFactory {
 

--- a/poi/src/test/java/org/apache/poi/extractor/TestMainExtractorFactory.java
+++ b/poi/src/test/java/org/apache/poi/extractor/TestMainExtractorFactory.java
@@ -1,0 +1,129 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.extractor;
+
+import static org.apache.poi.POITestCase.assertContains;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.poi.POIDataSamples;
+import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link MainExtractorFactory} password support introduced in
+ * commit eacd5f9bb6169ac90a5b899e41062048d6b9bb03.
+ */
+class TestMainExtractorFactory {
+
+    private static final POIDataSamples SS_SAMPLES = POIDataSamples.getSpreadSheetInstance();
+
+    private static final String PASSWORD_XLS = "password.xls";
+    private static final String PASSWORD = "password";
+
+    @Test
+    void testCreateFromFileWithPassword() throws IOException {
+        File file = SS_SAMPLES.getFile(PASSWORD_XLS);
+        MainExtractorFactory factory = new MainExtractorFactory();
+        try (POITextExtractor extractor = factory.create(file, PASSWORD)) {
+            assertNotNull(extractor);
+            assertContains(extractor.getText(), "ZIP");
+        }
+    }
+
+    @Test
+    void testCreateFromInputStreamWithPassword() throws IOException {
+        MainExtractorFactory factory = new MainExtractorFactory();
+        try (InputStream is = SS_SAMPLES.openResourceAsStream(PASSWORD_XLS);
+             POITextExtractor extractor = factory.create(is, PASSWORD)) {
+            assertNotNull(extractor);
+            assertContains(extractor.getText(), "ZIP");
+        }
+    }
+
+    @Test
+    void testCreateFromDirectoryWithPassword() throws IOException {
+        File file = SS_SAMPLES.getFile(PASSWORD_XLS);
+        MainExtractorFactory factory = new MainExtractorFactory();
+        try (POIFSFileSystem fs = new POIFSFileSystem(file, true);
+             POITextExtractor extractor = factory.create(fs.getRoot(), PASSWORD)) {
+            assertNotNull(extractor);
+            assertContains(extractor.getText(), "ZIP");
+        }
+    }
+
+    @Test
+    void testCreateWithNullPasswordUsesNoPassword() throws IOException {
+        // A non-encrypted file should be readable with null password
+        File file = SS_SAMPLES.getFile("Simple.xls");
+        MainExtractorFactory factory = new MainExtractorFactory();
+        try (POITextExtractor extractor = factory.create(file, null)) {
+            assertNotNull(extractor);
+            assertContains(extractor.getText(), "Sheet1");
+        }
+    }
+
+    @Test
+    void testBiff8EncryptionKeyCurrentUserPassword() {
+        // Verify the ThreadLocal get/set/clear behaviour
+        assertNull(Biff8EncryptionKey.getCurrentUserPassword());
+
+        Biff8EncryptionKey.setCurrentUserPassword("test");
+        assertNotNull(Biff8EncryptionKey.getCurrentUserPassword());
+        assertContains(Biff8EncryptionKey.getCurrentUserPassword(), "test");
+
+        // Clearing with null
+        Biff8EncryptionKey.setCurrentUserPassword(null);
+        assertNull(Biff8EncryptionKey.getCurrentUserPassword());
+    }
+
+    @Test
+    void testCreateEventBasedExtractorWithPassword() throws IOException {
+        ExtractorFactory.setThreadPrefersEventExtractors(true);
+        try {
+            File file = SS_SAMPLES.getFile(PASSWORD_XLS);
+            MainExtractorFactory factory = new MainExtractorFactory();
+            try (POITextExtractor extractor = factory.create(file, PASSWORD)) {
+                assertNotNull(extractor);
+                assertContains(extractor.getText(), "ZIP");
+            }
+        } finally {
+            ExtractorFactory.removeThreadPrefersEventExtractorsSetting();
+        }
+    }
+
+    @Test
+    void testCreateEventBasedExtractorFromInputStreamWithPassword() throws IOException {
+        ExtractorFactory.setThreadPrefersEventExtractors(true);
+        try {
+            MainExtractorFactory factory = new MainExtractorFactory();
+            try (InputStream is = SS_SAMPLES.openResourceAsStream(PASSWORD_XLS);
+                 POITextExtractor extractor = factory.create(is, PASSWORD)) {
+                assertNotNull(extractor);
+                assertContains(extractor.getText(), "ZIP");
+            }
+        } finally {
+            ExtractorFactory.removeThreadPrefersEventExtractorsSetting();
+        }
+    }
+}


### PR DESCRIPTION
- [x] Add tests for commit eacd5f9 (MainExtractorFactory password support)
- [x] Add `setOutputPassword` to `HSLFSlideShow` and `HSLFSlideShowImpl`
- [x] Add `setOutputPassword` to `HWPFDocumentCore`
- [x] Refactor `HSLFSlideShowEncrypted`:
  - [x] Add `updateEncryptionRecord(records, password)` overload that takes password directly
  - [x] Deprecate the old `updateEncryptionRecord(records)` (which reads from `Biff8EncryptionKey`)
- [x] Refactor `HSLFSlideShowImpl.write()`:
  - [x] Remove `Biff8EncryptionKey` manipulation (set/restore)
  - [x] Determine output password locally (`_outputPassword` → `Biff8EncryptionKey` fallback, constructor password NOT used)
  - [x] Call new `updateEncryptionRecord(records, password)` overload directly
  - [x] Updated javadoc and defensive copy in `setOutputPassword()`
- [x] Refactor `HSLFSlideShow.setOutputPassword()`: updated javadoc
- [x] Fix `HWPFDocumentCore.updateEncryptionInfo()`:
  - [x] Remove `_password` (constructor password) from the fallback chain
  - [x] Chain is now: `_outputPasswordChars` → `Biff8EncryptionKey.getCurrentUserPassword()`
  - [x] Updated javadoc and defensive copy in `setOutputPassword()`