### PR TITLE
Add @Isolated to test classes that mutate static limits

### DIFF
--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFBugs.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFBugs.java
@@ -35,8 +35,10 @@ import org.apache.poi.util.Units;
 import org.apache.poi.xwpf.XWPFTestDataSamples;
 import org.apache.poi.xwpf.usermodel.XWPFRun.FontCharRange;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTAbstractNum;
 
+@Isolated   // this test changes global static limits (ZipArchiveFakeEntry, IOUtils, ZipInputStreamZipEntrySource)
 class TestXWPFBugs {
     @Test
     void bug55802() throws Exception {

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/record/TestExOleObjStg.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/record/TestExOleObjStg.java
@@ -35,10 +35,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Tests that {@link ExOleObjStg} works properly
  */
+@Isolated   // this test changes global static MAX_RECORD_LENGTH
 public final class TestExOleObjStg {
 
     // From a real file (embedded SWF control)

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestMetafileInflateSizeLimit.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestMetafileInflateSizeLimit.java
@@ -34,12 +34,14 @@ import org.apache.poi.util.RecordFormatException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Tests that WMF, EMF, and PICT inflate operations respect the
  * {@link Metafile#getMaxRecordLength()} size limit to prevent zip-bomb
  * style decompression attacks.
  */
+@Isolated   // this test changes global static MAX_RECORD_LENGTH
 public class TestMetafileInflateSizeLimit {
 
     private static final POIDataSamples SLIDE_TESTS = POIDataSamples.getSlideShowInstance();

--- a/poi-scratchpad/src/test/java/org/apache/poi/hwpf/usermodel/TestPictures.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hwpf/usermodel/TestPictures.java
@@ -43,12 +43,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test the picture handling
  */
+@Isolated   // this test changes global static MAX_RECORD_LENGTH
 public final class TestPictures {
 
     private int savedMaxRecordLength;

--- a/poi/src/test/java/org/apache/poi/ddf/TestEscherMetafileBlip.java
+++ b/poi/src/test/java/org/apache/poi/ddf/TestEscherMetafileBlip.java
@@ -32,11 +32,13 @@ import org.apache.poi.util.RecordFormatException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Tests for {@link EscherMetafileBlip}, including the inflation size guard
  * against zip-bomb style payloads.
  */
+@Isolated   // this test changes global static MAX_RECORD_LENGTH
 class TestEscherMetafileBlip {
 
     private int savedMaxRecordLength;


### PR DESCRIPTION
avoid impact on tests running at the same time (in parallel)