### PR TITLE
Guard Ole10Native readUtf16 byte length against int overflow

### DIFF
--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/Ole10Native.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/Ole10Native.java
@@ -290,7 +290,7 @@ public class Ole10Native {
 
     private static String readUtf16(LittleEndianByteArrayInputStream leis) throws IOException {
         int size = leis.readInt();
-        byte[] buf = IOUtils.toByteArray(leis, size * 2, MAX_STRING_LENGTH);
+        byte[] buf = IOUtils.toByteArray(leis, size * 2L, MAX_STRING_LENGTH);
         return StringUtil.getFromUnicodeLE(buf, 0, size);
     }
 

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestOle10Native.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestOle10Native.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.poifs.filesystem;
 
+import static org.apache.poi.POITestCase.assertContains;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -124,7 +125,7 @@ class TestOle10Native {
             RecordFormatException.class,
             () -> new Ole10Native(data, 0)
         );
-        assertTrue(ex.getMessage().contains("Tried to allocate"));
+        assertContains(ex.getMessage(), "Tried to allocate");
     }
 
 }

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestOle10Native.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestOle10Native.java
@@ -33,6 +33,7 @@ import java.util.List;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.POIDataSamples;
 import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.RecordFormatException;
 import org.junit.jupiter.api.Test;
 
@@ -105,6 +106,25 @@ class TestOle10Native {
             );
             assertTrue(ex.getMessage().contains("Tried to allocate"));
         }
+    }
+
+    @Test
+    void testOle10NativeUtf16SizeOverflow() {
+        // command2 declares 0x40000001 UTF-16 chars; the byte count (size * 2) overflows
+        // a signed int to a negative value that slips past the MAX_STRING_LENGTH cap.
+        byte[] data = new byte[34];
+        LittleEndian.putShort(data, 4, (short) 2);    // flags1 -> parsed encoding
+        data[6] = 'A';                                // label (AsciiZ)
+        data[8] = 'B';                                // fileName (AsciiZ)
+        // flags2, unknown1, ascii command length and data length stay zero
+        LittleEndian.putInt(data, 22, 0x40000001);    // command2 char count
+        LittleEndian.putInt(data, 0, data.length - 4); // totalSize
+
+        RecordFormatException ex = assertThrows(
+            RecordFormatException.class,
+            () -> new Ole10Native(data, 0)
+        );
+        assertTrue(ex.getMessage().contains("Tried to allocate"));
     }
 
 }


### PR DESCRIPTION
Found while fuzzing Ole10Native record parsing. readUtf16 reads a 32-bit char count and hands size * 2 to IOUtils.toByteArray; a count near 0x40000000 makes that product overflow to a negative int, which slips past the MAX_STRING_LENGTH cap so an oversized record surfaces a raw IllegalArgumentException from getFromUnicodeLE rather than the RecordFormatException the cap is meant to raise. Compute the byte count as size * 2L so the long overload applies the cap before narrowing.