### PR TITLE
Apply zip bomb checks to encrypted temp ZIP processing

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveThresholdInputStream.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveThresholdInputStream.java
@@ -148,7 +148,7 @@ public class ZipArchiveThresholdInputStream extends FilterInputStream {
         throw new IOException(String.format(Locale.ROOT, MIN_INFLATE_RATIO_MSG, payloadSize, rawSize, ratio, MIN_INFLATE_RATIO, entryName));
     }
 
-    ZipArchiveEntry getNextEntry() throws IOException {
+    public ZipArchiveEntry getNextEntry() throws IOException {
         if (!(in instanceof ZipArchiveInputStream)) {
             throw new IllegalStateException("getNextEntry() is only allowed for stream based zip processing.");
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/AesZipFileZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/AesZipFileZipEntrySource.java
@@ -39,6 +39,7 @@ import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.openxml4j.util.ZipEntrySource;
+import org.apache.poi.openxml4j.util.ZipArchiveThresholdInputStream;
 import org.apache.poi.poifs.crypt.ChainingMode;
 import org.apache.poi.poifs.crypt.CipherAlgorithm;
 import org.apache.poi.poifs.crypt.CryptoFunctions;
@@ -130,7 +131,8 @@ public final class AesZipFileZipEntrySource implements ZipEntrySource {
         SecretKeySpec skeySpec = new SecretKeySpec(keyBytes, CipherAlgorithm.aes128.jceId);
         Cipher ciEnc = CryptoFunctions.getCipher(skeySpec, CipherAlgorithm.aes128, ChainingMode.cbc, ivBytes, Cipher.ENCRYPT_MODE, PADDING);
 
-        try (ZipArchiveInputStream zis = new ZipArchiveInputStream(is);
+        try (ZipArchiveInputStream zipStream = new ZipArchiveInputStream(is);
+             ZipArchiveThresholdInputStream zis = new ZipArchiveThresholdInputStream(zipStream);
              OutputStream fos = Files.newOutputStream(tmpFile.toPath());
              ZipArchiveOutputStream zos = new ZipArchiveOutputStream(fos)) {
 

--- a/poi-ooxml/src/test/java/org/apache/poi/poifs/crypt/tests/TestSecureTempZip.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/poifs/crypt/tests/TestSecureTempZip.java
@@ -18,9 +18,12 @@
 package org.apache.poi.poifs.crypt.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -29,9 +32,12 @@ import java.security.GeneralSecurityException;
 
 import javax.crypto.Cipher;
 
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.poi.openxml4j.exceptions.OpenXML4JException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.util.ZipEntrySource;
+import org.apache.poi.openxml4j.util.ZipSecureFile;
 import org.apache.poi.poifs.crypt.Decryptor;
 import org.apache.poi.poifs.crypt.EncryptionInfo;
 import org.apache.poi.poifs.crypt.temp.AesZipFileZipEntrySource;
@@ -124,6 +130,41 @@ class TestSecureTempZip {
         opc.close();
         poifs.close();
         fis.close();
+    }
+
+    @Test
+    void rejectsZipBombInput() throws IOException {
+        byte[] zipBytes = buildHighlyCompressedZip("xl/workbook.xml", 256 * 1024);
+
+        double defaultRatio = ZipSecureFile.getMinInflateRatio();
+        long defaultGrace = ZipSecureFile.getGraceEntrySize();
+        ZipSecureFile.setGraceEntrySize(0);
+        ZipSecureFile.setMinInflateRatio(0.50d);
+        try {
+            IOException exception = assertThrows(IOException.class, () -> {
+                try (InputStream is = new ByteArrayInputStream(zipBytes);
+                     AesZipFileZipEntrySource source = AesZipFileZipEntrySource.createZipEntrySource(is)) {
+                    // no-op
+                }
+            });
+            assertTrue(exception.getMessage().contains("ZipSecureFile.setMinInflateRatio()"),
+                    "unexpected exception message: " + exception.getMessage());
+        } finally {
+            ZipSecureFile.setMinInflateRatio(defaultRatio);
+            ZipSecureFile.setGraceEntrySize(defaultGrace);
+        }
+    }
+
+    private static byte[] buildHighlyCompressedZip(String entryName, int payloadSize) throws IOException {
+        byte[] payload = new byte[payloadSize];
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(bos)) {
+            ZipArchiveEntry entry = new ZipArchiveEntry(entryName);
+            zos.putArchiveEntry(entry);
+            zos.write(payload);
+            zos.closeArchiveEntry();
+        }
+        return bos.toByteArray();
     }
 
 }


### PR DESCRIPTION
## Summary

Apply existing zip-bomb protections to the encrypted temp ZIP processing path used by `AesZipFileZipEntrySource`.

Previously, this flow re-streamed attacker-controlled ZIP entries through `ZipArchiveInputStream` without `ZipArchiveThresholdInputStream` enforcement, allowing highly compressed entries to bypass configured inflate-ratio checks during temporary encrypted ZIP creation.

This change aligns the encrypted processing path with the existing ZIP security protections already used elsewhere in POI.

## Changes

* wrap encrypted temp ZIP input streams with `ZipArchiveThresholdInputStream`
* enforce configured inflate-ratio and entry-threshold checks during temp ZIP creation
* expose `getNextEntry()` on `ZipArchiveThresholdInputStream` for internal stream-based processing usage
* add regression coverage for highly compressed ZIP input

## Regression Test

Added `rejectsZipBombInput()` to verify:

* before this patch: highly compressed input was processed successfully
* after this patch: inflate-ratio enforcement correctly rejects the input with a zip-bomb exception

The test restores modified `ZipSecureFile` settings in a `finally` block to avoid leaking state across tests.
