### PR TITLE
Fix: XSLFTableCell.setBorderColor Overwrites

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTableCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTableCell.java
@@ -304,7 +304,10 @@ public class XSLFTableCell extends XSLFTextShape implements TableCell<XSLFShape,
             throw new IllegalArgumentException("Colors need to be specified.");
         }
 
-        CTLineProperties ln = setBorderDefaults(edge);
+        final CTLineProperties ln = setBorderDefaults(edge);
+        if (ln.isSetSolidFill()) {
+            ln.unsetSolidFill();
+        }
         CTSolidColorFillProperties fill = ln.addNewSolidFill();
         XSLFColor c = new XSLFColor(fill, getSheet().getTheme(), fill.getSchemeClr(), getSheet());
         c.setColor(color);

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTable.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTable.java
@@ -281,6 +281,25 @@ class TestXSLFTable {
     }
 
     @Test
+    void testBorderColorOverwrite() throws IOException {
+        XMLSlideShow ppt = new XMLSlideShow();
+        XSLFSlide slide = ppt.createSlide();
+        XSLFTable tbl = slide.createTable();
+        XSLFTableRow row = tbl.addRow();
+        XSLFTableCell cell = row.addCell();
+
+        for (BorderEdge edge : BorderEdge.values()) {
+            cell.setBorderColor(edge, Color.yellow);
+            assertEquals(Color.yellow, cell.getBorderColor(edge));
+            // additional calls to setBorderColor do not add multiple solidFill elements
+            cell.setBorderColor(edge, Color.red);
+            assertEquals(Color.red, cell.getBorderColor(edge));
+        }
+
+        ppt.close();
+    }
+
+    @Test
     void removeTable() throws IOException {
         XMLSlideShow ss = XSLFTestDataSamples.openSampleDocument("shapes.pptx");
         XSLFSlide sl = ss.getSlides().get(0);


### PR DESCRIPTION
We've been attempting to generate a pptx using POI but kept getting prompted to repair when actually loading into Powerpoint. Through the debugging process, it was revealed that the violation is caused by the existence of multiple solidFill elements.

Current behavior: calling `setBorderColor` multiple times will result in appending multiple solidFill elements.

New behavior: `setBorderColor` checks for existing solidFill element and removes it before creating a new one.