### PR TITLE
prevent overflow in blip buffer size calculation

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/Bitmap.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/Bitmap.java
@@ -60,7 +60,8 @@ public abstract class Bitmap extends HSLFPictureData {
     @Override
     protected byte[] formatImageForSlideshow(byte[] data) {
         byte[] checksum = getChecksum(data);
-        byte[] rawData = new byte[checksum.length * getUIDInstanceCount() + 1 + data.length];
+        long size = Math.addExact(Math.addExact((long)checksum.length * getUIDInstanceCount(), 1), data.length);
+        byte[] rawData = IOUtils.safelyAllocate(size, org.apache.poi.hslf.record.RecordAtom.getMaxRecordLength());
         int offset = 0;
 
         System.arraycopy(checksum, 0, rawData, offset, checksum.length);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/EMF.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/EMF.java
@@ -85,7 +85,8 @@ public final class EMF extends Metafile {
         header.setZipSize(compressed.length);
 
         byte[] checksum = getChecksum(data);
-        byte[] rawData = new byte[checksum.length * getUIDInstanceCount() + header.getSize() + compressed.length];
+        long size = Math.addExact(Math.addExact((long)checksum.length * getUIDInstanceCount(), header.getSize()), compressed.length);
+        byte[] rawData = IOUtils.safelyAllocate(size, org.apache.poi.hslf.record.RecordAtom.getMaxRecordLength());
         int offset = 0;
 
         System.arraycopy(checksum, 0, rawData, offset, checksum.length);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/PICT.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/PICT.java
@@ -127,7 +127,8 @@ public final class PICT extends Metafile {
         header.setDimension(new Dimension(Units.toEMU(nDim.getWidth()), Units.toEMU(nDim.getHeight())));
 
         byte[] checksum = getChecksum(data);
-        byte[] rawData = new byte[checksum.length * getUIDInstanceCount() + header.getSize() + compressed.length];
+        long size = Math.addExact(Math.addExact((long)checksum.length * getUIDInstanceCount(), header.getSize()), compressed.length);
+        byte[] rawData = IOUtils.safelyAllocate(size, org.apache.poi.hslf.record.RecordAtom.getMaxRecordLength());
         int offset = 0;
 
         System.arraycopy(checksum, 0, rawData, offset, checksum.length);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/WMF.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/blip/WMF.java
@@ -90,7 +90,8 @@ public final class WMF extends Metafile {
         header.setZipSize(compressed.length);
 
         byte[] checksum = getChecksum(data);
-        byte[] rawData = new byte[checksum.length * getUIDInstanceCount() + header.getSize() + compressed.length];
+        long size = Math.addExact(Math.addExact((long)checksum.length * getUIDInstanceCount(), header.getSize()), compressed.length);
+        byte[] rawData = IOUtils.safelyAllocate(size, org.apache.poi.hslf.record.RecordAtom.getMaxRecordLength());
         int offset = 0;
 
         System.arraycopy(checksum, 0, rawData, offset, checksum.length);

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/blip/TestBlipOverflow.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/blip/TestBlipOverflow.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.poi.hslf.blip;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.poi.hslf.record.RecordAtom;
+import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.RecordFormatException;
+import org.junit.jupiter.api.Test;
+
+public class TestBlipOverflow {
+
+    @Test
+    public void testBitmapOverflow() {
+        int dataLength = Integer.MAX_VALUE - 10;
+        int checksumLength = 16;
+        int uidInstanceCount = 1;
+        assertThrows(RecordFormatException.class, () -> {
+            long size = Math.addExact(Math.addExact((long)checksumLength * uidInstanceCount, 1), dataLength);
+            IOUtils.safelyAllocate(size, RecordAtom.getMaxRecordLength());
+        });
+    }
+}


### PR DESCRIPTION
### Summary
This change updates buffer size calculations in HSLF blip processing to avoid potential integer overflow before array allocation.

### What changed

\- Replaced inline size calculations using \`new byte\[...\]\` with:

\- \`long\`-based size computation

\- \`IOUtils.safelyAllocate(...)\` for allocation

\- Applied consistently to:

\- \`Bitmap\`

\- \`EMF\`

\- \`PICT\`

\- \`WMF\`

### Why

In the current implementation, buffer sizes are computed using integer arithmetic:

new byte\[a + b + c\]

If intermediate values exceed Integer.MAX\_VALUE, this can overflow before allocation, leading to incorrect buffer sizes and runtime failures.

Using IOUtils.safelyAllocate ensures:

*   size is evaluated using long
    
*   overflow is detected before allocation
    
*   behavior is consistent with existing POI safety patterns
    

### Scope

*   Limited to HSLF blip classes only
    
*   No API changes
    
*   No behavioral changes for valid inputs
    

### Notes

This follows the same allocation safety approach already used in other parts of POI.