### PR TITLE
Increase use of POITestCase assert methods and assertInstanceOf in tests

### DIFF
--- a/poi-excelant/src/test/java/org/apache/poi/ss/excelant/util/TestExcelAntWorkbookUtil.java
+++ b/poi-excelant/src/test/java/org/apache/poi/ss/excelant/util/TestExcelAntWorkbookUtil.java
@@ -17,6 +17,7 @@
 package org.apache.poi.ss.excelant.util;
 
 import static org.apache.poi.POITestCase.assertContains;
+import static org.apache.poi.POITestCase.assertNotContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -215,7 +216,7 @@ class TestExcelAntWorkbookUtil {
         assertContains(result.toString(), "evaluationCompletedWithError=false");
         assertContains(result.toString(), "returnValue=790.79");
         assertContains(result.toString(), "cellName='MortgageCalculator'!B4");
-        assertFalse(result.toString().contains("#N/A"));
+        assertNotContains(result.toString(), "#N/A");
 
         assertFalse(result.evaluationCompleteWithError());
         assertTrue(result.didTestPass());

--- a/poi-ooxml/src/test/java/org/apache/poi/ooxml/TestXMLPropertiesTextExtractor.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ooxml/TestXMLPropertiesTextExtractor.java
@@ -26,8 +26,8 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.poi.POITestCase.assertContains;
+import static org.apache.poi.POITestCase.assertNotContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -136,7 +136,7 @@ public final class TestXMLPropertiesTextExtractor {
                 POIXMLPropertiesTextExtractor ext = new POIXMLPropertiesTextExtractor(sl)
         ) {
             String text = ext.getText();
-            assertFalse(text.contains("Created =")); // With date is null
+            assertNotContains(text, "Created ="); // With date is null
             assertContains(text, "CreatedString = "); // Via string is blank
             assertContains(text, "LastModifiedBy = IT Client Services");
         }

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/internal/TestContentTypeManager.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/internal/TestContentTypeManager.java
@@ -19,9 +19,9 @@ package org.apache.poi.openxml4j.opc.internal;
 
 import static org.apache.poi.xssf.XSSFTestDataSamples.openSampleWorkbook;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -143,7 +143,7 @@ public final class TestContentTypeManager {
                 List<XSSFShape> shapes = drawingOld.getShapes();
 
                 for (XSSFShape shape : shapes) {
-                    assertTrue(shape instanceof XSSFPicture);
+                    assertInstanceOf(XSSFPicture.class, shape);
                     XSSFPicture pic = (XSSFPicture)shape;
                     XSSFPictureData picData = pic.getPictureData();
                     int pictureIndex = targetWB.addPicture(picData.getData(), picData.getPictureType());

--- a/poi-ooxml/src/test/java/org/apache/poi/poifs/crypt/tests/TestHxxFEncryption.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/poifs/crypt/tests/TestHxxFEncryption.java
@@ -22,9 +22,9 @@ import static org.apache.poi.POIDataSamples.getSlideShowInstance;
 import static org.apache.poi.POIDataSamples.getSpreadSheetInstance;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -153,7 +153,7 @@ class TestHxxFEncryption {
                 }
                 EncryptionInfo ei = doc.getEncryptionInfo();
                 assertNotNull(ei);
-                assertTrue(ei.getHeader() instanceof CryptoAPIEncryptionHeader);
+                assertInstanceOf(CryptoAPIEncryptionHeader.class, ei.getHeader());
                 assertEquals(0x28, ei.getHeader().getKeySize());
                 ei.getHeader().setKeySize(0x78);
                 bos.reset();
@@ -164,7 +164,7 @@ class TestHxxFEncryption {
                  POIDocument doc = (POIDocument) te4.getDocument()) {
                 EncryptionInfo ei = doc.getEncryptionInfo();
                 assertNotNull(ei);
-                assertTrue(ei.getHeader() instanceof CryptoAPIEncryptionHeader);
+                assertInstanceOf(CryptoAPIEncryptionHeader.class, ei.getHeader());
                 assertEquals(0x78, ei.getHeader().getKeySize());
             }
         } finally {

--- a/poi-ooxml/src/test/java/org/apache/poi/ss/tests/TestWorkbookFactory.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ss/tests/TestWorkbookFactory.java
@@ -19,6 +19,7 @@ package org.apache.poi.ss.tests;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,12 +36,12 @@ import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.EmptyFileException;
 import org.apache.poi.EncryptedDocumentException;
 import org.apache.poi.POIDataSamples;
 import org.apache.poi.hssf.HSSFTestDataSamples;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.logging.PoiLogManager;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackageAccess;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
@@ -109,14 +110,14 @@ public final class TestWorkbookFactory {
             new POIFSFileSystem(HSSFTestDataSamples.openSampleFileStream(xls))
         )) {
             assertNotNull(wb);
-            assertTrue(wb instanceof HSSFWorkbook);
+            assertInstanceOf(HSSFWorkbook.class, wb);
         }
 
         try (Workbook wb = WorkbookFactory.create(
             new POIFSFileSystem(HSSFTestDataSamples.openSampleFileStream(xls)).getRoot()
         )) {
             assertNotNull(wb);
-            assertTrue(wb instanceof HSSFWorkbook);
+            assertInstanceOf(HSSFWorkbook.class, wb);
         }
 
         // Package -> xssf
@@ -125,7 +126,7 @@ public final class TestWorkbookFactory {
         )) {
             assertNotNull(wb);
             //noinspection ConstantConditions
-            assertTrue(wb instanceof XSSFWorkbook);
+            assertInstanceOf(XSSFWorkbook.class, wb);
         }
     }
 
@@ -134,14 +135,14 @@ public final class TestWorkbookFactory {
         // POIFS -> hssf
         try (Workbook wb = WorkbookFactory.create(HSSFTestDataSamples.getSampleFile(xls), null, true)) {
             assertNotNull(wb);
-            assertTrue(wb instanceof HSSFWorkbook);
+            assertInstanceOf(HSSFWorkbook.class, wb);
             assertCloseDoesNotModifyFile(xls, wb);
         }
 
         // Package -> xssf
         try (Workbook wb = WorkbookFactory.create(HSSFTestDataSamples.getSampleFile(xlsx), null, true)) {
             assertNotNull(wb);
-            assertTrue(wb instanceof XSSFWorkbook);
+            assertInstanceOf(XSSFWorkbook.class, wb);
             assertCloseDoesNotModifyFile(xlsx, wb);
         }
     }
