### PR TITLE
Enforce max entry size consistently for streaming ZIP entries

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveFakeEntry.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveFakeEntry.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
 import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.RecordFormatException;
 import org.apache.poi.util.TempFile;
 
 /**
@@ -69,19 +70,35 @@ public final class ZipArchiveFakeEntry extends ZipArchiveEntry implements Closea
         super(entry.getName());
 
         final long entrySize = entry.getSize();
+        final int maxEntrySize = getMaxEntrySize();
 
         final int threshold = ZipInputStreamZipEntrySource.getThresholdBytesForTempFiles();
         if (threshold >= 0 && (entrySize >= threshold || entrySize == -1)) {
+            if (entrySize >= 0) {
+                checkEntrySize(entrySize, maxEntrySize, entry.getName());
+            }
             if (ZipInputStreamZipEntrySource.shouldEncryptTempFiles()) {
                 encryptedTempData = new EncryptedTempData();
                 try (OutputStream os = encryptedTempData.getOutputStream()) {
-                    IOUtils.copy(inp, os);
+                    copyWithMaxEntrySize(inp, os, maxEntrySize, entry.getName());
+                } catch (IOException | RuntimeException e) {
+                    encryptedTempData.dispose();
+                    encryptedTempData = null;
+                    throw e;
                 }
             } else {
                 tempFile = TempFile.createTempFile("poi-zip-entry", ".tmp");
                 LOG.atInfo().log("Creating temp file {} for zip entry {} of size {} bytes",
                         tempFile.getAbsolutePath(), entry.getName(), entrySize);
-                IOUtils.copy(inp, tempFile);
+                try (OutputStream os = Files.newOutputStream(tempFile.toPath())) {
+                    copyWithMaxEntrySize(inp, os, maxEntrySize, entry.getName());
+                } catch (IOException | RuntimeException e) {
+                    if (tempFile.exists() && !tempFile.delete()) {
+                        LOG.atDebug().log("temp file was already deleted (probably due to previous call to close this resource)");
+                    }
+                    tempFile = null;
+                    throw e;
+                }
             }
         } else {
             if (entrySize < -1 || entrySize >= Integer.MAX_VALUE) {
@@ -91,6 +108,25 @@ public final class ZipArchiveFakeEntry extends ZipArchiveEntry implements Closea
             // Grab the de-compressed contents for later
             data = (entrySize == -1) ? IOUtils.toByteArrayWithMaxLength(inp, getMaxEntrySize()) :
                     IOUtils.toByteArray(inp, entrySize, getMaxEntrySize());
+        }
+    }
+
+    private static void checkEntrySize(long entrySize, int maxEntrySize, String entryName) {
+        if (entrySize > maxEntrySize) {
+            throw new RecordFormatException("Zip entry " + entryName + " exceeds the max entry size of " + maxEntrySize + " bytes");
+        }
+    }
+
+    private static void copyWithMaxEntrySize(InputStream inp, OutputStream out, int maxEntrySize, String entryName) throws IOException {
+        byte[] buffer = new byte[4096];
+        int read;
+        long totalPayloadSize = 0;
+        while ((read = inp.read(buffer)) != -1) {
+            totalPayloadSize += read;
+            if (totalPayloadSize > maxEntrySize) {
+                throw new RecordFormatException("Zip entry " + entryName + " exceeds the max entry size of " + maxEntrySize + " bytes");
+            }
+            out.write(buffer, 0, read);
         }
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipArchiveFakeEntryLimits.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipArchiveFakeEntryLimits.java
@@ -1,0 +1,70 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.openxml4j.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.poi.util.RecordFormatException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Isolated
+class TestZipArchiveFakeEntryLimits {
+    @Test
+    void oversizedEntryIsRejectedInTempFileMode() throws IOException {
+        int origThreshold = ZipInputStreamZipEntrySource.getThresholdBytesForTempFiles();
+        int origMax = ZipArchiveFakeEntry.getMaxEntrySize();
+        try {
+            // Force temp-file spooling path
+            ZipInputStreamZipEntrySource.setThresholdBytesForTempFiles(0);
+            ZipArchiveFakeEntry.setMaxEntrySize(100);
+
+            // Create ZIP with unknown size (-1) and payload > maxEntrySize
+            byte[] zipBytes = createZipWithUnknownSize("test.txt", 200);
+            try (ZipArchiveInputStream zis = new ZipArchiveInputStream(new ByteArrayInputStream(zipBytes));
+                 ZipArchiveThresholdInputStream ztis = new ZipArchiveThresholdInputStream(zis)) {
+                
+                // Should throw RecordFormatException during ZipInputStreamZipEntrySource construction
+                assertThrows(RecordFormatException.class, () -> new ZipInputStreamZipEntrySource(ztis));
+            }
+        } finally {
+            // Restore static values
+            ZipInputStreamZipEntrySource.setThresholdBytesForTempFiles(origThreshold);
+            ZipArchiveFakeEntry.setMaxEntrySize(origMax);
+        }
+    }
+
+    private static byte[] createZipWithUnknownSize(String name, int size) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(bos)) {
+            ZipArchiveEntry entry = new ZipArchiveEntry(name);
+            zos.putArchiveEntry(entry);
+            zos.write(new byte[size]);
+            zos.closeArchiveEntry();
+            zos.finish();
+        }
+        return bos.toByteArray();
+    }
+}


### PR DESCRIPTION
### Summary

Enforce `maxEntrySize` consistently for ZIP entries processed via streaming, including when the entry size is unknown.

---

### Changes

- Add fail-fast validation for known-size entries.
- Replace size-limited copy with explicit bounded streaming:
  - Track bytes read.
  - Throw `RecordFormatException` when the limit is exceeded.
- Apply the same enforcement to temp-file paths.

---

### Test

- Adds a deterministic test for an unknown-size entry exceeding the limit.
- Fails on previous behavior, passes with this change.

---

### Notes

- Tightens validation; oversized entries are now rejected earlier.
- Scope limited to `ZipArchiveFakeEntry`.