### PR TITLE
Reject oversized XSSF table counts during integer conversion

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFTable.java
@@ -789,9 +789,10 @@ public class XSSFTable extends POIXMLDocumentPart implements Table {
         if(tableColumns == null) {
             return 0;
         }
-        // Casting to int should be safe here - tables larger than the
+        // Reject oversized workbook-controlled table metadata instead of
+        // silently truncating during long-to-int conversion.
         // sheet (which holds the actual data of the table) can't exists.
-        return (int) tableColumns.getCount();
+        return Math.toIntExact(tableColumns.getCount());
     }
 
     /**
@@ -912,7 +913,7 @@ public class XSSFTable extends POIXMLDocumentPart implements Table {
      */
     @Override
     public int getTotalsRowCount() {
-        return (int) ctTable.getTotalsRowCount();
+        return Math.toIntExact(ctTable.getTotalsRowCount());
     }
 
     /**
@@ -922,7 +923,7 @@ public class XSSFTable extends POIXMLDocumentPart implements Table {
      */
     @Override
     public int getHeaderRowCount() {
-        return (int) ctTable.getHeaderRowCount();
+        return Math.toIntExact(ctTable.getHeaderRowCount());
     }
 
     /**

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFTable.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFTable.java
@@ -163,6 +163,19 @@ public final class TestXSSFTable {
     }
 
     @Test
+    void oversizedTableCountsAreRejected() {
+        XSSFTable table = new XSSFTable();
+
+        table.getCTTable().setHeaderRowCount((long) Integer.MAX_VALUE + 1);
+        table.getCTTable().setTotalsRowCount((long) Integer.MAX_VALUE + 1);
+        table.getCTTable().addNewTableColumns().setCount((long) Integer.MAX_VALUE + 1);
+
+        assertThrows(ArithmeticException.class, table::getHeaderRowCount);
+        assertThrows(ArithmeticException.class, table::getTotalsRowCount);
+        assertThrows(ArithmeticException.class, table::getColumnCount);
+    }
+
+    @Test
     void getStartColIndex() throws IOException {
         try (XSSFWorkbook wb = XSSFTestDataSamples.openSampleWorkbook("StructuredReferences.xlsx")) {
             XSSFTable table = wb.getTable("\\_Prime.1");


### PR DESCRIPTION
XSSFTable currently narrows workbook-controlled table metadata from `long` to `int` using direct casts.

Oversized values in header row counts, totals row counts, or table column counts can silently truncate into invalid integer values and propagate malformed internal table state.

Replace these narrowing casts with `Math.toIntExact(...)` so oversized metadata is rejected deterministically instead of wrapping.

Add regression coverage verifying that oversized table metadata values throw `ArithmeticException`.
