### PR TITLE
Harden temporary file permissions

### DIFF
--- a/poi/src/main/java/org/apache/poi/util/DefaultTempFileCreationStrategy.java
+++ b/poi/src/main/java/org/apache/poi/util/DefaultTempFileCreationStrategy.java
@@ -24,6 +24,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -92,7 +95,27 @@ public class DefaultTempFileCreationStrategy implements TempFileCreationStrategy
         createPOIFilesDirectoryIfNecessary();
 
         // Generate a unique new filename
-        File newFile = Files.createTempFile(dir.toPath(), prefix, suffix).toFile();
+        File newFile;
+        try {
+            // Try POSIX permissions first (owner read/write only)
+            Path p = Files.createTempFile(dir.toPath(), prefix, suffix,
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+            newFile = p.toFile();
+        } catch (UnsupportedOperationException | IOException e) {
+            // POSIX not supported (e.g., Windows) or failed: fall back to creating normally
+            newFile = Files.createTempFile(dir.toPath(), prefix, suffix).toFile();
+            try {
+                // Clear all perms for everyone, then set owner-only perms where supported
+                newFile.setReadable(false, false);
+                newFile.setWritable(false, false);
+                newFile.setExecutable(false, false);
+                newFile.setReadable(true, true);
+                newFile.setWritable(true, true);
+                newFile.setExecutable(false, true);
+            } catch (Exception ignore) {
+                // best-effort only
+            }
+        }
 
         // Set the delete on exit flag if sys prop is set
         if (System.getProperty(DELETE_FILES_ON_EXIT) != null) {
@@ -110,7 +133,24 @@ public class DefaultTempFileCreationStrategy implements TempFileCreationStrategy
         createPOIFilesDirectoryIfNecessary();
 
         // Generate a unique new filename
-        File newDirectory = Files.createTempDirectory(dir.toPath(), prefix).toFile();
+        File newDirectory;
+        try {
+            Path p = Files.createTempDirectory(dir.toPath(), prefix,
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+            newDirectory = p.toFile();
+        } catch (UnsupportedOperationException | IOException e) {
+            newDirectory = Files.createTempDirectory(dir.toPath(), prefix).toFile();
+            try {
+                newDirectory.setReadable(false, false);
+                newDirectory.setWritable(false, false);
+                newDirectory.setExecutable(false, false);
+                newDirectory.setReadable(true, true);
+                newDirectory.setWritable(true, true);
+                newDirectory.setExecutable(true, true);
+            } catch (Exception ignore) {
+                // best-effort only
+            }
+        }
 
         //this method appears to be only used in tests, so it is probably ok to use deleteOnExit
         newDirectory.deleteOnExit();
@@ -155,6 +195,23 @@ public class DefaultTempFileCreationStrategy implements TempFileCreationStrategy
                         dir = fileDir;
                     } else {
                         dir = Files.createDirectories(dirPath).toFile();
+                        try {
+                            // attempt to restrict directory perms to owner only
+                            try {
+                                Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwx------");
+                                Files.setPosixFilePermissions(dir.toPath(), perms);
+                            } catch (UnsupportedOperationException | IOException e) {
+                                // fallback: use File API to set owner-only flags where supported
+                                dir.setReadable(false, false);
+                                dir.setWritable(false, false);
+                                dir.setExecutable(false, false);
+                                dir.setReadable(true, true);
+                                dir.setWritable(true, true);
+                                dir.setExecutable(true, true);
+                            }
+                        } catch (Exception ignored) {
+                            // best-effort only
+                        }
                     }
                 }
             } finally {

--- a/poi/src/test/java/org/apache/poi/util/DefaultTempFileCreationStrategyTest.java
+++ b/poi/src/test/java/org/apache/poi/util/DefaultTempFileCreationStrategyTest.java
@@ -28,11 +28,16 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class DefaultTempFileCreationStrategyTest {
 
@@ -212,6 +217,34 @@ class DefaultTempFileCreationStrategyTest {
                     "Failed for " + file);
         } finally {
             assertTrue(file.delete());
+        }
+    }
+
+    @Test
+    void testPosixPermissions() throws IOException {
+        DefaultTempFileCreationStrategy strategy = new DefaultTempFileCreationStrategy();
+        File dir = strategy.createTempDirectory("posixtest");
+        try {
+            Path dirPath = dir.toPath();
+            // Skip test if POSIX file attribute view not supported on this filesystem
+            Assumptions.assumeTrue(Files.getFileAttributeView(dirPath, PosixFileAttributeView.class) != null,
+                    "POSIX file attributes not supported on this filesystem");
+
+            File f = strategy.createTempFile("posixtestfile", ".tmp");
+            try {
+                Set<PosixFilePermission> perms = Files.getPosixFilePermissions(f.toPath());
+                // Owner should have read/write, no group/other perms
+                assertTrue(perms.contains(PosixFilePermission.OWNER_READ));
+                assertTrue(perms.contains(PosixFilePermission.OWNER_WRITE));
+                assertFalse(perms.contains(PosixFilePermission.GROUP_READ));
+                assertFalse(perms.contains(PosixFilePermission.GROUP_WRITE));
+                assertFalse(perms.contains(PosixFilePermission.OTHERS_READ));
+                assertFalse(perms.contains(PosixFilePermission.OTHERS_WRITE));
+            } finally {
+                assertTrue(f.delete());
+            }
+        } finally {
+            FileUtils.deleteDirectory(dir);
         }
     }
 }


### PR DESCRIPTION
This patch hardens POI temporary file and directory handling by restricting access permissions to the owning user where supported.

`DefaultTempFileCreationStrategy` previously relied on platform-default permissions when creating temporary artifacts. These temporary files and directories can contain sensitive intermediate document data during processing, including streamed workbook contents, extracted package data, and decrypted document material.

The change updates temp file handling to:

* Apply restrictive POSIX permissions atomically during temp file and temp directory creation (`rw-------` for files, `rwx------` for directories) on POSIX-capable platforms
* Fall back to best-effort owner-only restrictions on non-POSIX platforms
* Restrict the POI temp directory itself to owner-only access where supported
* Preserve existing behavior and compatibility while reducing unintended local filesystem exposure

The patch also adds regression tests validating that created temporary files do not expose group/other read or write permissions on POSIX-supported filesystems.
