### PR TITLE
remove info losing int casts

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusBrush.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusBrush.java
@@ -356,7 +356,7 @@ public class HemfPlusBrush {
                 size += LittleEndianConsts.INT_SIZE;
             }
 
-            brushBytes = IOUtils.toByteArray(leis, Math.toIntExact(dataSize-size), MAX_OBJECT_SIZE);
+            brushBytes = IOUtils.toByteArray(leis, dataSize-size, MAX_OBJECT_SIZE);
 
             return dataSize;
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusObject.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusObject.java
@@ -265,7 +265,7 @@ public class HemfPlusObject {
 
             long size = graphicsVersion.init(leis);
 
-            objectDataBytes = IOUtils.toByteArray(leis, (int)(dataSize - size), MAX_OBJECT_SIZE);
+            objectDataBytes = IOUtils.toByteArray(leis, dataSize - size, MAX_OBJECT_SIZE);
 
             return dataSize;
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwmf/record/HwmfEscape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwmf/record/HwmfEscape.java
@@ -260,8 +260,8 @@ public class HwmfEscape implements HwmfRecord {
         @Override
         public int init(LittleEndianInputStream leis, long recordSize, EscapeFunction escapeFunction) throws IOException {
             this.escapeFunction = escapeFunction;
-            escapeDataBytes = IOUtils.toByteArray(leis,(int)recordSize,MAX_OBJECT_SIZE);
-            return (int)recordSize;
+            escapeDataBytes = IOUtils.toByteArray(leis, recordSize, MAX_OBJECT_SIZE);
+            return Math.toIntExact(recordSize);
         }
 
         @Override
@@ -303,9 +303,9 @@ public class HwmfEscape implements HwmfRecord {
             if (commentIdentifier != EMF_COMMENT_IDENTIFIER) {
                 // there are some WMF implementation using this record as a MFCOMMENT or similar
                 // if the commentIdentifier doesn't match, then return immediately
-                emfData = IOUtils.toByteArray(leis, (int)(recordSize-LittleEndianConsts.INT_SIZE), MAX_OBJECT_SIZE);
+                emfData = IOUtils.toByteArray(leis, recordSize-LittleEndianConsts.INT_SIZE, MAX_OBJECT_SIZE);
                 remainingBytes = emfData.length;
-                return (int)recordSize;
+                return Math.toIntExact(recordSize);
             }
 
             // A 32-bit unsigned integer that identifies the type of comment in this record.


### PR DESCRIPTION
toByteArray can handle long values and will return exceptions if the length is too long. Casts can cause int overflow and break the flow.