@@ -156,24 +157,24 @@ public final class TestWorkbookFactory {
         // InputStream -> either
         try (Workbook wb = WorkbookFactory.create(HSSFTestDataSamples.openSampleFileStream(xls))) {
             assertNotNull(wb);
-            assertTrue(wb instanceof HSSFWorkbook);
+            assertInstanceOf(HSSFWorkbook.class, wb);
         }
 
         try (Workbook wb = WorkbookFactory.create(HSSFTestDataSamples.openSampleFileStream(xlsx))) {
             assertNotNull(wb);
-            assertTrue(wb instanceof XSSFWorkbook);
+            assertInstanceOf(XSSFWorkbook.class, wb);
         }
 
         // File -> either
         try (Workbook wb = WorkbookFactory.create(HSSFTestDataSamples.getSampleFile(xls))) {
             assertNotNull(wb);
-            assertTrue(wb instanceof HSSFWorkbook);
+            assertInstanceOf(HSSFWorkbook.class, wb);
             assertCloseDoesNotModifyFile(xls, wb);
         }
 
         try (Workbook wb = WorkbookFactory.create(HSSFTestDataSamples.getSampleFile(xlsx))) {
             assertNotNull(wb);
-            assertTrue(wb instanceof XSSFWorkbook);
+            assertInstanceOf(XSSFWorkbook.class, wb);
             assertCloseDoesNotModifyFile(xlsx, wb);
         }
 
@@ -284,13 +285,13 @@ public final class TestWorkbookFactory {
 
         try (Workbook wb = WorkbookFactory.create(altXLS)) {
             assertNotNull(wb);
-            assertTrue(wb instanceof HSSFWorkbook);
+            assertInstanceOf(HSSFWorkbook.class, wb);
             closeOrRevert(wb);
         }
 
         try (Workbook wb = WorkbookFactory.create(altXLSX)) {
             assertNotNull(wb);
-            assertTrue(wb instanceof XSSFWorkbook);
+            assertInstanceOf(XSSFWorkbook.class, wb);
             closeOrRevert(wb);
         }
     }
@@ -307,11 +308,11 @@ public final class TestWorkbookFactory {
     @Test
     void testCreateEmpty() throws Exception {
         Workbook wb = WorkbookFactory.create(false);
-        assertTrue(wb instanceof HSSFWorkbook);
+        assertInstanceOf(HSSFWorkbook.class, wb);
         closeOrRevert(wb);
 
         wb = WorkbookFactory.create(true);
-        assertTrue(wb instanceof XSSFWorkbook);
+        assertInstanceOf(XSSFWorkbook.class, wb);
         closeOrRevert(wb);
     }
 
@@ -343,7 +344,7 @@ public final class TestWorkbookFactory {
             try (InputStream is = HSSFTestDataSamples.openSampleFileStream(xls)) {
                 Workbook wb = WorkbookFactory.create(new POIFSFileSystem(is));
                 assertNotNull(wb);
-                assertTrue(wb instanceof HSSFWorkbook);
+                assertInstanceOf(HSSFWorkbook.class, wb);
                 assertCloseDoesNotModifyFile(xls, wb);
             }
             return true;

--- a/poi-ooxml/src/test/java/org/apache/poi/ss/tests/formula/TestFormulaParser.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ss/tests/formula/TestFormulaParser.java
@@ -19,6 +19,7 @@
 package org.apache.poi.ss.tests.formula;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -176,7 +177,7 @@ class TestFormulaParser {
         Ptg[] ptgs = FormulaParser.parse("[1]Sheet1!A1", fpwb, FormulaType.CELL, -1);
         // org.apache.poi.ss.formula.ptg.Ref3DPxg [ [workbook=1] sheet=Sheet 1 ! A1]
         assertEquals(1, ptgs.length, "Ptgs length");
-        assertTrue(ptgs[0] instanceof Ref3DPxg, "Ptg class");
+        assertInstanceOf(Ref3DPxg.class, ptgs[0], "Ptg class");
         Ref3DPxg pxg = (Ref3DPxg) ptgs[0];
         assertEquals(1, pxg.getExternalWorkbookNumber(), "External workbook number");
         assertEquals("Sheet1", pxg.getSheetName(), "Sheet name");
@@ -193,7 +194,7 @@ class TestFormulaParser {
         Ptg[] ptgs = FormulaParser.parse("'[1]Sheet 1'!A1", fpwb, FormulaType.CELL, -1);
         // org.apache.poi.ss.formula.ptg.Ref3DPxg [ [workbook=1] sheet=Sheet 1 ! A1]
         assertEquals(1, ptgs.length, "Ptgs length");
-        assertTrue(ptgs[0] instanceof Ref3DPxg, "Ptg class");
+        assertInstanceOf(Ref3DPxg.class, ptgs[0], "Ptg class");
         Ref3DPxg pxg = (Ref3DPxg) ptgs[0];
         assertEquals(1, pxg.getExternalWorkbookNumber(), "External workbook number");
         assertEquals("Sheet 1", pxg.getSheetName(), "Sheet name");

--- a/poi-ooxml/src/test/java/org/apache/poi/ss/tests/usermodel/TestEmbedOLEPackage.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/ss/tests/usermodel/TestEmbedOLEPackage.java
@@ -20,6 +20,7 @@ package org.apache.poi.ss.tests.usermodel;
 import static org.apache.poi.sl.tests.SLCommonUtils.xslfOnly;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
@@ -180,7 +181,7 @@ class TestEmbedOLEPackage {
         for (Sheet sheet : wb) {
             Drawing<? extends Shape> pat = sheet.getDrawingPatriarch();
             for (Shape shape : pat) {
-                assertTrue(shape instanceof ObjectData);
+                assertInstanceOf(ObjectData.class, shape);
                 ObjectData od = (ObjectData)shape;
                 EmbeddedData ed = ee.extractOne((DirectoryNode)od.getDirectory());
                 assertArrayEquals(data, ed.getEmbeddedData());

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/TestXSLFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/TestXSLFBugs.java
@@ -35,8 +35,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.text.AttributedCharacterIterator;
 import java.text.AttributedCharacterIterator.Attribute;
+import java.text.AttributedCharacterIterator;
 import java.text.CharacterIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,8 +54,8 @@ import org.apache.poi.POIDataSamples;
 import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.extractor.ExtractorFactory;
 import org.apache.poi.ooxml.HyperlinkRelationship;
-import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLDocumentPart.RelationPart;
+import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.ReferenceRelationship;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
@@ -65,11 +65,11 @@ import org.apache.poi.sl.draw.DrawFactory;
 import org.apache.poi.sl.draw.DrawPaint;
 import org.apache.poi.sl.extractor.SlideShowExtractor;
 import org.apache.poi.sl.usermodel.Hyperlink;
-import org.apache.poi.sl.usermodel.PaintStyle;
 import org.apache.poi.sl.usermodel.PaintStyle.SolidPaint;
 import org.apache.poi.sl.usermodel.PaintStyle.TexturePaint;
-import org.apache.poi.sl.usermodel.PictureData;
+import org.apache.poi.sl.usermodel.PaintStyle;
 import org.apache.poi.sl.usermodel.PictureData.PictureType;
+import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.sl.usermodel.PictureShape;
 import org.apache.poi.sl.usermodel.Shape;
 import org.apache.poi.sl.usermodel.ShapeType;
@@ -245,7 +245,7 @@ class TestXSLFBugs {
                 // relative url will be resolved to an absolute url, therefore this doesn't equals to "slide2.xml"
                 assertEquals("/ppt/slides/slide2.xml", h2.getAddress());
                 RelationPart sldRef = slide3.getRelationPartById(h2.getXmlObject().getId());
-                assertTrue(sldRef.getDocumentPart() instanceof XSLFSlide);
+                assertInstanceOf(XSLFSlide.class, sldRef.getDocumentPart());
             }
         }
 
@@ -734,7 +734,7 @@ class TestXSLFBugs {
     }
 
     private static void checkColor(Color expected, PaintStyle actualStyle) {
-        assertTrue(actualStyle instanceof SolidPaint);
+        assertInstanceOf(SolidPaint.class, actualStyle);
         SolidPaint ps = (SolidPaint) actualStyle;
         Color actual = DrawPaint.applyColorTransform(ps.getSolidColor());
         float[] expRGB = expected.getRGBComponents(null);
@@ -760,7 +760,7 @@ class TestXSLFBugs {
             newSlide.importContent(srcSlide);
             try (XMLSlideShow rwPptx = writeOutAndReadBack(newPptx)) {
                 PaintStyle ps = rwPptx.getSlides().get(0).getBackground().getFillStyle().getPaint();
-                assertTrue(ps instanceof TexturePaint);
+                assertInstanceOf(TexturePaint.class, ps);
             }
         }
     }
@@ -1023,7 +1023,7 @@ class TestXSLFBugs {
             int idx = 0;
             @Override
             public void clip(java.awt.Shape s) {
-                assertTrue(s instanceof Rectangle2D);
+                assertInstanceOf(Rectangle2D.class, s);
                 Rectangle2D r = (Rectangle2D)s;
 
                 double[] clip = clips[idx++];
@@ -1087,7 +1087,7 @@ class TestXSLFBugs {
             assertEquals(TextParagraph.TextAlign.RIGHT, tp.getTextAlign());
             XSLFTextRun tr = tp.getTextRuns().get(0);
             PaintStyle fc = tr.getFontColor();
-            assertTrue(fc instanceof SolidPaint);
+            assertInstanceOf(SolidPaint.class, fc);
             SolidPaint sp = (SolidPaint)fc;
             assertEquals(Color.RED, sp.getSolidColor().getColor());
         }

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFDiagram.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFDiagram.java
@@ -114,7 +114,7 @@ public class TestXSLFDiagram {
 
             // Shape 2 - Gradient Blue & Purple - "def" left aligned
             XSLFAutoShape gradientCircle = (XSLFAutoShape) shapes.get(2);
-            assertTrue(gradientCircle.getFillPaint() instanceof PaintStyle.GradientPaint);
+            assertInstanceOf(PaintStyle.GradientPaint.class, gradientCircle.getFillPaint());
             assertTrue(gradientCircle.getText().isEmpty());
 
             XSLFTextBox gradientCircleText = (XSLFTextBox) shapes.get(3);

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFExamples.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFExamples.java
@@ -18,7 +18,7 @@
 package org.apache.poi.xslf.usermodel;
 
 import static org.apache.poi.openxml4j.opc.PackageRelationshipTypes.CORE_PROPERTIES_ECMA376_NS;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.awt.Rectangle;
 import java.io.File;
@@ -112,7 +112,7 @@ class TestXSLFExamples {
 
             try (XMLSlideShow ppt2 = XSLFTestDataSamples.writeOutAndReadBack(pptx)) {
                 XSLFShape sh = ppt2.getSlides().get(0).getShapes().get(0);
-                assertTrue(sh instanceof XSLFPictureShape);
+                assertInstanceOf(XSLFPictureShape.class, sh);
             }
         }
     }

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFShape.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFShape.java
@@ -17,6 +17,7 @@
 package org.apache.poi.xslf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -54,7 +55,7 @@ class TestXSLFShape {
 
             XSLFSlide slide2 = slides.get(1);
             List<XSLFShape> shapes2 = slide2.getShapes();
-            assertTrue(shapes2.get(0) instanceof XSLFAutoShape);
+            assertInstanceOf(XSLFAutoShape.class, shapes2.get(0));
             assertEquals("PPTX Title", ((XSLFAutoShape) shapes2.get(0)).getText());
             XSLFAutoShape sh1 = (XSLFAutoShape) shapes2.get(0);
             List<XSLFTextParagraph> paragraphs1 = sh1.getTextParagraphs();
@@ -69,7 +70,7 @@ class TestXSLFShape {
             assertEquals(STTextUnderlineType.SNG, r2.get(1).getRPr(false).getU());
 
 
-            assertTrue(shapes2.get(1) instanceof XSLFAutoShape);
+            assertInstanceOf(XSLFAutoShape.class, shapes2.get(1));
             assertEquals("Subtitle\nAnd second line", ((XSLFAutoShape) shapes2.get(1)).getText());
             XSLFAutoShape sh2 = (XSLFAutoShape) shapes2.get(1);
             List<XSLFTextParagraph> paragraphs2 = sh2.getTextParagraphs();

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSheet.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSheet.java
@@ -64,10 +64,10 @@ class TestXSLFSheet {
         List<XSLFShape> shapes = slide.getShapes();
         assertEquals(4, shapes.size());
 
-        assertTrue(shapes.get(0) instanceof XSLFAutoShape);
-        assertTrue(shapes.get(1) instanceof XSLFTextBox);
-        assertTrue(shapes.get(2) instanceof XSLFConnectorShape);
-        assertTrue(shapes.get(3) instanceof XSLFGroupShape);
+        assertInstanceOf(XSLFAutoShape.class, shapes.get(0));
+        assertInstanceOf(XSLFTextBox.class, shapes.get(1));
+        assertInstanceOf(XSLFConnectorShape.class, shapes.get(2));
+        assertInstanceOf(XSLFGroupShape.class, shapes.get(3));
 
         ppt.close();
         ppt2.close();

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSimpleShape.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSimpleShape.java
@@ -18,6 +18,7 @@ package org.apache.poi.xslf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -328,7 +329,7 @@ class TestXSLFSimpleShape {
 
     static CTShapeProperties getSpPr(XSLFShape shape) {
         XmlObject xo = shape.getShapeProperties();
-        assertTrue(xo instanceof CTShapeProperties);
+        assertInstanceOf(CTShapeProperties.class, xo);
         return (CTShapeProperties)xo;
     }
 }

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlide.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFSlide.java
@@ -20,6 +20,7 @@ import static org.apache.poi.sl.usermodel.BaseTestSlideShow.getColor;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,60 +43,60 @@ class TestXSLFSlide {
         List<XSLFShape> shapes1 = slide1.getShapes();
         assertEquals(7, shapes1.size());
         assertEquals("TextBox 3", shapes1.get(0).getShapeName());
-        assertTrue(shapes1.get(0) instanceof XSLFTextBox);
+        assertInstanceOf(XSLFTextBox.class, shapes1.get(0));
         XSLFAutoShape sh0 = (XSLFAutoShape)shapes1.get(0);
         assertEquals("Learning PPTX", sh0.getText());
 
 
         assertEquals("Straight Connector 5", shapes1.get(1).getShapeName());
-        assertTrue(shapes1.get(1) instanceof XSLFConnectorShape);
+        assertInstanceOf(XSLFConnectorShape.class, shapes1.get(1));
 
         assertEquals("Freeform 6", shapes1.get(2).getShapeName());
-        assertTrue(shapes1.get(2) instanceof XSLFFreeformShape);
+        assertInstanceOf(XSLFFreeformShape.class, shapes1.get(2));
         XSLFAutoShape sh2 = (XSLFAutoShape)shapes1.get(2);
         assertEquals("Cloud", sh2.getText());
 
         assertEquals("Picture 1", shapes1.get(3).getShapeName());
-        assertTrue(shapes1.get(3) instanceof XSLFPictureShape);
+        assertInstanceOf(XSLFPictureShape.class, shapes1.get(3));
 
         assertEquals("Table 2", shapes1.get(4).getShapeName());
-        assertTrue(shapes1.get(4) instanceof XSLFGraphicFrame);
+        assertInstanceOf(XSLFGraphicFrame.class, shapes1.get(4));
 
         assertEquals("Straight Arrow Connector 7", shapes1.get(5).getShapeName());
-        assertTrue(shapes1.get(5) instanceof XSLFConnectorShape);
+        assertInstanceOf(XSLFConnectorShape.class, shapes1.get(5));
 
         assertEquals("Elbow Connector 9", shapes1.get(6).getShapeName());
-        assertTrue(shapes1.get(6) instanceof XSLFConnectorShape);
+        assertInstanceOf(XSLFConnectorShape.class, shapes1.get(6));
 
         // titles on slide2
         XSLFSlide slide2 = slides.get(1);
         List<XSLFShape> shapes2 = slide2.getShapes();
         assertEquals(2, shapes2.size());
-        assertTrue(shapes2.get(0) instanceof XSLFAutoShape);
+        assertInstanceOf(XSLFAutoShape.class, shapes2.get(0));
         assertEquals("PPTX Title", ((XSLFAutoShape)shapes2.get(0)).getText());
-        assertTrue(shapes2.get(1) instanceof XSLFAutoShape);
+        assertInstanceOf(XSLFAutoShape.class, shapes2.get(1));
         assertEquals("Subtitle\nAnd second line", ((XSLFAutoShape)shapes2.get(1)).getText());
 
         //  group shape on slide3
         XSLFSlide slide3 = slides.get(2);
         List<XSLFShape> shapes3 = slide3.getShapes();
         assertEquals(1, shapes3.size());
-        assertTrue(shapes3.get(0) instanceof XSLFGroupShape);
+        assertInstanceOf(XSLFGroupShape.class, shapes3.get(0));
         List<XSLFShape> groupShapes = ((XSLFGroupShape)shapes3.get(0)).getShapes();
         assertEquals(3, groupShapes.size());
-        assertTrue(groupShapes.get(0) instanceof XSLFAutoShape);
+        assertInstanceOf(XSLFAutoShape.class, groupShapes.get(0));
         assertEquals("Rectangle 1", groupShapes.get(0).getShapeName());
 
-        assertTrue(groupShapes.get(1) instanceof XSLFAutoShape);
+        assertInstanceOf(XSLFAutoShape.class, groupShapes.get(1));
         assertEquals("Oval 2", groupShapes.get(1).getShapeName());
 
-        assertTrue(groupShapes.get(2) instanceof XSLFAutoShape);
+        assertInstanceOf(XSLFAutoShape.class, groupShapes.get(2));
         assertEquals("Right Arrow 3", groupShapes.get(2).getShapeName());
 
         XSLFSlide slide4 = slides.get(3);
         List<XSLFShape> shapes4 = slide4.getShapes();
         assertEquals(1, shapes4.size());
-        assertTrue(shapes4.get(0) instanceof XSLFTable);
+        assertInstanceOf(XSLFTable.class, shapes4.get(0));
         XSLFTable tbl = (XSLFTable)shapes4.get(0);
         assertEquals(3, tbl.getNumberOfColumns());
         assertEquals(6, tbl.getNumberOfRows());

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTableCell.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTableCell.java
@@ -18,6 +18,7 @@ package org.apache.poi.xslf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,7 +40,7 @@ class TestXSLFTableCell
         XSLFSlide slide = ppt.getSlides().get(0);
         List<XSLFShape> shapes = slide.getShapes();
         assertEquals(1, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSLFTable);
+        assertInstanceOf(XSLFTable.class, shapes.get(0));
         XSLFTable tbl = (XSLFTable)shapes.get(0);
         assertEquals(1, tbl.getNumberOfColumns());
         assertEquals(2, tbl.getNumberOfRows());
@@ -64,7 +65,7 @@ class TestXSLFTableCell
         assertFalse(run00.isBold());
         assertFalse(run00.isItalic());
         assertNotNull(run00.getFontColor());
-        assertTrue(run00.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run00.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run00.getFontColor()).getSolidColor().getColor());
 
         // Second row has 1 col and 3 runs
@@ -84,7 +85,7 @@ class TestXSLFTableCell
         assertTrue(run10.isBold());
         assertFalse(run10.isItalic());
         assertNotNull(run10.getFontColor());
-        assertTrue(run10.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run10.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run10.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run11 = runs1.get(1);
@@ -92,7 +93,7 @@ class TestXSLFTableCell
         assertFalse(run11.isBold());
         assertFalse(run11.isItalic());
         assertNotNull(run11.getFontColor());
-        assertTrue(run11.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run11.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run11.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run12 = runs1.get(2);
@@ -100,7 +101,7 @@ class TestXSLFTableCell
         assertFalse(run12.isBold());
         assertTrue(run12.isItalic());
         assertNotNull(run12.getFontColor());
-        assertTrue(run12.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run12.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run12.getFontColor()).getSolidColor().getColor());
 
         ppt.close();
@@ -113,7 +114,7 @@ class TestXSLFTableCell
         XSLFSlide slide = ppt.getSlides().get(0);
         List<XSLFShape> shapes = slide.getShapes();
         assertEquals(1, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSLFTable);
+        assertInstanceOf(XSLFTable.class, shapes.get(0));
         XSLFTable tbl = (XSLFTable)shapes.get(0);
         assertEquals(1, tbl.getNumberOfColumns());
         assertEquals(2, tbl.getNumberOfRows());
@@ -138,7 +139,7 @@ class TestXSLFTableCell
         assertTrue(run00.isBold());
         assertFalse(run00.isItalic());
         assertNotNull(run00.getFontColor());
-        assertTrue(run00.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run00.getFontColor());
         assertEquals(Color.white, ((PaintStyle.SolidPaint)run00.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run01 = runs0.get(1);
@@ -146,7 +147,7 @@ class TestXSLFTableCell
         assertTrue(run01.isBold());
         assertFalse(run01.isItalic());
         assertNotNull(run01.getFontColor());
-        assertTrue(run01.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run01.getFontColor());
         assertEquals(Color.white, ((PaintStyle.SolidPaint)run01.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run02 = runs0.get(2);
@@ -154,7 +155,7 @@ class TestXSLFTableCell
         assertFalse(run02.isBold());
         assertFalse(run02.isItalic());
         assertNotNull(run02.getFontColor());
-        assertTrue(run02.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run02.getFontColor());
         assertEquals(Color.red, ((PaintStyle.SolidPaint)run02.getFontColor()).getSolidColor().getColor());
 
         // Second row has 1 col and 7 runs
@@ -174,7 +175,7 @@ class TestXSLFTableCell
         assertTrue(run10.isBold());
         assertFalse(run10.isItalic());
         assertNotNull(run10.getFontColor());
-        assertTrue(run10.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run10.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run10.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run11 = runs1.get(1);
@@ -182,7 +183,7 @@ class TestXSLFTableCell
         assertFalse(run11.isBold());
         assertFalse(run11.isItalic());
         assertNotNull(run11.getFontColor());
-        assertTrue(run11.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run11.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run11.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run12 = runs1.get(2);
@@ -190,7 +191,7 @@ class TestXSLFTableCell
         assertFalse(run12.isBold());
         assertTrue(run12.isItalic());
         assertNotNull(run12.getFontColor());
-        assertTrue(run12.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run12.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run12.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run13 = runs1.get(3);
@@ -198,7 +199,7 @@ class TestXSLFTableCell
         assertFalse(run13.isBold());
         assertFalse(run13.isItalic());
         assertNotNull(run13.getFontColor());
-        assertTrue(run13.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run13.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run13.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run14 = runs1.get(4);
@@ -206,7 +207,7 @@ class TestXSLFTableCell
         assertFalse(run14.isBold());
         assertFalse(run14.isItalic());
         assertNotNull(run14.getFontColor());
-        assertTrue(run14.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run14.getFontColor());
         assertEquals(Color.yellow, ((PaintStyle.SolidPaint)run14.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run15 = runs1.get(5);
@@ -214,7 +215,7 @@ class TestXSLFTableCell
         assertFalse(run15.isBold());
         assertFalse(run15.isItalic());
         assertNotNull(run15.getFontColor());
-        assertTrue(run15.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run15.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run15.getFontColor()).getSolidColor().getColor());
 
         XSLFTextRun run16 = runs1.get(6);
@@ -222,7 +223,7 @@ class TestXSLFTableCell
         assertFalse(run16.isBold());
         assertFalse(run16.isItalic());
         assertNotNull(run16.getFontColor());
-        assertTrue(run16.getFontColor() instanceof PaintStyle.SolidPaint);
+        assertInstanceOf(PaintStyle.SolidPaint.class, run16.getFontColor());
         assertEquals(Color.black, ((PaintStyle.SolidPaint)run16.getFontColor()).getSolidColor().getColor());
 
         ppt.close();
@@ -238,7 +239,7 @@ class TestXSLFTableCell
             List<XSLFTextRun> cellTextRuns = cellParagraphs.get(0).getTextRuns();
             PaintStyle fontColor = cellTextRuns.get(0).getFontColor();
             assertNotNull(fontColor);
-            assertTrue(fontColor instanceof PaintStyle.SolidPaint);
+            assertInstanceOf(PaintStyle.SolidPaint.class, fontColor);
             assertEquals(Color.black, ((PaintStyle.SolidPaint) fontColor).getSolidColor().getColor());
         }
     }

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTheme.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTheme.java
@@ -19,16 +19,17 @@ package org.apache.poi.xslf.usermodel;
 import static org.apache.poi.sl.usermodel.BaseTestSlideShow.getColor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
 import java.util.List;
 
-import org.apache.poi.sl.usermodel.PaintStyle;
 import org.apache.poi.sl.usermodel.PaintStyle.GradientPaint;
 import org.apache.poi.sl.usermodel.PaintStyle.SolidPaint;
 import org.apache.poi.sl.usermodel.PaintStyle.TexturePaint;
+import org.apache.poi.sl.usermodel.PaintStyle;
 import org.apache.poi.xslf.XSLFTestDataSamples;
 import org.junit.jupiter.api.Test;
 
@@ -72,7 +73,7 @@ class TestXSLFTheme {
         XSLFTextRun run1 = sh1.getTextParagraphs().get(0).getTextRuns().get(0);
         assertEquals(Color.white, getColor(run1.getFontColor()));
         assertEquals(new Color(79, 129, 189), sh1.getFillColor());
-        assertTrue(sh1.getFillStyle().getPaint() instanceof SolidPaint) ;   // solid fill
+        assertInstanceOf(SolidPaint.class, sh1.getFillStyle().getPaint()) ;   // solid fill
 
     }
 
@@ -84,18 +85,18 @@ class TestXSLFTheme {
 
     void slide3(XSLFSlide slide){
         PaintStyle fs = slide.getBackground().getFillStyle().getPaint();
-        assertTrue(fs instanceof GradientPaint);
+        assertInstanceOf(GradientPaint.class, fs);
     }
 
     void slide4(XSLFSlide slide){
         PaintStyle fs = slide.getBackground().getFillStyle().getPaint();
-        assertTrue(fs instanceof GradientPaint);
+        assertInstanceOf(GradientPaint.class, fs);
 
         XSLFTextShape sh1 = (XSLFTextShape)getShape(slide, "Rectangle 4");
         XSLFTextRun run1 = sh1.getTextParagraphs().get(0).getTextRuns().get(0);
         assertEquals(Color.white, getColor(run1.getFontColor()));
         assertEquals(new Color(148, 198, 0), sh1.getFillColor());
-        assertTrue(sh1.getFillStyle().getPaint() instanceof SolidPaint) ;   // solid fill
+        assertInstanceOf(SolidPaint.class, sh1.getFillStyle().getPaint()) ;   // solid fill
 
         XSLFTextShape sh2 = (XSLFTextShape)getShape(slide, "Title 3");
         XSLFTextRun run2 = sh2.getTextParagraphs().get(0).getTextRuns().get(0);
@@ -107,7 +108,7 @@ class TestXSLFTheme {
 
     void slide5(XSLFSlide slide){
         PaintStyle fs = slide.getBackground().getFillStyle().getPaint();
-        assertTrue(fs instanceof TexturePaint);
+        assertInstanceOf(TexturePaint.class, fs);
 
         XSLFTextShape sh2 = (XSLFTextShape)getShape(slide, "Title 1");
         XSLFTextRun run2 = sh2.getTextParagraphs().get(0).getTextRuns().get(0);
@@ -144,17 +145,17 @@ class TestXSLFTheme {
 
     void slide8(XSLFSlide slide){
         PaintStyle fs = slide.getBackground().getFillStyle().getPaint();
-        assertTrue(fs instanceof TexturePaint);
+        assertInstanceOf(TexturePaint.class, fs);
     }
 
     void slide9(XSLFSlide slide){
         PaintStyle fs = slide.getBackground().getFillStyle().getPaint();
-        assertTrue(fs instanceof TexturePaint);
+        assertInstanceOf(TexturePaint.class, fs);
     }
 
     void slide10(XSLFSlide slide){
         PaintStyle fs = slide.getBackground().getFillStyle().getPaint();
-        assertTrue(fs instanceof GradientPaint);
+        assertInstanceOf(GradientPaint.class, fs);
 
         XSLFTextShape sh1 = (XSLFTextShape)getShape(slide, "Title 3");
         XSLFTextRun run1 = sh1.getTextParagraphs().get(0).getTextRuns().get(0);

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFReader.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/eventusermodel/TestXSSFReader.java
@@ -75,14 +75,14 @@ public final class TestXSSFReader {
 
             SharedStrings sst1 = r.getSharedStringsTable();
             assertNotNull(sst1);
-            assertTrue(sst1 instanceof SharedStringsTable, "instanceof SharedStringsTable");
+            assertInstanceOf(SharedStringsTable.class, sst1, "instanceof SharedStringsTable");
 
             assertFalse(r.useReadOnlySharedStringsTable(), "useReadOnlySharedStringsTable defaults to false");
             r.setUseReadOnlySharedStringsTable(true);
             assertTrue(r.useReadOnlySharedStringsTable(), "useReadOnlySharedStringsTable changed to true");
             SharedStrings sst2 = r.getSharedStringsTable();
             assertNotNull(sst2);
-            assertTrue(sst2 instanceof ReadOnlySharedStringsTable, "instanceof ReadOnlySharedStringsTable");
+            assertInstanceOf(ReadOnlySharedStringsTable.class, sst2, "instanceof ReadOnlySharedStringsTable");
         }
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/model/TestStylesTable.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/model/TestStylesTable.java
@@ -23,6 +23,7 @@ import org.apache.poi.xssf.usermodel.XSSFRelation;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -216,7 +217,7 @@ public final class TestStylesTable {
             }
             IllegalStateException e = assertThrows(IllegalStateException.class,
                 () -> styles.putNumberFormat("\"anotherformat \"0"));
-            assertTrue(e.getMessage().startsWith("The maximum number of Data Formats was exceeded."));
+            assertStartsWith(e.getMessage(), "The maximum number of Data Formats was exceeded.");
         }
     }
 
@@ -299,7 +300,7 @@ public final class TestStylesTable {
             // Check negative (illegal) limits
             IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> styles.setMaxNumberOfDataFormats(-1),
                 "Expected to get an IllegalArgumentException(\"Maximum Number of Data Formats must be greater than or equal to 0\")");
-            assertTrue(e.getMessage().startsWith("Maximum Number of Data Formats must be greater than or equal to 0"));
+            assertStartsWith(e.getMessage(), "Maximum Number of Data Formats must be greater than or equal to 0");
         }
     }
 
@@ -311,7 +312,7 @@ public final class TestStylesTable {
 
             // Try adding a format beyond the upper limit
             IllegalStateException e = assertThrows(IllegalStateException.class, () -> styles.putNumberFormat("\"test \"0"));
-            assertTrue(e.getMessage().startsWith("The maximum number of Data Formats was exceeded."));
+            assertStartsWith(e.getMessage(), "The maximum number of Data Formats was exceeded.");
         }
     }
 
@@ -323,7 +324,7 @@ public final class TestStylesTable {
 
             // Try decreasing the upper limit below the current number of formats
             IllegalStateException e = assertThrows(IllegalStateException.class, () -> styles.setMaxNumberOfDataFormats(0));
-            assertTrue(e.getMessage().startsWith("Cannot set the maximum number of data formats less than the current quantity."));
+            assertStartsWith(e.getMessage(), "Cannot set the maximum number of data formats less than the current quantity.");
         }
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFChartSheet.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFChartSheet.java
@@ -35,7 +35,7 @@ public final class TestXSSFChartSheet {
 
             //the third sheet is of type 'chartsheet'
             assertEquals("Chart1", wb.getSheetName(2));
-            assertTrue(wb.getSheetAt(2) instanceof XSSFChartSheet);
+            assertInstanceOf(XSSFChartSheet.class, wb.getSheetAt(2));
             assertEquals("Chart1", wb.getSheetAt(2).getSheetName());
 
             final CTChartsheet ctChartsheet = ((XSSFChartSheet) wb.getSheetAt(2)).getCTChartsheet();

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFConditionalFormatting.java
@@ -20,6 +20,7 @@ package org.apache.poi.xssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -152,8 +153,7 @@ class TestXSSFConditionalFormatting extends BaseTestConditionalFormatting {
     protected void checkThreshold(ConditionalFormattingThreshold threshold) {
         assertNull(threshold.getValue());
         assertNull(threshold.getFormula());
-        assertTrue(threshold instanceof XSSFConditionalFormattingThreshold,
-                "threshold is a XSSFConditionalFormattingThreshold?");
+        assertInstanceOf(XSSFConditionalFormattingThreshold.class, threshold, "threshold is a XSSFConditionalFormattingThreshold?");
         XSSFConditionalFormattingThreshold xssfThreshold = (XSSFConditionalFormattingThreshold)threshold;
         assertTrue(xssfThreshold.isGte(), "gte defaults to true?");
         xssfThreshold.setGte(false);

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFDrawing.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFDrawing.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.poi.hssf.HSSFTestDataSamples;
-import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLDocumentPart.RelationPart;
+import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.FontUnderline;
@@ -62,7 +62,7 @@ class TestXSSFDrawing {
         List<RelationPart> rels = sheet.getRelationParts();
         assertEquals(1, rels.size());
         RelationPart rp = rels.get(0);
-        assertTrue(rp.getDocumentPart() instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rp.getDocumentPart());
 
         XSSFDrawing drawing = rp.getDocumentPart();
         //sheet.createDrawingPatriarch() should return the same instance of XSSFDrawing
@@ -76,12 +76,12 @@ class TestXSSFDrawing {
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(6, shapes.size());
 
-        assertTrue(shapes.get(0) instanceof XSSFPicture);
-        assertTrue(shapes.get(1) instanceof XSSFPicture);
-        assertTrue(shapes.get(2) instanceof XSSFPicture);
-        assertTrue(shapes.get(3) instanceof XSSFPicture);
-        assertTrue(shapes.get(4) instanceof XSSFSimpleShape);
-        assertTrue(shapes.get(5) instanceof XSSFPicture);
+        assertInstanceOf(XSSFPicture.class, shapes.get(0));
+        assertInstanceOf(XSSFPicture.class, shapes.get(1));
+        assertInstanceOf(XSSFPicture.class, shapes.get(2));
+        assertInstanceOf(XSSFPicture.class, shapes.get(3));
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(4));
+        assertInstanceOf(XSSFPicture.class, shapes.get(5));
 
         for(XSSFShape sh : shapes) assertNotNull(sh.getAnchor());
 
@@ -101,7 +101,7 @@ class TestXSSFDrawing {
         List<RelationPart> rels = sheet.getRelationParts();
         assertEquals(1, rels.size());
         RelationPart rp = rels.get(0);
-        assertTrue(rp.getDocumentPart() instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rp.getDocumentPart());
 
         XSSFDrawing drawing = rp.getDocumentPart();
         String drawingId = rp.getRelationship().getId();
@@ -132,10 +132,10 @@ class TestXSSFDrawing {
 
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(4, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFConnector);
-        assertTrue(shapes.get(1) instanceof XSSFShapeGroup);
-        assertTrue(shapes.get(2) instanceof XSSFSimpleShape);
-        assertTrue(shapes.get(3) instanceof XSSFSimpleShape); //
+        assertInstanceOf(XSSFConnector.class, shapes.get(0));
+        assertInstanceOf(XSSFShapeGroup.class, shapes.get(1));
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(2));
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(3)); //
 
         // Save and re-load it
         XSSFWorkbook wb2 = XSSFTestDataSamples.writeOutAndReadBack(wb1);
@@ -192,11 +192,11 @@ class TestXSSFDrawing {
         //the source sheet has one relationship and it is XSSFDrawing
         List<POIXMLDocumentPart> rels1 = sheet1.getRelations();
         assertEquals(1, rels1.size());
-        assertTrue(rels1.get(0) instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rels1.get(0));
 
         List<POIXMLDocumentPart> rels2 = sheet2.getRelations();
         assertEquals(1, rels2.size());
-        assertTrue(rels2.get(0) instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rels2.get(0));
 
         XSSFDrawing drawing1 = (XSSFDrawing)rels1.get(0);
         XSSFDrawing drawing2 = (XSSFDrawing)rels2.get(0);
@@ -420,7 +420,7 @@ class TestXSSFDrawing {
 
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(1, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFSimpleShape);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(0));
 
         XSSFSimpleShape sshape = (XSSFSimpleShape) shapes.get(0);
 
@@ -526,7 +526,7 @@ class TestXSSFDrawing {
         List<RelationPart> rels = sheet.getRelationParts();
         assertEquals(1, rels.size());
         RelationPart rp = rels.get(0);
-        assertTrue(rp.getDocumentPart() instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rp.getDocumentPart());
 
         XSSFDrawing drawing = rp.getDocumentPart();
         //sheet.createDrawingPatriarch() should return the same instance of XSSFDrawing
@@ -540,7 +540,7 @@ class TestXSSFDrawing {
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(6, shapes.size());
 
-        assertTrue(shapes.get(4) instanceof XSSFSimpleShape);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(4));
 
         XSSFSimpleShape textbox = (XSSFSimpleShape) shapes.get(4);
         assertEquals("Sheet with various pictures\n(jpeg, png, wmf, emf and pict)", textbox.getText());
@@ -562,7 +562,7 @@ class TestXSSFDrawing {
         assertEquals(1, rels.size());
         RelationPart rp = rels.get(0);
 
-        assertTrue(rp.getDocumentPart() instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rp.getDocumentPart());
 
         XSSFDrawing drawing = rp.getDocumentPart();
 
@@ -577,7 +577,7 @@ class TestXSSFDrawing {
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(1, shapes.size());
 
-        assertTrue(shapes.get(0) instanceof XSSFSimpleShape);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(0));
 
         XSSFSimpleShape textbox = (XSSFSimpleShape) shapes.get(0);
 
@@ -681,7 +681,7 @@ class TestXSSFDrawing {
 
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(1, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFSimpleShape);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(0));
 
         XSSFSimpleShape sshape = (XSSFSimpleShape) shapes.get(0);
 
@@ -782,7 +782,7 @@ class TestXSSFDrawing {
         List<RelationPart> rels = sheet.getRelationParts();
         assertEquals(1, rels.size());
         RelationPart rp = rels.get(0);
-        assertTrue(rp.getDocumentPart() instanceof XSSFDrawing);
+        assertInstanceOf(XSSFDrawing.class, rp.getDocumentPart());
 
         assertEquals(0, rp.getDocumentPart().getRelations().size());
 
@@ -809,8 +809,8 @@ class TestXSSFDrawing {
 
         List<XSSFShape> shapes = drawing.getShapes();
         assertEquals(3, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFPicture);
-        assertTrue(shapes.get(1) instanceof XSSFPicture);
+        assertInstanceOf(XSSFPicture.class, shapes.get(0));
+        assertInstanceOf(XSSFPicture.class, shapes.get(1));
 
         // Save and re-load it
         XSSFWorkbook wb2 = XSSFTestDataSamples.writeOutAndReadBack(wb1);
@@ -828,8 +828,8 @@ class TestXSSFDrawing {
 
         shapes = dr1.getShapes();
         assertEquals(3, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFPicture);
-        assertTrue(shapes.get(1) instanceof XSSFPicture);
+        assertInstanceOf(XSSFPicture.class, shapes.get(0));
+        assertInstanceOf(XSSFPicture.class, shapes.get(1));
 
         checkRewrite(wb2);
         wb2.close();
@@ -896,15 +896,15 @@ class TestXSSFDrawing {
         XSSFDrawing draw = wb2.getSheetAt(0).getDrawingPatriarch();
         List<XSSFShape> shapes = draw.getShapes();
         assertEquals(2, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFSimpleShape);
-        assertTrue(shapes.get(1) instanceof XSSFShapeGroup);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(0));
+        assertInstanceOf(XSSFShapeGroup.class, shapes.get(1));
         shapes = draw.getShapes((XSSFShapeGroup)shapes.get(1));
         assertEquals(2, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFSimpleShape);
-        assertTrue(shapes.get(1) instanceof XSSFShapeGroup);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(0));
+        assertInstanceOf(XSSFShapeGroup.class, shapes.get(1));
         shapes = draw.getShapes((XSSFShapeGroup)shapes.get(1));
         assertEquals(1, shapes.size());
-        assertTrue(shapes.get(0) instanceof XSSFSimpleShape);
+        assertInstanceOf(XSSFSimpleShape.class, shapes.get(0));
 
         wb2.close();
     }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFFormulaParser.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFFormulaParser.java
@@ -18,6 +18,7 @@
 package org.apache.poi.xssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -151,12 +152,12 @@ public final class TestXSSFFormulaParser {
 
         ptgs = parse(fpb, "LOG10");
         assertEquals(1, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
 
         ptgs = parse(fpb, "LOG10(100)");
         assertEquals(2, ptgs.length);
-        assertTrue(ptgs[0] instanceof IntPtg);
-        assertTrue(ptgs[1] instanceof FuncPtg);
+        assertInstanceOf(IntPtg.class, ptgs[0]);
+        assertInstanceOf(FuncPtg.class, ptgs[1]);
 
         wb.close();
     }
@@ -492,36 +493,36 @@ public final class TestXSSFFormulaParser {
         // verify whitespaces in different places
         ptgs = parse(fpb, "(ABC10)");
         assertEquals(2, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
-        assertTrue(ptgs[1] instanceof ParenthesisPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[1]);
 
         ptgs = parse(fpb, "( ABC10)");
         assertEquals(2, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
-        assertTrue(ptgs[1] instanceof ParenthesisPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[1]);
 
         ptgs = parse(fpb, "(ABC10 )");
         assertEquals(2, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
-        assertTrue(ptgs[1] instanceof ParenthesisPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[1]);
 
         ptgs = parse(fpb, "((ABC10))");
         assertEquals(3, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
-        assertTrue(ptgs[1] instanceof ParenthesisPtg);
-        assertTrue(ptgs[2] instanceof ParenthesisPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[1]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[2]);
 
         ptgs = parse(fpb, "((ABC10) )");
         assertEquals(3, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
-        assertTrue(ptgs[1] instanceof ParenthesisPtg);
-        assertTrue(ptgs[2] instanceof ParenthesisPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[1]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[2]);
 
         ptgs = parse(fpb, "( (ABC10))");
         assertEquals(3, ptgs.length);
-        assertTrue(ptgs[0] instanceof RefPtg);
-        assertTrue(ptgs[1] instanceof ParenthesisPtg);
-        assertTrue(ptgs[2] instanceof ParenthesisPtg);
+        assertInstanceOf(RefPtg.class, ptgs[0]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[1]);
+        assertInstanceOf(ParenthesisPtg.class, ptgs[2]);
 
         wb.close();
     }
@@ -571,35 +572,35 @@ public final class TestXSSFFormulaParser {
         // verify whitespaces in different places
         ptgs = parse(fpb, "INTERCEPT(A2:A5, B2:B5)");
         assertEquals(3, ptgs.length);
-        assertTrue(ptgs[0] instanceof AreaPtg);
-        assertTrue(ptgs[1] instanceof AreaPtg);
-        assertTrue(ptgs[2] instanceof FuncPtg);
+        assertInstanceOf(AreaPtg.class, ptgs[0]);
+        assertInstanceOf(AreaPtg.class, ptgs[1]);
+        assertInstanceOf(FuncPtg.class, ptgs[2]);
 
         ptgs = parse(fpb, " INTERCEPT ( \t \r A2 : \nA5 , B2 : B5 ) \t");
         assertEquals(3, ptgs.length);
-        assertTrue(ptgs[0] instanceof AreaPtg);
-        assertTrue(ptgs[1] instanceof AreaPtg);
-        assertTrue(ptgs[2] instanceof FuncPtg);
+        assertInstanceOf(AreaPtg.class, ptgs[0]);
+        assertInstanceOf(AreaPtg.class, ptgs[1]);
+        assertInstanceOf(FuncPtg.class, ptgs[2]);
 
         ptgs = parse(fpb, "(VLOOKUP(\"item1\", A2:B3, 2, FALSE) - VLOOKUP(\"item2\", A2:B3, 2, FALSE) )");
         assertEquals(12, ptgs.length);
-        assertTrue(ptgs[0] instanceof StringPtg);
-        assertTrue(ptgs[1] instanceof AreaPtg);
-        assertTrue(ptgs[2] instanceof IntPtg);
+        assertInstanceOf(StringPtg.class, ptgs[0]);
+        assertInstanceOf(AreaPtg.class, ptgs[1]);
+        assertInstanceOf(IntPtg.class, ptgs[2]);
 
         ptgs = parse(fpb, "A1:B1 B1:B2");
         assertEquals(4, ptgs.length);
-        assertTrue(ptgs[0] instanceof MemAreaPtg);
-        assertTrue(ptgs[1] instanceof AreaPtg);
-        assertTrue(ptgs[2] instanceof AreaPtg);
-        assertTrue(ptgs[3] instanceof IntersectionPtg);
+        assertInstanceOf(MemAreaPtg.class, ptgs[0]);
+        assertInstanceOf(AreaPtg.class, ptgs[1]);
+        assertInstanceOf(AreaPtg.class, ptgs[2]);
+        assertInstanceOf(IntersectionPtg.class, ptgs[3]);
 
         ptgs = parse(fpb, "A1:B1    B1:B2");
         assertEquals(4, ptgs.length);
-        assertTrue(ptgs[0] instanceof MemAreaPtg);
-        assertTrue(ptgs[1] instanceof AreaPtg);
-        assertTrue(ptgs[2] instanceof AreaPtg);
-        assertTrue(ptgs[3] instanceof IntersectionPtg);
+        assertInstanceOf(MemAreaPtg.class, ptgs[0]);
+        assertInstanceOf(AreaPtg.class, ptgs[1]);
+        assertInstanceOf(AreaPtg.class, ptgs[2]);
+        assertInstanceOf(IntersectionPtg.class, ptgs[3]);
 
         wb.close();
     }
@@ -613,17 +614,17 @@ public final class TestXSSFFormulaParser {
         // verify whitespaces in different places
         ptgs = parse(fpb, "SUM(A1:INDEX(1:1048576,MAX(IFERROR(MATCH(99^99,B:B,1),0),IFERROR(MATCH(\"zzzz\",B:B,1),0)),MAX(IFERROR(MATCH(99^99,1:1,1),0),IFERROR(MATCH(\"zzzz\",1:1,1),0))))");
         assertEquals(40, ptgs.length);
-        assertTrue(ptgs[0] instanceof MemFuncPtg);
-        assertTrue(ptgs[1] instanceof RefPtg);
-        assertTrue(ptgs[2] instanceof AreaPtg);
-        assertTrue(ptgs[3] instanceof NameXPxg);
+        assertInstanceOf(MemFuncPtg.class, ptgs[0]);
+        assertInstanceOf(RefPtg.class, ptgs[1]);
+        assertInstanceOf(AreaPtg.class, ptgs[2]);
+        assertInstanceOf(NameXPxg.class, ptgs[3]);
 
         ptgs = parse(fpb, "SUM ( A1 : INDEX( 1 : 1048576 , MAX( IFERROR ( MATCH ( 99 ^ 99 , B : B , 1 ) , 0 ) , IFERROR ( MATCH ( \"zzzz\" , B:B , 1 ) , 0 ) ) , MAX ( IFERROR ( MATCH ( 99 ^ 99 , 1 : 1 , 1 ) , 0 ) , IFERROR ( MATCH ( \"zzzz\" , 1 : 1 , 1 )   , 0 )   )   )   )");
         assertEquals(40, ptgs.length);
-        assertTrue(ptgs[0] instanceof MemFuncPtg);
-        assertTrue(ptgs[1] instanceof RefPtg);
-        assertTrue(ptgs[2] instanceof AreaPtg);
-        assertTrue(ptgs[3] instanceof NameXPxg);
+        assertInstanceOf(MemFuncPtg.class, ptgs[0]);
+        assertInstanceOf(RefPtg.class, ptgs[1]);
+        assertInstanceOf(AreaPtg.class, ptgs[2]);
+        assertInstanceOf(NameXPxg.class, ptgs[3]);
 
         wb.close();
     }
@@ -666,7 +667,7 @@ public final class TestXSSFFormulaParser {
         assertEquals(2, ptgs.length);
 
         // Area3DPxg [sheet=Table ! A2:A7]
-        assertTrue(ptgs[0] instanceof Area3DPxg);
+        assertInstanceOf(Area3DPxg.class, ptgs[0]);
         Area3DPxg ptg0 = (Area3DPxg) ptgs[0];
         assertEquals("Table", ptg0.getSheetName());
         assertEquals("A2:A7", ptg0.format2DRefAsString());
@@ -674,7 +675,7 @@ public final class TestXSSFFormulaParser {
         assertEquals("Table!A2:A7", ptg0.toFormulaString());
 
         // AttrPtg [sum ]
-        assertTrue(ptgs[1] instanceof AttrPtg);
+        assertInstanceOf(AttrPtg.class, ptgs[1]);
         AttrPtg ptg1 = (AttrPtg) ptgs[1];
         assertTrue(ptg1.isSum());
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFSimpleShape.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFSimpleShape.java
@@ -18,6 +18,7 @@ package org.apache.poi.xssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -186,16 +187,16 @@ class TestXSSFSimpleShape {
             assertTrue(shape.getWordWrap());
 
             assertEquals(TextAutofit.NORMAL, shape.getTextAutofit());
-            assertTrue(props.getAutoFit() instanceof XDDFNormalAutoFit);
+            assertInstanceOf(XDDFNormalAutoFit.class, props.getAutoFit());
             shape.setTextAutofit(TextAutofit.NORMAL);
             assertEquals(TextAutofit.NORMAL, shape.getTextAutofit());
-            assertTrue(props.getAutoFit() instanceof XDDFNormalAutoFit);
+            assertInstanceOf(XDDFNormalAutoFit.class, props.getAutoFit());
             shape.setTextAutofit(TextAutofit.SHAPE);
             assertEquals(TextAutofit.SHAPE, shape.getTextAutofit());
-            assertTrue(props.getAutoFit() instanceof XDDFShapeAutoFit);
+            assertInstanceOf(XDDFShapeAutoFit.class, props.getAutoFit());
             shape.setTextAutofit(TextAutofit.NONE);
             assertEquals(TextAutofit.NONE, shape.getTextAutofit());
-            assertTrue(props.getAutoFit() instanceof XDDFNoAutoFit);
+            assertInstanceOf(XDDFNoAutoFit.class, props.getAutoFit());
 
             assertEquals(5, shape.getShapeType());
             shape.setShapeType(23);

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFWorkbook.java
@@ -51,8 +51,8 @@ import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.FormulaError;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.RichTextString;
-import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Row.MissingCellPolicy;
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -93,6 +93,7 @@ import java.util.Locale;
 import java.util.zip.CRC32;
 
 import static org.apache.poi.POITestCase.assertContains;
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.apache.poi.hssf.HSSFTestDataSamples.openSampleFileStream;
 import static org.apache.poi.xssf.XSSFTestDataSamples.getSampleFile;
 import static org.apache.poi.xssf.XSSFTestDataSamples.openSampleWorkbook;
@@ -101,6 +102,7 @@ import static org.apache.poi.xssf.XSSFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -489,7 +491,7 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
             assertEquals("Numbers", wb1.getSheetName(0));
             //the second sheet is of type 'chartsheet'
             assertEquals("Chart", wb1.getSheetName(1));
-            assertTrue(wb1.getSheetAt(1) instanceof XSSFChartSheet);
+            assertInstanceOf(XSSFChartSheet.class, wb1.getSheetAt(1));
             assertEquals("SomeJunk", wb1.getSheetName(2));
 
             wb1.removeSheetAt(2);
@@ -771,9 +773,9 @@ public final class TestXSSFWorkbook extends BaseTestXWorkbook {
                 assertSheetOrder(read, "Sheet1-Renamed", "Sheet2", "Sheet3");
                 XSSFSheet sheet = (XSSFSheet) read.getSheet("Sheet1-Renamed");
                 XDDFChartData.Series series = sheet.getDrawingPatriarch().getCharts().get(0).getChartSeries().get(0).getSeries(0);
-                assertTrue(series instanceof XDDFBarChartData.Series, "should be a bar chart data series");
+                assertInstanceOf(XDDFBarChartData.Series.class, series, "should be a bar chart data series");
                 String formula = series.getCategoryData().getFormula();
-                assertTrue(formula.startsWith("'Sheet1-Renamed'!"), "should contain new sheet name");
+                assertStartsWith("should contain new sheet name", formula, "'Sheet1-Renamed'!");
             }
         }
     }

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/extractor/TestXWPFWordExtractor.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/extractor/TestXWPFWordExtractor.java
@@ -22,7 +22,6 @@ import static org.apache.poi.POITestCase.assertEndsWith;
 import static org.apache.poi.POITestCase.assertNotContains;
 import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -291,8 +290,8 @@ class TestXWPFWordExtractor {
             XWPFWordExtractor extractor = new XWPFWordExtractor(doc)) {
             String text = extractor.getText();
             assertTrue(text.length() > 0);
-            assertFalse(text.contains("AUTHOR"));
-            assertFalse(text.contains("CREATEDATE"));
+            assertNotContains(text, "AUTHOR");
+            assertNotContains(text, "CREATEDATE");
         }
     }
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestXWPFDecorators.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/model/TestXWPFDecorators.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * Tests for the various XWPF decorators
@@ -73,7 +73,7 @@ class TestXWPFDecorators {
         // The proper way to do hyperlinks(!)
         assertFalse(ps.getRuns().get(0) instanceof XWPFHyperlinkRun);
         assertFalse(ph.getRuns().get(0) instanceof XWPFHyperlinkRun);
-        assertTrue(ph.getRuns().get(1) instanceof XWPFHyperlinkRun);
+        assertInstanceOf(XWPFHyperlinkRun.class, ph.getRuns().get(1));
         assertFalse(ph.getRuns().get(2) instanceof XWPFHyperlinkRun);
 
         XWPFHyperlinkRun link = (XWPFHyperlinkRun) ph.getRuns().get(1);

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFSDT.java
@@ -19,6 +19,7 @@ package org.apache.poi.xwpf.usermodel;
 
 import static org.apache.poi.POITestCase.assertContains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -99,21 +100,21 @@ public final class TestXWPFSDT {
     void testGetSDTContentBodyElements() throws Exception {
         try (XWPFDocument doc = XWPFTestDataSamples.openSampleDocument("Bug54849.docx")) {
             IBodyElement sdtBodyElement = doc.getBodyElements().get(2);
-            assertTrue(sdtBodyElement instanceof XWPFSDT, "sdtBodyElement instance of XWPFSDT");
+            assertInstanceOf(XWPFSDT.class, sdtBodyElement, "sdtBodyElement instance of XWPFSDT");
             XWPFSDTContent content = (XWPFSDTContent) ((XWPFSDT) sdtBodyElement).getContent();
             assertEquals(3, content.getBodyElements().size(), "elements inside SDT");
 
             ISDTContents c1 = content.getBodyElements().get(0);
-            assertTrue(c1 instanceof XWPFParagraph, "c1 instance of XWPFParagraph");
+            assertInstanceOf(XWPFParagraph.class, c1, "c1 instance of XWPFParagraph");
             assertEquals("Rich_text_pre_table", ((XWPFParagraph) c1).getText());
 
             ISDTContents c2 = content.getBodyElements().get(1);
-            assertTrue(c2 instanceof XWPFTable, "c2 instance of XWPFTable");
+            assertInstanceOf(XWPFTable.class, c2, "c2 instance of XWPFTable");
             assertEquals(3, ((XWPFTable) c2).getNumberOfRows(), "rows in table inside SDT");
             assertEquals("Rich_text_cell1", ((XWPFTable) c2).getRow(0).getCell(0).getText());
 
             ISDTContents c3 = content.getBodyElements().get(2);
-            assertTrue(c3 instanceof XWPFParagraph, "c3 instance of XWPFParagraph");
+            assertInstanceOf(XWPFParagraph.class, c3, "c3 instance of XWPFParagraph");
             assertEquals("Rich_text_post_table", ((XWPFParagraph) c3).getText());
         }
     }

--- a/poi-scratchpad/src/test/java/org/apache/poi/hdgf/chunks/TestChunks.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hdgf/chunks/TestChunks.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hdgf.chunks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -50,7 +51,7 @@ public final class TestChunks {
     void testChunkHeaderA() {
         ChunkHeader h = ChunkHeader.createChunkHeader(11, data_a, 0);
 
-        assertTrue(h instanceof ChunkHeaderV11);
+        assertInstanceOf(ChunkHeaderV11.class, h);
         ChunkHeaderV11 header = (ChunkHeaderV11)h;
 
         assertEquals(70, header.getType());
@@ -112,7 +113,7 @@ public final class TestChunks {
     void testChunkHeaderB() {
         ChunkHeader h = ChunkHeader.createChunkHeader(11, data_b, 0);
 
-        assertTrue(h instanceof ChunkHeaderV11);
+        assertInstanceOf(ChunkHeaderV11.class, h);
         ChunkHeaderV11 header = (ChunkHeaderV11)h;
 
         assertEquals(70, header.getType());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hdgf/streams/TestStreamBasics.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hdgf/streams/TestStreamBasics.java
@@ -20,8 +20,8 @@ package org.apache.poi.hdgf.streams;
 import static org.apache.poi.poifs.storage.RawDataUtil.decompress;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -65,8 +65,8 @@ public final class TestStreamBasics extends StreamTest {
         // Check
         assertNotNull(stream.getPointer());
         assertNotNull(stream.getStore());
-        assertTrue(stream.getStore() instanceof CompressedStreamStore);
-        assertTrue(stream instanceof UnknownStream);
+        assertInstanceOf(CompressedStreamStore.class, stream.getStore());
+        assertInstanceOf(UnknownStream.class, stream);
 
         // Check the stream store
         CompressedStreamStore ss = (CompressedStreamStore)stream.getStore();
@@ -90,6 +90,6 @@ public final class TestStreamBasics extends StreamTest {
         assertNotNull(stream.getPointer());
         assertNotNull(stream.getStore());
         assertFalse(stream.getStore() instanceof CompressedStreamStore);
-        assertTrue(stream instanceof UnknownStream);
+        assertInstanceOf(UnknownStream.class, stream);
     }
 }

--- a/poi-scratchpad/src/test/java/org/apache/poi/hdgf/streams/TestStreamComplex.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hdgf/streams/TestStreamComplex.java
@@ -19,6 +19,7 @@ package org.apache.poi.hdgf.streams;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,7 +73,7 @@ public final class TestStreamComplex extends StreamTest {
         assertEquals(trailerDataAt, trailerPtr.getOffset());
 
         Stream stream = Stream.createStream(trailerPtr, contents, chunkFactory, ptrFactory);
-        assertTrue(stream instanceof TrailerStream);
+        assertInstanceOf(TrailerStream.class, stream);
         TrailerStream ts = (TrailerStream)stream;
 
         assertNotNull(ts.getChildPointers());
@@ -99,7 +100,7 @@ public final class TestStreamComplex extends StreamTest {
 
         Stream stream = Stream.createStream(chunkPtr, contents, chunkFactory, ptrFactory);
         assertNotNull(stream);
-        assertTrue(stream instanceof ChunkStream);
+        assertInstanceOf(ChunkStream.class, stream);
 
         // Now find the chunks within it
         ChunkStream cs = (ChunkStream)stream;
@@ -120,7 +121,7 @@ public final class TestStreamComplex extends StreamTest {
 
         Stream stream = Stream.createStream(stringPtr, contents, chunkFactory, ptrFactory);
         assertNotNull(stream);
-        assertTrue(stream instanceof StringsStream);
+        assertInstanceOf(StringsStream.class, stream);
     }
 
     @Test
@@ -164,8 +165,8 @@ public final class TestStreamComplex extends StreamTest {
         // Should have two, both strings
         assertNotNull(s4312.getPointedToStreams());
         assertEquals(2, s4312.getPointedToStreams().length);
-        assertTrue(s4312.getPointedToStreams()[0] instanceof StringsStream);
-        assertTrue(s4312.getPointedToStreams()[1] instanceof StringsStream);
+        assertInstanceOf(StringsStream.class, s4312.getPointedToStreams()[0]);
+        assertInstanceOf(StringsStream.class, s4312.getPointedToStreams()[1]);
     }
 
     @Test
@@ -188,36 +189,36 @@ public final class TestStreamComplex extends StreamTest {
         // Step down:
         // 8 -> 4 -> 5 -> 1 -> 0 == String
         assertNotNull(ts.getPointedToStreams()[8]);
-        assertTrue(ts.getPointedToStreams()[8] instanceof PointerContainingStream);
+        assertInstanceOf(PointerContainingStream.class, ts.getPointedToStreams()[8]);
 
         PointerContainingStream s8 =
             (PointerContainingStream)ts.getPointedToStreams()[8];
         assertNotNull(s8.getPointedToStreams());
 
         assertNotNull(s8.getPointedToStreams()[4]);
-        assertTrue(s8.getPointedToStreams()[4] instanceof PointerContainingStream);
+        assertInstanceOf(PointerContainingStream.class, s8.getPointedToStreams()[4]);
 
         PointerContainingStream s84 =
             (PointerContainingStream)s8.getPointedToStreams()[4];
         assertNotNull(s84.getPointedToStreams());
 
         assertNotNull(s84.getPointedToStreams()[5]);
-        assertTrue(s84.getPointedToStreams()[5] instanceof PointerContainingStream);
+        assertInstanceOf(PointerContainingStream.class, s84.getPointedToStreams()[5]);
 
         PointerContainingStream s845 =
             (PointerContainingStream)s84.getPointedToStreams()[5];
         assertNotNull(s845.getPointedToStreams());
 
         assertNotNull(s845.getPointedToStreams()[1]);
-        assertTrue(s845.getPointedToStreams()[1] instanceof PointerContainingStream);
+        assertInstanceOf(PointerContainingStream.class, s845.getPointedToStreams()[1]);
 
         PointerContainingStream s8451 =
             (PointerContainingStream)s845.getPointedToStreams()[1];
         assertNotNull(s8451.getPointedToStreams());
 
         assertNotNull(s8451.getPointedToStreams()[0]);
-        assertTrue(s8451.getPointedToStreams()[0] instanceof StringsStream);
-        assertTrue(s8451.getPointedToStreams()[1] instanceof StringsStream);
+        assertInstanceOf(StringsStream.class, s8451.getPointedToStreams()[0]);
+        assertInstanceOf(StringsStream.class, s8451.getPointedToStreams()[1]);
     }
 
     @Test

--- a/poi-scratchpad/src/test/java/org/apache/poi/hmef/TestCompressedRTF.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hmef/TestCompressedRTF.java
@@ -19,8 +19,8 @@ package org.apache.poi.hmef;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -55,7 +55,7 @@ public final class TestCompressedRTF {
 
         MAPIAttribute rtfAttr = msg.getMessageMAPIAttribute(MAPIProperty.RTF_COMPRESSED);
         assertNotNull(rtfAttr);
-        assertTrue(rtfAttr instanceof MAPIRtfAttribute);
+        assertInstanceOf(MAPIRtfAttribute.class, rtfAttr);
 
         // Check the start of the compressed version
         byte[] data = ((MAPIRtfAttribute) rtfAttr).getRawData();

--- a/poi-scratchpad/src/test/java/org/apache/poi/hpbf/model/TestQuillContents.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hpbf/model/TestQuillContents.java
@@ -17,12 +17,12 @@
 
 package org.apache.poi.hpbf.model;
 
-import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.apache.poi.POITestCase.assertEndsWith;
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -98,9 +98,9 @@ public final class TestQuillContents {
         QuillContents qc = doc.getQuillContents();
         assertEquals(20, qc.getBits().length);
 
-        assertTrue(qc.getBits()[9] instanceof Type4);
-        assertTrue(qc.getBits()[10] instanceof Type4);
-        assertTrue(qc.getBits()[12] instanceof Type8);
+        assertInstanceOf(Type4.class, qc.getBits()[9]);
+        assertInstanceOf(Type4.class, qc.getBits()[10]);
+        assertInstanceOf(Type8.class, qc.getBits()[12]);
 
         Type4 plc9 = (Type4)qc.getBits()[9];
         Type4 plc10 = (Type4)qc.getBits()[10];
@@ -162,12 +162,12 @@ public final class TestQuillContents {
         QuillContents qc = doc.getQuillContents();
         assertEquals(20, qc.getBits().length);
 
-        assertTrue(qc.getBits()[10] instanceof Type4);
-        assertTrue(qc.getBits()[11] instanceof Type4);
-        assertTrue(qc.getBits()[13] instanceof Type0);
-        assertTrue(qc.getBits()[14] instanceof Type12);
-        assertTrue(qc.getBits()[15] instanceof Type12);
-        assertTrue(qc.getBits()[16] instanceof Type8);
+        assertInstanceOf(Type4.class, qc.getBits()[10]);
+        assertInstanceOf(Type4.class, qc.getBits()[11]);
+        assertInstanceOf(Type0.class, qc.getBits()[13]);
+        assertInstanceOf(Type12.class, qc.getBits()[14]);
+        assertInstanceOf(Type12.class, qc.getBits()[15]);
+        assertInstanceOf(Type8.class, qc.getBits()[16]);
 
         Type4 plc10 = (Type4)qc.getBits()[10];
         Type4 plc11 = (Type4)qc.getBits()[11];

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/extractor/TestExtractor.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/extractor/TestExtractor.java
@@ -350,7 +350,7 @@ public final class TestExtractor {
         try (final SlideShowExtractor<?,?> ppe = openExtractor("master_text.ppt")) {
             // Initially not there
             String text = ppe.getText();
-            assertFalse(text.contains("Text that I added to the master slide"));
+            assertNotContains(text, "Text that I added to the master slide");
 
             // Enable, shows up
             ppe.setMasterByDefault(true);

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/model/TestShapes.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/model/TestShapes.java
@@ -23,6 +23,7 @@ import static org.apache.poi.hslf.HSLFTestDataSamples.writeOutAndReadBack;
 import static org.apache.poi.sl.usermodel.BaseTestSlideShow.getColor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -93,10 +94,10 @@ public final class TestShapes {
                 List<HSLFShape> shape = slide.getShapes();
                 assertEquals(2, shape.size());
 
-                assertTrue(shape.get(0) instanceof HSLFLine); //group shape
+                assertInstanceOf(HSLFLine.class, shape.get(0)); //group shape
                 assertEquals(lineAnchor, shape.get(0).getAnchor()); //group shape
 
-                assertTrue(shape.get(1) instanceof HSLFAutoShape); //group shape
+                assertInstanceOf(HSLFAutoShape.class, shape.get(1)); //group shape
                 assertEquals(ellipseAnchor, shape.get(1).getAnchor()); //group shape
 
             }
@@ -111,7 +112,7 @@ public final class TestShapes {
         try (HSLFSlideShow ppt = getSlideShow("with_textbox.ppt")) {
             HSLFSlide sl = ppt.getSlides().get(0);
             for (HSLFShape sh : sl.getShapes()) {
-                assertTrue(sh instanceof HSLFTextBox);
+                assertInstanceOf(HSLFTextBox.class, sh);
                 HSLFTextBox txtbox = (HSLFTextBox) sh;
                 String text = txtbox.getText();
                 assertNotNull(text);
@@ -332,13 +333,13 @@ public final class TestShapes {
 
                 List<HSLFShape> shape = slide.getShapes();
                 assertEquals(1, shape.size());
-                assertTrue(shape.get(0) instanceof HSLFGroupShape);
+                assertInstanceOf(HSLFGroupShape.class, shape.get(0));
 
                 group = (HSLFGroupShape) shape.get(0);
                 List<HSLFShape> grshape = group.getShapes();
                 assertEquals(2, grshape.size());
-                assertTrue(grshape.get(0) instanceof HSLFPictureShape);
-                assertTrue(grshape.get(1) instanceof HSLFLine);
+                assertInstanceOf(HSLFPictureShape.class, grshape.get(0));
+                assertInstanceOf(HSLFLine.class, grshape.get(1));
 
                 pict = (HSLFPictureShape) grshape.get(0);
                 assertEquals(new Rectangle2D.Double(0, 0, 200, 200), pict.getAnchor());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/model/TestSlideMaster.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/model/TestSlideMaster.java
@@ -26,6 +26,7 @@ import static org.apache.poi.sl.usermodel.TextShape.TextPlaceholder.TITLE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -146,7 +147,7 @@ public final class TestSlideMaster {
         try (HSLFSlideShow ppt = getSlideShow("slide_master.ppt")) {
             HSLFSlide slide = ppt.getSlides().get(2);
             HSLFMasterSheet masterSheet = slide.getMasterSheet();
-            assertTrue(masterSheet instanceof HSLFTitleMaster);
+            assertInstanceOf(HSLFTitleMaster.class, masterSheet);
 
             for (List<HSLFTextParagraph> txt : slide.getTextParagraphs()) {
                 HSLFTextRun rt = txt.get(0).getTextRuns().get(0);

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/model/TestTable.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/model/TestTable.java
@@ -20,10 +20,10 @@ package org.apache.poi.hslf.model;
 import static org.apache.poi.hslf.HSLFTestDataSamples.getSlideShow;
 import static org.apache.poi.hslf.HSLFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -64,14 +64,14 @@ public final class TestTable {
             assertEquals(TextPlaceholder.OTHER.nativeId, cell.getTextParagraphs().get(0).getRunType());
 
             HSLFShape tblSh = slide.getShapes().get(0);
-            assertTrue(tblSh instanceof HSLFTable);
+            assertInstanceOf(HSLFTable.class, tblSh);
             HSLFTable tbl2 = (HSLFTable) tblSh;
             assertEquals(noColumns, tbl2.getNumberOfColumns());
             assertEquals(noRows, tbl2.getNumberOfRows());
 
             try (HSLFSlideShow ppt2 = writeOutAndReadBack(ppt)) {
                 HSLFSlide slide2 = ppt2.getSlides().get(0);
-                assertTrue(slide2.getShapes().get(0) instanceof HSLFTable);
+                assertInstanceOf(HSLFTable.class, slide2.getShapes().get(0));
                 HSLFTable tbl3 = (HSLFTable) slide2.getShapes().get(0);
                 assertEquals(noColumns, tbl3.getNumberOfColumns());
                 assertEquals(noRows, tbl3.getNumberOfRows());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/record/TestComment2000.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/record/TestComment2000.java
@@ -21,8 +21,8 @@ package org.apache.poi.hslf.record;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -225,11 +225,11 @@ public final class TestComment2000 {
         Record[] ch = ca.getChildRecords();
         assertEquals(3, ch.length);
 
-        assertTrue(ch[0] instanceof CString);
+        assertInstanceOf(CString.class, ch[0]);
         assertEquals(0, ((CString)ch[0]).getOptions() >> 4);
-        assertTrue(ch[1] instanceof CString);
+        assertInstanceOf(CString.class, ch[1]);
         assertEquals(2, ((CString)ch[1]).getOptions() >> 4);
-        assertTrue(ch[2] instanceof Comment2000Atom);
+        assertInstanceOf(Comment2000Atom.class, ch[2]);
 
         assertEquals("NESS", ca.getAuthor());
         assertEquals("N", ca.getAuthorInitials());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/record/TestStyleTextPropAtom.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/record/TestStyleTextPropAtom.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -232,7 +233,7 @@ public final class TestStyleTextPropAtom {
         assertEquals(2,b_ch_1.getTextPropList().size());
         TextProp tp_1_1 = b_ch_1.getTextPropList().get(0);
         TextProp tp_1_2 = b_ch_1.getTextPropList().get(1);
-        assertTrue(tp_1_1 instanceof CharFlagsTextProp);
+        assertInstanceOf(CharFlagsTextProp.class, tp_1_1);
         assertEquals("font.size", tp_1_2.getName());
         assertEquals(20, tp_1_2.getValue());
 
@@ -241,7 +242,7 @@ public final class TestStyleTextPropAtom {
         TextProp tp_2_1 = b_ch_2.getTextPropList().get(0);
         TextProp tp_2_2 = b_ch_2.getTextPropList().get(1);
         TextProp tp_2_3 = b_ch_2.getTextPropList().get(2);
-        assertTrue(tp_2_1 instanceof CharFlagsTextProp);
+        assertInstanceOf(CharFlagsTextProp.class, tp_2_1);
         assertEquals("font.size", tp_2_2.getName());
         assertEquals("font.color", tp_2_3.getName());
         assertEquals(20, tp_2_2.getValue());
@@ -259,7 +260,7 @@ public final class TestStyleTextPropAtom {
         TextProp tp_4_1 = b_ch_4.getTextPropList().get(0);
         TextProp tp_4_2 = b_ch_4.getTextPropList().get(1);
         TextProp tp_4_3 = b_ch_4.getTextPropList().get(2);
-        assertTrue(tp_4_1 instanceof CharFlagsTextProp);
+        assertInstanceOf(CharFlagsTextProp.class, tp_4_1);
         assertEquals("font.index", tp_4_2.getName());
         assertEquals("font.size", tp_4_3.getName());
         assertEquals(24, tp_4_3.getValue());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestBugs.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestBugs.java
@@ -23,6 +23,7 @@ import static org.apache.poi.hslf.HSLFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -59,8 +60,8 @@ import org.apache.poi.hslf.model.HeadersFooters;
 import org.apache.poi.hslf.record.DocInfoListContainer;
 import org.apache.poi.hslf.record.Document;
 import org.apache.poi.hslf.record.RecordTypes;
-import org.apache.poi.hslf.record.SlideListWithText;
 import org.apache.poi.hslf.record.SlideListWithText.SlideAtomsSet;
+import org.apache.poi.hslf.record.SlideListWithText;
 import org.apache.poi.hslf.record.TextHeaderAtom;
 import org.apache.poi.hslf.record.VBAInfoAtom;
 import org.apache.poi.hslf.record.VBAInfoContainer;
@@ -107,14 +108,14 @@ public final class TestBugs {
             HSLFFill f = as.getFill();
             assertEquals(HSLFFill.FILL_TEXTURE, f.getFillType());
             PaintStyle p = f.getFillStyle().getPaint();
-            assertTrue(p instanceof PaintStyle.TexturePaint);
+            assertInstanceOf(PaintStyle.TexturePaint.class, p);
         }
         try (HSLFSlideShow ppt = open("backgrounds.ppt")) {
             HSLFAutoShape as = (HSLFAutoShape) ppt.getSlides().get(1).getShapes().get(0);
             HSLFFill f = as.getFill();
             assertEquals(HSLFFill.FILL_BACKGROUND, f.getFillType());
             PaintStyle p = as.getFillStyle().getPaint();
-            assertTrue(p instanceof SolidPaint);
+            assertInstanceOf(SolidPaint.class, p);
             assertEquals(Color.WHITE, ((SolidPaint)p).getSolidColor().getColor());
         }
     }
@@ -376,7 +377,7 @@ public final class TestBugs {
             HSLFSlide slide = ppt.getSlides().get(0);
             List<HSLFShape> sh = slide.getShapes();
             assertEquals(1, sh.size());
-            assertTrue(sh.get(0) instanceof HSLFTextShape);
+            assertInstanceOf(HSLFTextShape.class, sh.get(0));
             HSLFTextShape tx = (HSLFTextShape) sh.get(0);
             assertEquals("Fundera, planera och involvera.", HSLFTextParagraph.getRawText(tx.getTextParagraphs()));
 
@@ -595,7 +596,7 @@ public final class TestBugs {
                 assertFalse(rt.isItalic());
                 assertTrue(rt.isBold());
                 PaintStyle ps = tp.getBulletStyle().getBulletFontColor();
-                assertTrue(ps instanceof SolidPaint);
+                assertInstanceOf(SolidPaint.class, ps);
                 Color actColor = DrawPaint.applyColorTransform(((SolidPaint) ps).getSolidColor());
                 assertEquals(Color.red, actColor);
                 assertEquals("A", tp.getBulletStyle().getBulletCharacter());
@@ -823,7 +824,7 @@ public final class TestBugs {
                 assertEquals(cExp.getAlpha(), cAct.getAlpha(), 1);
 
                 PaintStyle ps = fs.getFillStyle().getPaint();
-                assertTrue(ps instanceof SolidPaint);
+                assertInstanceOf(SolidPaint.class, ps);
                 ColorStyle cs = ((SolidPaint) ps).getSolidColor();
                 cAct = cs.getColor();
                 assertEquals(cExp.getRed(), cAct.getRed());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestPictures.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestPictures.java
@@ -21,6 +21,7 @@ import static org.apache.poi.hslf.HSLFTestDataSamples.getSlideShow;
 import static org.apache.poi.hslf.HSLFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -182,7 +183,7 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(0).getShapes().get(0); //the first slide contains JPEG
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof JPEG);
+            assertInstanceOf(JPEG.class, pdata);
             assertEquals(PictureType.JPEG, pdata.getType());
             src_bytes = pdata.getData();
             ppt_bytes = slTests.readFile("clock.jpg");
@@ -190,7 +191,7 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(1).getShapes().get(0); //the second slide contains PNG
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof PNG);
+            assertInstanceOf(PNG.class, pdata);
             assertEquals(PictureType.PNG, pdata.getType());
             src_bytes = pdata.getData();
             ppt_bytes = slTests.readFile("tomcat.png");
@@ -198,7 +199,7 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(2).getShapes().get(0); //the third slide contains WMF
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof WMF);
+            assertInstanceOf(WMF.class, pdata);
             assertEquals(PictureType.WMF, pdata.getType());
             src_bytes = pdata.getData();
             ppt_bytes = slTests.readFile("santa.wmf");
@@ -210,7 +211,7 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(3).getShapes().get(0); //the forth slide contains PICT
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof PICT);
+            assertInstanceOf(PICT.class, pdata);
             assertEquals(PictureType.PICT, pdata.getType());
             src_bytes = pdata.getData();
             ppt_bytes = slTests.readFile("cow.pict");
@@ -222,7 +223,7 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(4).getShapes().get(0); //the fifth slide contains EMF
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof EMF);
+            assertInstanceOf(EMF.class, pdata);
             assertEquals(PictureType.EMF, pdata.getType());
             src_bytes = pdata.getData();
             ppt_bytes = slTests.readFile("wrench.emf");
@@ -256,12 +257,12 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(0).getShapes().get(1); // 2nd object on 1st slide
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof WMF);
+            assertInstanceOf(WMF.class, pdata);
             assertEquals(PictureType.WMF, pdata.getType());
 
             pict = (HSLFPictureShape) slides.get(0).getShapes().get(2); // 3rd object on 1st slide
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof WMF);
+            assertInstanceOf(WMF.class, pdata);
             assertEquals(PictureType.WMF, pdata.getType());
         }
     }
@@ -308,12 +309,12 @@ public final class TestPictures {
 
             pict = (HSLFPictureShape) slides.get(6).getShapes().get(13);
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof WMF);
+            assertInstanceOf(WMF.class, pdata);
             assertEquals(PictureType.WMF, pdata.getType());
 
             pict = (HSLFPictureShape) slides.get(7).getShapes().get(13);
             pdata = pict.getPictureData();
-            assertTrue(pdata instanceof WMF);
+            assertInstanceOf(WMF.class, pdata);
             assertEquals(PictureType.WMF, pdata.getType());
 
             //add a new picture, it should be correctly appended to the Pictures stream

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestTable.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestTable.java
@@ -22,8 +22,8 @@ package org.apache.poi.hslf.usermodel;
 import static org.apache.poi.hslf.HSLFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
 import java.awt.geom.Rectangle2D;
@@ -89,7 +89,7 @@ public class TestTable {
         List<HSLFShape> shapes = s.getShapes();
         assertNotNull(shapes);
         assertEquals(3, shapes.size());
-        assertTrue(shapes.get(2) instanceof HSLFTable);
+        assertInstanceOf(HSLFTable.class, shapes.get(2));
         final HSLFTable table = (HSLFTable) shapes.get(2);
         assertEquals(4, table.getNumberOfColumns());
         assertEquals(6, table.getNumberOfRows());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestTextShape.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestTextShape.java
@@ -20,6 +20,7 @@ package org.apache.poi.hslf.usermodel;
 import static org.apache.poi.hslf.HSLFTestDataSamples.getSlideShow;
 import static org.apache.poi.hslf.HSLFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -140,12 +141,12 @@ public final class TestTextShape {
                 slide = ppt2.getSlides().get(0);
                 List<HSLFShape> shape = slide.getShapes();
 
-                assertTrue(shape.get(0) instanceof HSLFTextShape);
+                assertInstanceOf(HSLFTextShape.class, shape.get(0));
                 shape1 = (HSLFTextShape) shape.get(0);
                 assertEquals(ShapeType.TEXT_BOX, shape1.getShapeType());
                 assertEquals("Hello, World!", shape1.getText());
 
-                assertTrue(shape.get(1) instanceof HSLFTextShape);
+                assertInstanceOf(HSLFTextShape.class, shape.get(1));
                 shape1 = (HSLFTextShape) shape.get(1);
                 assertEquals(ShapeType.RIGHT_ARROW, shape1.getShapeType());
                 assertEquals("Testing TextShape", shape1.getText());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hsmf/TestOutlook30FileRead.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hsmf/TestOutlook30FileRead.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.hsmf;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -61,7 +62,7 @@ public final class TestOutlook30FileRead {
     void testReadDisplayTo() throws ChunkNotFoundException {
         String obtained = mapiMessage.getDisplayTo();
 
-        assertTrue(obtained.startsWith("Bohn, Shawn"));
+        assertStartsWith(obtained, "Bohn, Shawn");
     }
 
     /**
@@ -93,7 +94,7 @@ public final class TestOutlook30FileRead {
     @Test
     void testReadBody() throws Exception {
         String obtained = mapiMessage.getTextBody();
-        assertTrue(obtained.startsWith("I am shutting down"));
+        assertStartsWith(obtained, "I am shutting down");
     }
 
     /**

--- a/poi-scratchpad/src/test/java/org/apache/poi/hsmf/parsers/TestPOIFSChunkParser.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hsmf/parsers/TestPOIFSChunkParser.java
@@ -19,10 +19,10 @@ package org.apache.poi.hsmf.parsers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -36,8 +36,8 @@ import org.apache.poi.hsmf.datatypes.ChunkGroup;
 import org.apache.poi.hsmf.datatypes.Chunks;
 import org.apache.poi.hsmf.datatypes.MAPIProperty;
 import org.apache.poi.hsmf.datatypes.NameIdChunks;
-import org.apache.poi.hsmf.datatypes.RecipientChunks;
 import org.apache.poi.hsmf.datatypes.RecipientChunks.RecipientChunksSorter;
+import org.apache.poi.hsmf.datatypes.RecipientChunks;
 import org.apache.poi.hsmf.datatypes.StringChunk;
 import org.apache.poi.hsmf.datatypes.Types;
 import org.apache.poi.hsmf.exceptions.ChunkNotFoundException;
@@ -86,9 +86,9 @@ public final class TestPOIFSChunkParser {
 
             ChunkGroup[] groups = POIFSChunkParser.parse(simple.getRoot());
             assertEquals(3, groups.length);
-            assertTrue(groups[0] instanceof Chunks);
-            assertTrue(groups[1] instanceof RecipientChunks);
-            assertTrue(groups[2] instanceof NameIdChunks);
+            assertInstanceOf(Chunks.class, groups[0]);
+            assertInstanceOf(RecipientChunks.class, groups[1]);
+            assertInstanceOf(NameIdChunks.class, groups[2]);
 
             RecipientChunks recips = (RecipientChunks) groups[1];
             assertEquals("kevin.roast@alfresco.org", recips.getRecipientSMTPChunk().getValue());
@@ -145,15 +145,15 @@ public final class TestPOIFSChunkParser {
 
             ChunkGroup[] groups = POIFSChunkParser.parse(multiple.getRoot());
             assertEquals(9, groups.length);
-            assertTrue(groups[0] instanceof Chunks);
-            assertTrue(groups[1] instanceof RecipientChunks);
-            assertTrue(groups[2] instanceof RecipientChunks);
-            assertTrue(groups[3] instanceof RecipientChunks);
-            assertTrue(groups[4] instanceof RecipientChunks);
-            assertTrue(groups[5] instanceof AttachmentChunks);
-            assertTrue(groups[6] instanceof RecipientChunks);
-            assertTrue(groups[7] instanceof RecipientChunks);
-            assertTrue(groups[8] instanceof NameIdChunks);
+            assertInstanceOf(Chunks.class, groups[0]);
+            assertInstanceOf(RecipientChunks.class, groups[1]);
+            assertInstanceOf(RecipientChunks.class, groups[2]);
+            assertInstanceOf(RecipientChunks.class, groups[3]);
+            assertInstanceOf(RecipientChunks.class, groups[4]);
+            assertInstanceOf(AttachmentChunks.class, groups[5]);
+            assertInstanceOf(RecipientChunks.class, groups[6]);
+            assertInstanceOf(RecipientChunks.class, groups[7]);
+            assertInstanceOf(NameIdChunks.class, groups[8]);
 
             // In FS order initially
             RecipientChunks[] chunks = new RecipientChunks[] {
@@ -232,9 +232,9 @@ public final class TestPOIFSChunkParser {
 
             ChunkGroup[] groups = POIFSChunkParser.parse(simple.getRoot());
             assertEquals(3, groups.length);
-            assertTrue(groups[0] instanceof Chunks);
-            assertTrue(groups[1] instanceof RecipientChunks);
-            assertTrue(groups[2] instanceof NameIdChunks);
+            assertInstanceOf(Chunks.class, groups[0]);
+            assertInstanceOf(RecipientChunks.class, groups[1]);
+            assertInstanceOf(NameIdChunks.class, groups[2]);
 
             NameIdChunks nameId = (NameIdChunks) groups[2];
             assertEquals(10, nameId.getAll().length);
@@ -261,11 +261,11 @@ public final class TestPOIFSChunkParser {
 
             ChunkGroup[] groups = POIFSChunkParser.parse(with.getRoot());
             assertEquals(5, groups.length);
-            assertTrue(groups[0] instanceof Chunks);
-            assertTrue(groups[1] instanceof RecipientChunks);
-            assertTrue(groups[2] instanceof AttachmentChunks);
-            assertTrue(groups[3] instanceof AttachmentChunks);
-            assertTrue(groups[4] instanceof NameIdChunks);
+            assertInstanceOf(Chunks.class, groups[0]);
+            assertInstanceOf(RecipientChunks.class, groups[1]);
+            assertInstanceOf(AttachmentChunks.class, groups[2]);
+            assertInstanceOf(AttachmentChunks.class, groups[3]);
+            assertInstanceOf(NameIdChunks.class, groups[4]);
 
             attachment = (AttachmentChunks) groups[2];
             assertEquals("TEST-U~1.DOC", attachment.getAttachFileName().toString());

--- a/poi/src/test/java/org/apache/poi/ddf/TestEscherBlipRecord.java
+++ b/poi/src/test/java/org/apache/poi/ddf/TestEscherBlipRecord.java
@@ -20,8 +20,8 @@ package org.apache.poi.ddf;
 import static org.apache.poi.ddf.EscherRecordTypes.BLIP_PICT;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.poi.POIDataSamples;
 import org.apache.poi.sl.usermodel.PictureData;
@@ -154,7 +154,7 @@ final class TestEscherBlipRecord {
         bse.fillFields(data, 0, new DefaultEscherRecordFactory());
         //assert that toString() works
         assertNotNull(bse.toString());
-        assertTrue(bse.getBlipRecord() instanceof EscherMetafileBlip);
+        assertInstanceOf(EscherMetafileBlip.class, bse.getBlipRecord());
 
         EscherMetafileBlip blip = (EscherMetafileBlip)bse.getBlipRecord();
         //assert that toString() works

--- a/poi/src/test/java/org/apache/poi/hssf/eventusermodel/TestEventWorkbookBuilder.java
+++ b/poi/src/test/java/org/apache/poi/hssf/eventusermodel/TestEventWorkbookBuilder.java
@@ -18,8 +18,8 @@
 package org.apache.poi.hssf.eventusermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -121,7 +121,7 @@ final class TestEventWorkbookBuilder {
         //  all the ptgs give back the right things
         Ptg[] ptgs = fRecs.get(0).getParsedExpression();
         assertEquals(1, ptgs.length);
-        assertTrue(ptgs[0] instanceof Ref3DPtg);
+        assertInstanceOf(Ref3DPtg.class, ptgs[0]);
 
         Ref3DPtg ptg = (Ref3DPtg)ptgs[0];
         HSSFEvaluationWorkbook book = HSSFEvaluationWorkbook.create(stubHSSF);

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestDrawingShapes.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestDrawingShapes.java
@@ -20,6 +20,7 @@ package org.apache.poi.hssf.model;
 import static org.apache.poi.hssf.usermodel.HSSFTestHelper.getEscherAggregate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -788,9 +789,9 @@ class TestDrawingShapes {
             List<HSSFShape> children = patriarchBack.getChildren();
             assertEquals(4, children.size());
             HSSFShape hssfShape = children.get(0);
-            assertTrue(hssfShape instanceof HSSFSimpleShape);
+            assertInstanceOf(HSSFSimpleShape.class, hssfShape);
             HSSFAnchor anchor = hssfShape.getAnchor();
-            assertTrue(anchor instanceof HSSFClientAnchor);
+            assertInstanceOf(HSSFClientAnchor.class, anchor);
             assertEquals(0, anchor.getDx1());
             assertEquals(512, anchor.getDx2());
             assertEquals(0, anchor.getDy1());
@@ -802,9 +803,9 @@ class TestDrawingShapes {
             assertEquals(1, cAnchor.getRow2());
 
             hssfShape = children.get(1);
-            assertTrue(hssfShape instanceof HSSFSimpleShape);
+            assertInstanceOf(HSSFSimpleShape.class, hssfShape);
             anchor = hssfShape.getAnchor();
-            assertTrue(anchor instanceof HSSFClientAnchor);
+            assertInstanceOf(HSSFClientAnchor.class, anchor);
             assertEquals(512, anchor.getDx1());
             assertEquals(1024, anchor.getDx2());
             assertEquals(0, anchor.getDy1());
@@ -816,9 +817,9 @@ class TestDrawingShapes {
             assertEquals(1, cAnchor.getRow2());
 
             hssfShape = children.get(2);
-            assertTrue(hssfShape instanceof HSSFSimpleShape);
+            assertInstanceOf(HSSFSimpleShape.class, hssfShape);
             anchor = hssfShape.getAnchor();
-            assertTrue(anchor instanceof HSSFClientAnchor);
+            assertInstanceOf(HSSFClientAnchor.class, anchor);
             assertEquals(0, anchor.getDx1());
             assertEquals(512, anchor.getDx2());
             assertEquals(0, anchor.getDy1());
@@ -830,9 +831,9 @@ class TestDrawingShapes {
             assertEquals(2, cAnchor.getRow2());
 
             hssfShape = children.get(3);
-            assertTrue(hssfShape instanceof HSSFSimpleShape);
+            assertInstanceOf(HSSFSimpleShape.class, hssfShape);
             anchor = hssfShape.getAnchor();
-            assertTrue(anchor instanceof HSSFClientAnchor);
+            assertInstanceOf(HSSFClientAnchor.class, anchor);
             assertEquals(0, anchor.getDx1());
             assertEquals(512, anchor.getDx2());
             assertEquals(100, anchor.getDy1());

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestEscherRecordFactory.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestEscherRecordFactory.java
@@ -19,8 +19,8 @@ package org.apache.poi.hssf.model;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -59,7 +59,7 @@ class TestEscherRecordFactory {
         sh.getDrawingPatriarch();
         EscherAggregate agg = (EscherAggregate) ish.findFirstRecordBySid(EscherAggregate.sid);
         assertNotNull(agg);
-        assertTrue(agg.getEscherRecords().get(0) instanceof EscherContainerRecord);
+        assertInstanceOf(EscherContainerRecord.class, agg.getEscherRecords().get(0));
         assertEquals(EscherContainerRecord.DG_CONTAINER, agg.getEscherRecords().get(0).getRecordId());
         assertEquals((short) 0x0, agg.getEscherRecords().get(0).getOptions());
         agg = (EscherAggregate) ish.findFirstRecordBySid(EscherAggregate.sid);

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestFormulaParser.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestFormulaParser.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.hssf.model;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.apache.poi.hssf.model.HSSFFormulaParser.parse;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -865,7 +866,7 @@ final class TestFormulaParser {
                 DividePtg.instance,
         };
         IllegalStateException e = assertThrows(IllegalStateException.class, () -> toFormulaString(ptgs));
-        assertTrue(e.getMessage().startsWith("Too few arguments supplied to operation"));
+        assertStartsWith(e.getMessage(), "Too few arguments supplied to operation");
     }
 
     /**
@@ -1112,7 +1113,7 @@ final class TestFormulaParser {
     private static void confirmSingle3DRef(Ptg[] ptgs, int expectedExternSheetIndex) {
         assertEquals(1, ptgs.length);
         Ptg ptg0 = ptgs[0];
-        assertTrue(ptg0 instanceof Ref3DPtg);
+        assertInstanceOf(Ref3DPtg.class, ptg0);
         assertEquals(expectedExternSheetIndex, ((Ref3DPtg)ptg0).getExternSheetIndex());
     }
 

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestFormulaParserIf.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestFormulaParserIf.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hssf.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.poi.ss.formula.ptg.AddPtg;
@@ -211,11 +212,11 @@ final class TestFormulaParserIf {
         Ptg[] ptgs = parseFormula("IF(A1=B1,AVERAGE(A1:B1),AVERAGE(A2:B2))");
         assertEquals(11, ptgs.length);
 
-        assertTrue((ptgs[3] instanceof AttrPtg), "IF Attr set correctly");
+        assertInstanceOf(AttrPtg.class, (ptgs[3]), "IF Attr set correctly");
         AttrPtg ifFunc = (AttrPtg)ptgs[3];
         assertTrue(ifFunc.isOptimizedIf(), "It is not an if");
 
-        assertTrue((ptgs[5] instanceof FuncVarPtg), "Average Function set correctly");
+        assertInstanceOf(FuncVarPtg.class, (ptgs[5]), "Average Function set correctly");
     }
 
     @Test
@@ -223,15 +224,15 @@ final class TestFormulaParserIf {
         Ptg[] ptgs = parseFormula("IF(1=1,10)");
         assertEquals(7, ptgs.length);
 
-        assertTrue((ptgs[3] instanceof AttrPtg), "IF Attr set correctly");
+        assertInstanceOf(AttrPtg.class, (ptgs[3]), "IF Attr set correctly");
         AttrPtg ifFunc = (AttrPtg)ptgs[3];
         assertTrue(ifFunc.isOptimizedIf(), "It is not an if");
 
-        assertTrue((ptgs[4] instanceof IntPtg), "Single Value is not an IntPtg");
+        assertInstanceOf(IntPtg.class, (ptgs[4]), "Single Value is not an IntPtg");
         IntPtg intPtg = (IntPtg)ptgs[4];
         assertEquals((short)10, intPtg.getValue(), "Result");
 
-        assertTrue((ptgs[6] instanceof FuncVarPtg), "Ptg is not a Variable Function");
+        assertInstanceOf(FuncVarPtg.class, (ptgs[6]), "Ptg is not a Variable Function");
         FuncVarPtg funcPtg = (FuncVarPtg)ptgs[6];
         assertEquals(2, funcPtg.getNumberOfOperands(), "Arguments");
     }

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestLinkTable.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestLinkTable.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hssf.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -210,10 +211,10 @@ final class TestLinkTable {
         //    [EOFRecord]
 
         assertEquals(5, wrl.getRecords().size());
-        assertTrue(wrl.get(2) instanceof SupBookRecord);
+        assertInstanceOf(SupBookRecord.class, wrl.get(2));
         SupBookRecord sup1 = (SupBookRecord)wrl.get(2);
         assertEquals(numberOfSheets, sup1.getNumberOfSheets());
-        assertTrue(wrl.get(3) instanceof ExternSheetRecord);
+        assertInstanceOf(ExternSheetRecord.class, wrl.get(3));
         ExternSheetRecord extSheet = (ExternSheetRecord)wrl.get(3);
         assertEquals(0, extSheet.getNumOfRefs());
 
@@ -244,13 +245,13 @@ final class TestLinkTable {
         //    [EOFRecord]
 
         assertEquals(7, wrl.getRecords().size());
-        assertTrue(wrl.get(3) instanceof SupBookRecord);
+        assertInstanceOf(SupBookRecord.class, wrl.get(3));
         SupBookRecord sup2 = (SupBookRecord)wrl.get(3);
         assertTrue(sup2.isAddInFunctions());
-        assertTrue(wrl.get(4) instanceof ExternalNameRecord);
+        assertInstanceOf(ExternalNameRecord.class, wrl.get(4));
         ExternalNameRecord ext1 = (ExternalNameRecord)wrl.get(4);
         assertEquals("ISODD", ext1.getText());
-        assertTrue(wrl.get(5) instanceof ExternSheetRecord);
+        assertInstanceOf(ExternSheetRecord.class, wrl.get(5));
         assertEquals(1, extSheet.getNumOfRefs());
 
         //check that
@@ -274,13 +275,13 @@ final class TestLinkTable {
         //    [EXTERNALNAME .name    = ISEVEN]
         //    [EXTERNSHEET]
         //    [EOFRecord]
-        assertTrue(wrl.get(3) instanceof SupBookRecord);
-        assertTrue(wrl.get(4) instanceof ExternalNameRecord);
-        assertTrue(wrl.get(5) instanceof ExternalNameRecord);
+        assertInstanceOf(SupBookRecord.class, wrl.get(3));
+        assertInstanceOf(ExternalNameRecord.class, wrl.get(4));
+        assertInstanceOf(ExternalNameRecord.class, wrl.get(5));
         assertEquals("ISODD", ((ExternalNameRecord)wrl.get(4)).getText());
         assertEquals("ISEVEN", ((ExternalNameRecord)wrl.get(5)).getText());
-        assertTrue(wrl.get(6) instanceof ExternSheetRecord);
-        assertTrue(wrl.get(7) instanceof EOFRecord);
+        assertInstanceOf(ExternSheetRecord.class, wrl.get(6));
+        assertInstanceOf(EOFRecord.class, wrl.get(7));
 
         assertEquals(0, tbl.resolveNameXIx(namex2.getSheetRefIndex(), namex2.getNameIndex()));
         assertEquals("ISEVEN", tbl.resolveNameXText(namex2.getSheetRefIndex(), namex2.getNameIndex(), null));

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestSheet.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestSheet.java
@@ -19,6 +19,7 @@ package org.apache.poi.hssf.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -69,11 +70,11 @@ final class TestSheet {
         sheet.visitContainedRecords(outRecs::add, 0);
 
         Iterator<org.apache.poi.hssf.record.Record> iter = outRecs.iterator();
-        assertTrue(iter.next() instanceof BOFRecord );
-        assertTrue(iter.next() instanceof IndexRecord);
-        assertTrue(iter.next() instanceof DimensionsRecord);
-        assertTrue(iter.next() instanceof WindowTwoRecord );
-        assertTrue(iter.next() instanceof EOFRecord);
+        assertInstanceOf(BOFRecord.class, iter.next());
+        assertInstanceOf(IndexRecord.class, iter.next());
+        assertInstanceOf(DimensionsRecord.class, iter.next());
+        assertInstanceOf(WindowTwoRecord.class, iter.next());
+        assertInstanceOf(EOFRecord.class, iter.next());
     }
 
     private static org.apache.poi.hssf.record.Record createWindow2Record() {

--- a/poi/src/test/java/org/apache/poi/hssf/record/TestDrawingRecord.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/TestDrawingRecord.java
@@ -19,7 +19,7 @@ package org.apache.poi.hssf.record;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -54,8 +54,8 @@ final class TestDrawingRecord {
 
         List<org.apache.poi.hssf.record.Record> rec = RecordFactory.createRecords(out.toInputStream());
         assertEquals(2, rec.size());
-        assertTrue(rec.get(0) instanceof DrawingRecord);
-        assertTrue(rec.get(1) instanceof ContinueRecord);
+        assertInstanceOf(DrawingRecord.class, rec.get(0));
+        assertInstanceOf(ContinueRecord.class, rec.get(1));
 
         assertArrayEquals(data1, ((DrawingRecord)rec.get(0)).getRecordData());
         assertArrayEquals(data2, ((ContinueRecord)rec.get(1)).getData());

--- a/poi/src/test/java/org/apache/poi/hssf/record/TestLbsDataSubRecord.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/TestLbsDataSubRecord.java
@@ -21,8 +21,8 @@ package org.apache.poi.hssf.record;
 import static org.apache.poi.hssf.record.TestcaseRecordInputStream.confirmRecordEncoding;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -60,11 +60,11 @@ final class TestLbsDataSubRecord {
         ObjRecord record = new ObjRecord(in);
         assertEquals(3, record.getSubRecords().size());
         SubRecord sr = record.getSubRecords().get(2);
-        assertTrue(sr instanceof LbsDataSubRecord);
+        assertInstanceOf(LbsDataSubRecord.class, sr);
         LbsDataSubRecord lbs = (LbsDataSubRecord)sr;
         assertEquals(4, lbs.getNumberOfItems());
 
-        assertTrue(lbs.getFormula() instanceof AreaPtg);
+        assertInstanceOf(AreaPtg.class, lbs.getFormula());
         AreaPtg ptg = (AreaPtg)lbs.getFormula();
         CellRangeAddress range = new CellRangeAddress(
                 ptg.getFirstRow(), ptg.getLastRow(), ptg.getFirstColumn(), ptg.getLastColumn());
@@ -103,7 +103,7 @@ final class TestLbsDataSubRecord {
         ObjRecord record = new ObjRecord(in);
 
         SubRecord sr = record.getSubRecords().get(2);
-        assertTrue(sr instanceof LbsDataSubRecord);
+        assertInstanceOf(LbsDataSubRecord.class, sr);
         LbsDataSubRecord lbs = (LbsDataSubRecord)sr;
         assertEquals(8, lbs.getNumberOfItems());
         assertNull(lbs.getFormula());

--- a/poi/src/test/java/org/apache/poi/hssf/record/TestMergeCellsRecord.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/TestMergeCellsRecord.java
@@ -18,8 +18,8 @@
 package org.apache.poi.hssf.record;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 
@@ -64,7 +64,7 @@ final class TestMergeCellsRecord {
         RecordStream rs = new RecordStream(Collections.singletonList(mcr1), 0);
         mct.read(rs);
         mct.visitContainedRecords(r -> {
-            assertTrue(r instanceof MergeCellsRecord);
+            assertInstanceOf(MergeCellsRecord.class, r);
             MergeCellsRecord mcr2 = (MergeCellsRecord)r;
             assertEquals(mcr1.getNumAreas(), mcr2.getNumAreas());
             assertEquals(mcr1.getAreaAt(0), mcr2.getAreaAt(0));

--- a/poi/src/test/java/org/apache/poi/hssf/record/TestNameRecord.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/TestNameRecord.java
@@ -17,11 +17,11 @@
 
 package org.apache.poi.hssf.record;
 
+import static org.apache.poi.POITestCase.assertEndsWith;
 import static org.apache.poi.hssf.record.TestcaseRecordInputStream.confirmRecordEncoding;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -56,7 +56,7 @@ final class TestNameRecord {
         NameRecord name = new NameRecord(TestcaseRecordInputStream.create(NameRecord.sid, examples));
         String description = name.getDescriptionText();
         assertNotNull(description);
-        assertTrue(description.endsWith("Macro recorded 27-Sep-93 by ALLWOR"));
+        assertEndsWith(description, "Macro recorded 27-Sep-93 by ALLWOR");
     }
 
     @Test

--- a/poi/src/test/java/org/apache/poi/hssf/record/TestObjRecord.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/TestObjRecord.java
@@ -20,8 +20,8 @@ package org.apache.poi.hssf.record;
 import static org.apache.poi.hssf.record.TestcaseRecordInputStream.confirmRecordEncoding;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -67,8 +67,8 @@ final class TestObjRecord {
 
         List<SubRecord> subrecords = record.getSubRecords();
         assertEquals(2, subrecords.size() );
-        assertTrue(subrecords.get(0) instanceof CommonObjectDataSubRecord);
-        assertTrue(subrecords.get(1) instanceof EndSubRecord );
+        assertInstanceOf(CommonObjectDataSubRecord.class, subrecords.get(0));
+        assertInstanceOf(EndSubRecord.class, subrecords.get(1));
 
     }
 
@@ -104,8 +104,8 @@ final class TestObjRecord {
         record = new ObjRecord(TestcaseRecordInputStream.create(ObjRecord.sid, bytes));
         List<SubRecord> subrecords = record.getSubRecords();
         assertEquals( 2, subrecords.size() );
-        assertTrue( subrecords.get(0) instanceof CommonObjectDataSubRecord);
-        assertTrue( subrecords.get(1) instanceof EndSubRecord );
+        assertInstanceOf(CommonObjectDataSubRecord.class, subrecords.get(0));
+        assertInstanceOf(EndSubRecord.class, subrecords.get(1));
     }
 
     @Test

--- a/poi/src/test/java/org/apache/poi/hssf/record/aggregates/TestColumnInfoRecordsAggregate.java
+++ b/poi/src/test/java/org/apache/poi/hssf/record/aggregates/TestColumnInfoRecordsAggregate.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hssf.record.aggregates;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -116,7 +117,7 @@ final class TestColumnInfoRecordsAggregate {
     }
 
     private static void confirmCIR(List<org.apache.poi.hssf.record.Record> cirs, int ix, int startColIx, int endColIx, int level, boolean isHidden, boolean isCollapsed) {
-        assertTrue(cirs.get(ix) instanceof ColumnInfoRecord);
+        assertInstanceOf(ColumnInfoRecord.class, cirs.get(ix));
         ColumnInfoRecord cir = (ColumnInfoRecord)cirs.get(ix);
         assertEquals(startColIx, cir.getFirstColumn(), "startColIx");
         assertEquals(endColIx, cir.getLastColumn(), "endColIx");

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/SanityChecker.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/SanityChecker.java
@@ -20,6 +20,7 @@
 package org.apache.poi.hssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -177,7 +178,7 @@ public class SanityChecker {
 
     private void checkWorkbookRecords(InternalWorkbook workbook) {
         List<org.apache.poi.hssf.record.Record> records = workbook.getRecords();
-        assertTrue(records.get(0) instanceof BOFRecord);
+        assertInstanceOf(BOFRecord.class, records.get(0));
         assertTrue(records.get(records.size() - 1) instanceof EOFRecord);
 
         checkRecordOrder(records, workbookRecords);
@@ -185,7 +186,7 @@ public class SanityChecker {
 
     private void checkSheetRecords(InternalSheet sheet) {
         List<RecordBase> records = sheet.getRecords();
-        assertTrue(records.get(0) instanceof BOFRecord);
+        assertInstanceOf(BOFRecord.class, records.get(0));
         assertTrue(records.get(records.size() - 1) instanceof EOFRecord);
 
         checkRecordOrder(records, sheetRecords);

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestBugs.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestBugs.java
@@ -631,7 +631,7 @@ final class TestBugs extends BaseTestBugzillaIssues {
 
             Ptg[] nd = r.getNameDefinition();
             assertEquals(1, nd.length);
-            assertTrue(nd[0] instanceof DeletedArea3DPtg);
+            assertInstanceOf(DeletedArea3DPtg.class, nd[0]);
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestEscherGraphics.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestEscherGraphics.java
@@ -19,8 +19,8 @@ package org.apache.poi.hssf.usermodel;
 
 import static org.apache.poi.hssf.HSSFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -130,8 +130,8 @@ final class TestEscherGraphics {
 
         // Check the two groups too
         assertEquals(2, patriarch.countOfAllChildren());
-        assertTrue(patriarch.getChildren().get(0) instanceof HSSFShapeGroup);
-        assertTrue(patriarch.getChildren().get(1) instanceof HSSFShapeGroup);
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(0));
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(1));
 
         s1 = (HSSFShapeGroup)patriarch.getChildren().get(0);
         s2 = (HSSFShapeGroup)patriarch.getChildren().get(1);
@@ -168,8 +168,8 @@ final class TestEscherGraphics {
 
         // Check the two groups too
         assertEquals(2, patriarch.countOfAllChildren());
-        assertTrue(patriarch.getChildren().get(0) instanceof HSSFShapeGroup);
-        assertTrue(patriarch.getChildren().get(1) instanceof HSSFShapeGroup);
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(0));
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(1));
 
         s1 = (HSSFShapeGroup)patriarch.getChildren().get(0);
         s2 = (HSSFShapeGroup)patriarch.getChildren().get(1);
@@ -209,8 +209,8 @@ final class TestEscherGraphics {
         // Check the two groups too
         assertEquals(2, patriarch.countOfAllChildren());
         assertEquals(2, patriarch.getChildren().size());
-        assertTrue(patriarch.getChildren().get(0) instanceof HSSFShapeGroup);
-        assertTrue(patriarch.getChildren().get(1) instanceof HSSFShapeGroup);
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(0));
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(1));
 
         s1 = (HSSFShapeGroup)patriarch.getChildren().get(0);
         s2 = (HSSFShapeGroup)patriarch.getChildren().get(1);
@@ -263,9 +263,9 @@ final class TestEscherGraphics {
         assertEquals(3, patriarch.getChildren().size());
 
         // Should be two groups and a text
-        assertTrue(patriarch.getChildren().get(0) instanceof HSSFShapeGroup);
-        assertTrue(patriarch.getChildren().get(1) instanceof HSSFShapeGroup);
-        assertTrue(patriarch.getChildren().get(2) instanceof HSSFTextbox);
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(0));
+        assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(1));
+        assertInstanceOf(HSSFTextbox.class, patriarch.getChildren().get(2));
 
         s1 = (HSSFShapeGroup)patriarch.getChildren().get(0);
         tbox1 = (HSSFTextbox)patriarch.getChildren().get(2);

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFSheet.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFSheet.java
@@ -21,6 +21,7 @@ import static org.apache.poi.hssf.HSSFTestDataSamples.writeOutAndReadBack;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -922,7 +923,7 @@ final class TestHSSFSheet extends BaseTestSheet {
             // The built-in name for auto-filter must consist of a single Area3d Ptg.
             Ptg[] ptg = name.getNameDefinition();
             assertEquals(1, ptg.length, "The built-in name for auto-filter must consist of a single Area3d Ptg");
-            assertTrue(ptg[0] instanceof Area3DPtg, "The built-in name for auto-filter must consist of a single Area3d Ptg");
+            assertInstanceOf(Area3DPtg.class, ptg[0], "The built-in name for auto-filter must consist of a single Area3d Ptg");
 
             Area3DPtg aref = (Area3DPtg) ptg[0];
             assertEquals(range.getFirstColumn(), aref.getFirstColumn());
@@ -949,9 +950,9 @@ final class TestHSSFSheet extends BaseTestSheet {
                 assertNotNull(objRecord);
                 List<SubRecord> subRecords = objRecord.getSubRecords();
                 assertEquals(3, subRecords.size());
-                assertTrue(subRecords.get(0) instanceof CommonObjectDataSubRecord);
-                assertTrue(subRecords.get(1) instanceof FtCblsSubRecord); // must be present, see Bug 51481
-                assertTrue(subRecords.get(2) instanceof LbsDataSubRecord);
+                assertInstanceOf(CommonObjectDataSubRecord.class, subRecords.get(0));
+                assertInstanceOf(FtCblsSubRecord.class, subRecords.get(1)); // must be present, see Bug 51481
+                assertInstanceOf(LbsDataSubRecord.class, subRecords.get(2));
             }
         }
     }

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestHSSFWorkbook.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hssf.usermodel;
 
 import static org.apache.poi.POITestCase.assertContains;
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.apache.poi.hssf.HSSFTestDataSamples.openSampleWorkbook;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -391,7 +392,7 @@ public final class TestHSSFWorkbook extends BaseTestWorkbook {
             sheetRecords.add(new BadlyBehavedRecord());
             // There is also much logic inside Sheet that (if buggy) might also cause the discrepancy
             IllegalStateException e = assertThrows(IllegalStateException.class, wb::getBytes, "Identified bug 45066 a");
-            assertTrue(e.getMessage().startsWith("Actual serialized sheet size"));
+            assertStartsWith(e.getMessage(), "Actual serialized sheet size");
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestPolygon.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestPolygon.java
@@ -20,7 +20,7 @@ package org.apache.poi.hssf.usermodel;
 import static org.apache.poi.poifs.storage.RawDataUtil.decompress;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.IOException;
 
@@ -269,8 +269,8 @@ class TestPolygon {
                     patriarch = sh.getDrawingPatriarch();
 
                     assertEquals(2, patriarch.getChildren().size());
-                    assertTrue(patriarch.getChildren().get(0) instanceof HSSFPolygon);
-                    assertTrue(patriarch.getChildren().get(1) instanceof HSSFPolygon);
+                    assertInstanceOf(HSSFPolygon.class, patriarch.getChildren().get(0));
+                    assertInstanceOf(HSSFPolygon.class, patriarch.getChildren().get(1));
                 }
             }
         }

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestReadWriteChart.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestReadWriteChart.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
@@ -56,7 +57,7 @@ final class TestReadWriteChart {
         InternalSheet newSheet = workbook.getSheetAt(0).getSheet();
         List<RecordBase> records  = newSheet.getRecords();
 
-        assertTrue(records.get(0) instanceof BOFRecord);
+        assertInstanceOf(BOFRecord.class, records.get(0));
         assertTrue(records.get(records.size() - 1) instanceof EOFRecord);
 
         workbook.close();

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestShapeGroup.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestShapeGroup.java
@@ -18,8 +18,8 @@
 package org.apache.poi.hssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -186,15 +186,15 @@ class TestShapeGroup {
                 patriarch = sheet.getDrawingPatriarch();
                 assertEquals(1, patriarch.getChildren().size());
 
-                assertTrue(patriarch.getChildren().get(0) instanceof HSSFShapeGroup);
+                assertInstanceOf(HSSFShapeGroup.class, patriarch.getChildren().get(0));
                 group = (HSSFShapeGroup) patriarch.getChildren().get(0);
 
                 assertEquals(4, group.getChildren().size());
 
-                assertTrue(group.getChildren().get(0) instanceof HSSFPicture);
-                assertTrue(group.getChildren().get(1) instanceof HSSFPolygon);
-                assertTrue(group.getChildren().get(2) instanceof HSSFTextbox);
-                assertTrue(group.getChildren().get(3) instanceof HSSFSimpleShape);
+                assertInstanceOf(HSSFPicture.class, group.getChildren().get(0));
+                assertInstanceOf(HSSFPolygon.class, group.getChildren().get(1));
+                assertInstanceOf(HSSFTextbox.class, group.getChildren().get(2));
+                assertInstanceOf(HSSFSimpleShape.class, group.getChildren().get(3));
 
                 HSSFShapeGroup group2 = patriarch.createGroup(new HSSFClientAnchor());
 
@@ -215,11 +215,11 @@ class TestShapeGroup {
 
                     assertEquals(5, group.getChildren().size());
 
-                    assertTrue(group.getChildren().get(0) instanceof HSSFPicture);
-                    assertTrue(group.getChildren().get(1) instanceof HSSFPolygon);
-                    assertTrue(group.getChildren().get(2) instanceof HSSFTextbox);
-                    assertTrue(group.getChildren().get(3) instanceof HSSFSimpleShape);
-                    assertTrue(group.getChildren().get(4) instanceof HSSFSimpleShape);
+                    assertInstanceOf(HSSFPicture.class, group.getChildren().get(0));
+                    assertInstanceOf(HSSFPolygon.class, group.getChildren().get(1));
+                    assertInstanceOf(HSSFTextbox.class, group.getChildren().get(2));
+                    assertInstanceOf(HSSFSimpleShape.class, group.getChildren().get(3));
+                    assertInstanceOf(HSSFSimpleShape.class, group.getChildren().get(4));
 
                     group.getShapeId();
                 }

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestFileSystemBugs.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestFileSystemBugs.java
@@ -18,6 +18,7 @@
 package org.apache.poi.poifs.filesystem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
@@ -90,7 +91,7 @@ final class TestFileSystemBugs {
 
         Entry entry = root.getEntries().next();
         assertTrue(entry.isDirectoryEntry());
-        assertTrue(entry instanceof DirectoryEntry);
+        assertInstanceOf(DirectoryEntry.class, entry);
 
         // The directory lacks a name!
         DirectoryEntry dir = (DirectoryEntry)entry;

--- a/poi/src/test/java/org/apache/poi/poifs/filesystem/TestFilteringDirectoryNode.java
+++ b/poi/src/test/java/org/apache/poi/poifs/filesystem/TestFilteringDirectoryNode.java
@@ -20,6 +20,7 @@ package org.apache.poi.poifs.filesystem;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -166,7 +167,7 @@ final class TestFilteringDirectoryNode {
         assertFalse(d.hasEntryCaseInsensitive(eRoot.getName()));
 
         // Check filtering down
-        assertTrue(d.getEntryCaseInsensitive(dirA.getName()) instanceof FilteringDirectoryNode);
+        assertInstanceOf(FilteringDirectoryNode.class, d.getEntryCaseInsensitive(dirA.getName()));
         assertFalse(d.getEntryCaseInsensitive(dirB.getName()) instanceof FilteringDirectoryNode);
 
         DirectoryEntry fdA = (DirectoryEntry) d.getEntryCaseInsensitive(dirA.getName());

--- a/poi/src/test/java/org/apache/poi/ss/formula/BaseTestExternalFunctions.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/BaseTestExternalFunctions.java
@@ -18,6 +18,7 @@ package org.apache.poi.ss.formula;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -111,7 +112,7 @@ public abstract class BaseTestExternalFunctions {
             cell2.setCellFormula("MYFUNC(\"B1\")");
             NotImplementedException e = assertThrows(NotImplementedException.class, () -> evaluator.evaluate(cell2),
                 "Expected NotImplementedFunctionException/NotImplementedException");
-            assertTrue(e.getCause() instanceof NotImplementedFunctionException);
+            assertInstanceOf(NotImplementedFunctionException.class, e.getCause());
             // Alternatively, a future implementation of evaluate could return #NAME? error to align behavior with Excel
             // assertEquals(ErrorEval.NAME_INVALID, ErrorEval.valueOf(evaluator.evaluate(cell2).getErrorValue()));
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/eval/TestEqualEval.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/eval/TestEqualEval.java
@@ -18,6 +18,7 @@
 package org.apache.poi.ss.formula.eval;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,7 +44,7 @@ final class TestEqualEval {
         };
         ValueEval result = evaluate(EvalInstances.Equal, args, 10, 10);
         assertNotEquals(ErrorEval.VALUE_INVALID, result, "Identified bug in evaluation of 1x1 area");
-        assertTrue(result instanceof BoolEval);
+        assertInstanceOf(BoolEval.class, result);
         assertTrue(((BoolEval)result).getBooleanValue());
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/eval/TestRangeEval.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/eval/TestRangeEval.java
@@ -18,7 +18,7 @@
 package org.apache.poi.ss.formula.eval;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,8 +29,8 @@ import org.apache.poi.hssf.usermodel.HSSFRow;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.formula.TwoDEval;
-import org.apache.poi.ss.formula.ptg.AreaI;
 import org.apache.poi.ss.formula.ptg.AreaI.OffsetArea;
+import org.apache.poi.ss.formula.ptg.AreaI;
 import org.apache.poi.ss.usermodel.CellValue;
 import org.apache.poi.ss.util.AreaReference;
 import org.apache.poi.ss.util.CellReference;
@@ -61,7 +61,7 @@ final class TestRangeEval {
         for(SpreadsheetVersion version : versions) {
             AreaReference ar = new AreaReference(expectedAreaRef, version);
             ValueEval result = EvalInstances.Range.evaluate(args, 0, (short)0);
-            assertTrue(result instanceof AreaEval);
+            assertInstanceOf(AreaEval.class, result);
             AreaEval ae = (AreaEval) result;
             assertEquals(ar.getFirstCell().getRow(), ae.getFirstRow());
             assertEquals(ar.getLastCell().getRow(), ae.getLastRow());

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestAverageIf.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestAverageIf.java
@@ -21,7 +21,7 @@ package org.apache.poi.ss.formula.functions;
 
 import static org.apache.poi.ss.util.Utils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
@@ -50,7 +50,7 @@ final class TestAverageIf {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval) actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestAverageifs.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestAverageifs.java
@@ -20,7 +20,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.ss.formula.OperationEvaluationContext;
 import org.apache.poi.ss.formula.eval.ErrorEval;
@@ -42,7 +42,7 @@ final class TestAverageifs {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval)actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestEDate.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestEDate.java
@@ -18,7 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -105,7 +105,7 @@ class TestEDate {
     @Test
     void testEDateInvalidValueEval() {
         ValueEval evaluate = new EDate().evaluate(new ValueEval[]{new ValueEval() {}, new NumberEval(0)}, null);
-        assertTrue(evaluate instanceof ErrorEval);
+        assertInstanceOf(ErrorEval.class, evaluate);
         assertEquals(ErrorEval.VALUE_INVALID, evaluate);
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestEOMonth.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestEOMonth.java
@@ -18,7 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -85,11 +85,11 @@ class TestEOMonth {
     @Test
     void testEOMonthInvalidArguments() {
         ValueEval result = eOMonth.evaluate(new ValueEval[] {new NumberEval(DATE_1902_09_26)}, ec);
-        assertTrue(result instanceof ErrorEval);
+        assertInstanceOf(ErrorEval.class, result);
         assertEquals(FormulaError.VALUE.getCode(), ((ErrorEval) result).getErrorCode(), 0);
 
         result = eOMonth.evaluate(new ValueEval[] {new StringEval("a"), new StringEval("b")}, ec);
-        assertTrue(result instanceof ErrorEval);
+        assertInstanceOf(ErrorEval.class, result);
         assertEquals(FormulaError.VALUE.getCode(), ((ErrorEval) result).getErrorCode(), 0);
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestFixed.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestFixed.java
@@ -18,6 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -91,22 +92,22 @@ final class TestFixed {
     void testOptionalParams() {
         Fixed fixed = new Fixed();
         ValueEval evaluate = fixed.evaluate(0, 0, new NumberEval(1234.56789));
-        assertTrue(evaluate instanceof StringEval);
+        assertInstanceOf(StringEval.class, evaluate);
         assertEquals("1,234.57", ((StringEval)evaluate).getStringValue());
 
         evaluate = fixed.evaluate(0, 0, new NumberEval(1234.56789), new NumberEval(1));
-        assertTrue(evaluate instanceof StringEval);
+        assertInstanceOf(StringEval.class, evaluate);
         assertEquals("1,234.6", ((StringEval)evaluate).getStringValue());
 
         evaluate = fixed.evaluate(0, 0, new NumberEval(1234.56789), new NumberEval(1), BoolEval.TRUE);
-        assertTrue(evaluate instanceof StringEval);
+        assertInstanceOf(StringEval.class, evaluate);
         assertEquals("1234.6", ((StringEval)evaluate).getStringValue());
 
         evaluate = fixed.evaluate(new ValueEval[] {}, 1, 1);
-        assertTrue(evaluate instanceof ErrorEval);
+        assertInstanceOf(ErrorEval.class, evaluate);
 
         evaluate = fixed.evaluate(new ValueEval[] { new NumberEval(1), new NumberEval(1), new NumberEval(1), new NumberEval(1) }, 1, 1);
-        assertTrue(evaluate instanceof ErrorEval);
+        assertInstanceOf(ErrorEval.class, evaluate);
     }
 
     private void confirm(String formulaText, String expectedResult) {

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestGeomean.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestGeomean.java
@@ -17,7 +17,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.ss.formula.eval.BlankEval;
 import org.apache.poi.ss.formula.eval.BoolEval;
@@ -124,7 +124,7 @@ class TestGeomean {
     }
 
     private void verifyNumericResult(double expected, ValueEval result) {
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(expected, ((NumberEval) result).getNumberValue(), 1e-15);
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestIndex.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestIndex.java
@@ -19,7 +19,7 @@ package org.apache.poi.ss.formula.functions;
 
 import static org.apache.poi.ss.util.Utils.assertDouble;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -154,7 +154,7 @@ final class TestIndex {
      */
     private static AreaEval confirmAreaEval(String refText, ValueEval ve) {
         CellRangeAddress cra = CellRangeAddress.valueOf(refText);
-        assertTrue(ve instanceof AreaEval);
+        assertInstanceOf(AreaEval.class, ve);
         AreaEval ae = (AreaEval) ve;
         assertEquals(cra.getFirstRow(), ae.getFirstRow());
         assertEquals(cra.getFirstColumn(), ae.getFirstColumn());

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMaxifs.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMaxifs.java
@@ -20,7 +20,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.ss.formula.OperationEvaluationContext;
 import org.apache.poi.ss.formula.eval.NumberEval;
@@ -41,7 +41,7 @@ final class TestMaxifs {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval)actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMinifs.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMinifs.java
@@ -20,7 +20,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.ss.formula.OperationEvaluationContext;
 import org.apache.poi.ss.formula.eval.NumberEval;
@@ -41,7 +41,7 @@ final class TestMinifs {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval)actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMultiOperandNumericFunction.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMultiOperandNumericFunction.java
@@ -18,7 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.formula.eval.EvaluationException;
@@ -45,7 +45,7 @@ class TestMultiOperandNumericFunction {
     void missingArgEvalsAreCountedAsZeroIfPolicyIsCoerce() {
         MultiOperandNumericFunction instance = new Stub(true, true, MultiOperandNumericFunction.Policy.COERCE);
         ValueEval result = instance.evaluate(new ValueEval[]{MissingArgEval.instance}, 0, 0);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(0.0, ((NumberEval)result).getNumberValue(), 0);
     }
 
@@ -53,7 +53,7 @@ class TestMultiOperandNumericFunction {
     void missingArgEvalsAreSkippedIfZeroIfPolicyIsSkipped() {
         MultiOperandNumericFunction instance = new Stub(true, true, MultiOperandNumericFunction.Policy.SKIP);
         ValueEval result = instance.evaluate(new ValueEval[]{new NumberEval(1), MissingArgEval.instance}, 0, 0);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(1.0, ((NumberEval)result).getNumberValue(), 0);
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestProduct.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestProduct.java
@@ -32,13 +32,13 @@ import java.io.IOException;
 
 import static org.apache.poi.ss.util.Utils.assertDouble;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class TestProduct {
     @Test
     void missingArgsAreIgnored() {
         ValueEval result = getInstance().evaluate(new ValueEval[]{new NumberEval(2.0), MissingArgEval.instance}, 0, 0);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(2, ((NumberEval)result).getNumberValue(), 0);
     }
 
@@ -50,14 +50,14 @@ class TestProduct {
     @Test
     void missingArgEvalReturns0() {
         ValueEval result = getInstance().evaluate(new ValueEval[0], 0, 0);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(0, ((NumberEval)result).getNumberValue(), 0);
     }
 
     @Test
     void twoMissingArgEvalsReturn0() {
         ValueEval result = getInstance().evaluate(new ValueEval[]{MissingArgEval.instance, MissingArgEval.instance}, 0, 0);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(0, ((NumberEval)result).getNumberValue(), 0);
     }
 
@@ -69,7 +69,7 @@ class TestProduct {
                 new StringEval("6"),
                 BoolEval.TRUE};
         ValueEval result = getInstance().evaluate(args, 0, 0);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(12, ((NumberEval)result).getNumberValue(), 0);
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestSumif.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestSumif.java
@@ -19,8 +19,8 @@ package org.apache.poi.ss.formula.functions;
 
 import static org.apache.poi.ss.util.Utils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.poi.hssf.usermodel.*;
 import org.apache.poi.ss.formula.eval.AreaEval;
@@ -197,7 +197,7 @@ final class TestSumif {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval)actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestSumifs.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestSumifs.java
@@ -21,6 +21,7 @@ package org.apache.poi.ss.formula.functions;
 
 import static org.apache.poi.ss.util.Utils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.poi.hssf.HSSFTestDataSamples;
@@ -51,7 +52,7 @@ final class TestSumifs {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval)actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestSumproduct.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestSumproduct.java
@@ -20,7 +20,7 @@ package org.apache.poi.ss.formula.functions;
 import static org.apache.poi.ss.util.Utils.addRow;
 import static org.apache.poi.ss.util.Utils.assertDouble;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.apache.poi.hssf.usermodel.HSSFCell;
 import org.apache.poi.hssf.usermodel.HSSFFormulaEvaluator;
@@ -45,7 +45,7 @@ final class TestSumproduct {
     }
 
     private static void confirmDouble(double expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result");
+        assertInstanceOf(NumericValueEval.class, actualEval, "Expected numeric result");
         NumericValueEval nve = (NumericValueEval)actualEval;
         assertEquals(expected, nve.getNumberValue(), 0);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestTFunc.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestTFunc.java
@@ -18,9 +18,9 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.poi.ss.formula.eval.AreaEval;
 import org.apache.poi.ss.formula.eval.BlankEval;
@@ -86,7 +86,7 @@ final class TestTFunc {
     }
 
     private static void confirmString(ValueEval eval, String expected) {
-        assertTrue(eval instanceof StringEval);
+        assertInstanceOf(StringEval.class, eval);
         assertEquals(expected, ((StringEval)eval).getStringValue());
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestWeekNumFunc.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestWeekNumFunc.java
@@ -18,7 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -95,7 +95,7 @@ class TestWeekNumFunc {
         String formula = "WEEKNUM(" + dateValue + ")";
         ValueEval[] args = new ValueEval[] { new NumberEval(dateValue) };
         ValueEval result = WeekNum.instance.evaluate(args, DEFAULT_CONTEXT);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(expected, ((NumberEval)result).getNumberValue(), TOLERANCE, formula);
     }
 
@@ -103,7 +103,7 @@ class TestWeekNumFunc {
         String formula = "WEEKNUM(" + dateValue + ", " + return_type + ")";
         ValueEval[] args = new ValueEval[] { new NumberEval(dateValue), new NumberEval(return_type) };
         ValueEval result = WeekNum.instance.evaluate(args, DEFAULT_CONTEXT);
-        assertTrue(result instanceof NumberEval);
+        assertInstanceOf(NumberEval.class, result);
         assertEquals(expected, ((NumberEval)result).getNumberValue(), TOLERANCE, formula);
     }
 }

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestCell.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestCell.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.ss.usermodel;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.apache.poi.ss.usermodel.FormulaError.forInt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -198,7 +199,7 @@ public abstract class BaseTestCell {
 
             } catch (IllegalStateException e){
                 // expected during successful test
-                assertTrue(e.getMessage().startsWith("Cannot get a"));
+                assertStartsWith(e.getMessage(), "Cannot get a");
             }
         }
     }

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestCellComment.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestCellComment.java
@@ -20,6 +20,7 @@ package org.apache.poi.ss.usermodel;
 import static org.apache.poi.util.Units.EMU_PER_PIXEL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -375,11 +376,11 @@ public abstract class BaseTestCellComment {
 
             if (wb instanceof HSSFWorkbook) {
                 // HSSFWorkbooks fail when writing out workbook
-                assertTrue(e instanceof IllegalStateException);
+                assertInstanceOf(IllegalStateException.class, e);
                 assertEquals("found multiple cell comments for cell $A$1", e.getMessage());
             } else {
                 // XSSFWorkbooks fail when creating and setting the cell address of the comment
-                assertTrue(e instanceof IllegalArgumentException);
+                assertInstanceOf(IllegalArgumentException.class, e);
                 assertEquals("Multiple cell comments in one cell are not allowed, cell: A1", e.getMessage());
             }
         }

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestConditionalFormatting.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestConditionalFormatting.java
@@ -19,6 +19,7 @@
 
 package org.apache.poi.ss.usermodel;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -64,10 +65,10 @@ public abstract class BaseTestConditionalFormatting {
 
             assertEquals(0, sheetCF.getNumConditionalFormattings());
             IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> sheetCF.getConditionalFormattingAt(0));
-            assertTrue(e.getMessage().startsWith("Specified CF index 0 is outside the allowable range"));
+            assertStartsWith(e.getMessage(), "Specified CF index 0 is outside the allowable range");
 
             e = assertThrows(IllegalArgumentException.class, () -> sheetCF.removeConditionalFormatting(0));
-            assertTrue(e.getMessage().startsWith("Specified CF index 0 is outside the allowable range"));
+            assertStartsWith(e.getMessage(), "Specified CF index 0 is outside the allowable range");
 
             ConditionalFormattingRule rule1 = sheetCF.createConditionalFormattingRule("1");
             ConditionalFormattingRule rule2 = sheetCF.createConditionalFormattingRule("2");
@@ -75,15 +76,15 @@ public abstract class BaseTestConditionalFormatting {
             ConditionalFormattingRule rule4 = sheetCF.createConditionalFormattingRule("4");
 
             e = assertThrows(IllegalArgumentException.class, () -> sheetCF.addConditionalFormatting(null, rule1));
-            assertTrue(e.getMessage().startsWith("regions must not be null"));
+            assertStartsWith(e.getMessage(), "regions must not be null");
 
             e = assertThrows(IllegalArgumentException.class, () -> sheetCF.addConditionalFormatting(
                 new CellRangeAddress[]{CellRangeAddress.valueOf("A1:A3")}, (ConditionalFormattingRule) null));
-            assertTrue(e.getMessage().startsWith("cfRules must not be null"));
+            assertStartsWith(e.getMessage(), "cfRules must not be null");
 
             e = assertThrows(IllegalArgumentException.class, () -> sheetCF.addConditionalFormatting(
                 new CellRangeAddress[]{CellRangeAddress.valueOf("A1:A3")}, new ConditionalFormattingRule[0]));
-            assertTrue(e.getMessage().startsWith("cfRules must not be empty"));
+            assertStartsWith(e.getMessage(), "cfRules must not be empty");
 
             Executable exec = () ->
                 sheetCF.addConditionalFormatting(
@@ -92,7 +93,7 @@ public abstract class BaseTestConditionalFormatting {
 
             if (applyLimitOf3()) {
                 e = assertThrows(IllegalArgumentException.class, exec);
-                assertTrue(e.getMessage().startsWith("Number of rules must not exceed 3"));
+                assertStartsWith(e.getMessage(), "Number of rules must not exceed 3");
             } else {
                 exec.execute();
             }
@@ -262,7 +263,7 @@ public abstract class BaseTestConditionalFormatting {
 
             IllegalArgumentException e;
             e = assertThrows(IllegalArgumentException.class, () -> sheetCF.getConditionalFormattingAt(0));
-            assertTrue(e.getMessage().startsWith("Specified CF index 0 is outside the allowable range"));
+            assertStartsWith(e.getMessage(), "Specified CF index 0 is outside the allowable range");
 
             formatIndex = sheetCF.addConditionalFormatting(
                 new CellRangeAddress[]{CellRangeAddress.valueOf("A1:A5")}, rule1);
@@ -272,7 +273,7 @@ public abstract class BaseTestConditionalFormatting {
             assertEquals(0, sheetCF.getNumConditionalFormattings());
 
             e = assertThrows(IllegalArgumentException.class, () -> sheetCF.getConditionalFormattingAt(0));
-            assertTrue(e.getMessage().startsWith("Specified CF index 0 is outside the allowable range"));
+            assertStartsWith(e.getMessage(), "Specified CF index 0 is outside the allowable range");
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestRow.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestRow.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.ss.usermodel;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -155,7 +156,7 @@ public abstract class BaseTestRow {
             sheet.createRow(0);
             //Test low row bound exception
             IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> sheet.createRow(-1));
-            assertTrue(e.getMessage().startsWith("Invalid row number (-1)"));
+            assertStartsWith(e.getMessage(), "Invalid row number (-1)");
 
             //Test high row bound
             sheet.createRow(maxRowNum);
@@ -175,7 +176,7 @@ public abstract class BaseTestRow {
             //Test low cell bound
             IllegalArgumentException e;
             e = assertThrows(IllegalArgumentException.class, () -> row1.createCell(-1));
-            assertTrue(e.getMessage().startsWith("Invalid column index (-1)"));
+            assertStartsWith(e.getMessage(), "Invalid column index (-1)");
 
             //Test high cell bound
             e = assertThrows(IllegalArgumentException.class, () -> row1.createCell(maxCellNum + 1));

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestWorkbook.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestWorkbook.java
@@ -17,6 +17,7 @@
 
 package org.apache.poi.ss.usermodel;
 
+import static org.apache.poi.POITestCase.assertNotContains;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -141,7 +142,7 @@ public abstract class BaseTestWorkbook {
                 "should have thrown exception due to invalid sheet index"
             );
             // expected during successful test no negative index in the range message
-            assertFalse(ex.getMessage().contains("-1"));
+            assertNotContains(ex.getMessage(), "-1");
 
             assertThrows(IllegalArgumentException.class, () -> wb.getSheetAt(0));
 

--- a/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/BaseTestCellUtil.java
@@ -26,6 +26,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -562,7 +563,7 @@ public abstract class BaseTestCellUtil {
 
             // font belongs to different workbook
             IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> CellUtil.setFont(A1, font2));
-            assertTrue(e.getMessage().startsWith("Font does not belong to this workbook"));
+            assertStartsWith(e.getMessage(), "Font does not belong to this workbook");
         }
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/util/TestCellReference.java
+++ b/poi/src/test/java/org/apache/poi/ss/util/TestCellReference.java
@@ -18,6 +18,7 @@
 package org.apache.poi.ss.util;
 
 import static org.apache.poi.POITestCase.assertContains;
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -432,7 +433,7 @@ final class TestCellReference {
         String unescapedName = "'Don't Touch'!A5";
         new CellReference(escapedName);
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new CellReference(unescapedName));
-        assertTrue(e.getMessage().startsWith("Bad sheet name quote escaping: "));
+        assertStartsWith(e.getMessage(), "Bad sheet name quote escaping: ");
     }
 
     @Test

--- a/poi/src/test/java/org/apache/poi/util/TestTempFile.java
+++ b/poi/src/test/java/org/apache/poi/util/TestTempFile.java
@@ -16,6 +16,8 @@
 ==================================================================== */
 package org.apache.poi.util;
 
+import static org.apache.poi.POITestCase.assertEndsWith;
+import static org.apache.poi.POITestCase.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -94,8 +96,8 @@ class TestTempFile {
         fos.close();
         assertTrue(tempFile.exists());
         assertTrue(tempFile.isFile());
-        assertTrue(tempFile.getName().startsWith("test"));
-        assertTrue(tempFile.getName().endsWith(".txt"));
+        assertStartsWith(tempFile.getName(), "test");
+        assertEndsWith(tempFile.getName(), ".txt");
         assertEquals(DefaultTempFileCreationStrategy.POIFILES, tempFile.getParentFile().getName());
 
         // Can't think of a good way to check whether a file is actually deleted since it would require the VM to stop.
@@ -106,7 +108,7 @@ class TestTempFile {
     @Test
     void createTempFileWithDefaultSuffix() throws IOException {
         File tempFile = TempFile.createTempFile("test", null);
-        assertTrue(tempFile.getName().endsWith(".tmp"));
+        assertEndsWith(tempFile.getName(), ".tmp");
     }
 
     @Test
@@ -115,7 +117,7 @@ class TestTempFile {
         File tempDir = TempFile.createTempDirectory("testDir");
         assertTrue(tempDir.exists());
         assertTrue(tempDir.isDirectory());
-        assertTrue(tempDir.getName().startsWith("testDir"));
+        assertStartsWith(tempDir.getName(), "testDir");
         assertEquals(DefaultTempFileCreationStrategy.POIFILES, tempDir.getParentFile().getName());
 
         // Can't think of a good way to check whether a directory is actually deleted since it would require the VM to stop.


### PR DESCRIPTION
- Replace assertTrue(x instanceof Y) → assertInstanceOf(Y.class, x) (JUnit 5)
- Replace assertTrue(str.startsWith("lit")) → assertStartsWith(str, "lit") (POITestCase)
- Replace assertTrue(str.endsWith("lit")) → assertEndsWith(str, "lit") (POITestCase)
- Replace assertTrue(str.contains("lit")) → assertContains(str, "lit") (POITestCase)
- Replace assertFalse(str.contains("lit")) → assertNotContains(str, "lit") (POITestCase)
- Add missing assertInstanceOf/assertStartsWith/assertEndsWith/assertContains/assertNotContains imports
- Remove assertTrue/assertFalse imports from files where they are no longer used
- Sort all static and regular imports alphabetically (case-sensitive/ASCII order) in changed files

