### PR TITLE
HemfPlusPath: validate PointCount before array allocation

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusPath.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusPath.java
@@ -41,6 +41,7 @@ import org.apache.poi.hemf.record.emfplus.HemfPlusObject.EmfPlusObjectType;
 import org.apache.poi.util.BitField;
 import org.apache.poi.util.BitFieldFactory;
 import org.apache.poi.util.GenericRecordUtil;
+import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LittleEndianConsts;
 import org.apache.poi.util.LittleEndianInputStream;
 
@@ -60,6 +61,28 @@ public class HemfPlusPath {
 
     @SuppressWarnings("unused")
     public static class EmfPlusPath implements EmfPlusObjectData, EmfPlusCompressed, EmfPlusRelativePosition {
+        /**
+         * The maximum number of points (and associated point types) we allocate for a single path.
+         * PointCount is an untrusted 32-bit field, so cap it before it is used as an array length -
+         * consistent with e.g. {@code HemfPlusDraw.MAX_OBJECT_SIZE} and {@code HemfDraw.MAX_NUMBER_OF_POLYGONS}.
+         */
+        private static final int DEFAULT_MAX_POINTS = 1_000_000;
+        private static int MAX_POINTS = DEFAULT_MAX_POINTS;
+
+        /**
+         * @param maxPoints the maximum number of points allowed for a single path
+         */
+        public static void setMaxPoints(int maxPoints) {
+            MAX_POINTS = maxPoints;
+        }
+
+        /**
+         * @return the maximum number of points allowed for a single path
+         */
+        public static int getMaxPoints() {
+            return MAX_POINTS;
+        }
+
         /**
          * If set, the point types in the PathPointTypes array are specified by EmfPlusPathPointTypeRLE objects,
          * which use run-length encoding (RLE) compression, and/or EmfPlusPathPointType objects.
@@ -118,6 +141,11 @@ public class HemfPlusPath {
             } else {
                 readPoint = HemfPlusDraw::readPointF;
             }
+
+            // pointCount is an untrusted 32-bit field that is used as the length of both arrays below.
+            // Reject negative and oversized values before allocating, so a malformed path can't trigger
+            // a NegativeArraySizeException or an OutOfMemoryError instead of the usual RecordFormatException.
+            IOUtils.safelyAllocateCheck(pointCount, MAX_POINTS);
 
             pathPoints = new Point2D[pointCount];
             for (int i=0; i<pointCount; i++) {

--- a/poi-scratchpad/src/test/java/org/apache/poi/hemf/record/emfplus/TestHemfPlusPath.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hemf/record/emfplus/TestHemfPlusPath.java
@@ -18,6 +18,7 @@
 package org.apache.poi.hemf.record.emfplus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 
@@ -25,6 +26,7 @@ import org.apache.poi.hemf.record.emfplus.HemfPlusObject.EmfPlusObjectType;
 import org.apache.poi.hemf.record.emfplus.HemfPlusPath.EmfPlusPath;
 import org.apache.poi.util.LittleEndian;
 import org.apache.poi.util.LittleEndianInputStream;
+import org.apache.poi.util.RecordFormatException;
 import org.junit.jupiter.api.Test;
 
 class TestHemfPlusPath {
@@ -55,6 +57,40 @@ class TestHemfPlusPath {
         EmfPlusPath path = new EmfPlusPath();
         try (LittleEndianInputStream leis = new LittleEndianInputStream(new ByteArrayInputStream(data))) {
             assertDoesNotThrow(() -> path.init(leis, data.length, EmfPlusObjectType.PATH, 0));
+        }
+    }
+
+    /**
+     * PointCount is an untrusted 32-bit field that is used directly as the length of the
+     * {@code pathPoints} and {@code pointTypes} arrays. Without validation a crafted path
+     * makes the parser run {@code new Point2D[pointCount]} / {@code new byte[pointCount]} on
+     * an arbitrary attacker value - a high-bit value yields a NegativeArraySizeException and a
+     * large positive value (e.g. 0x40000000 ~ 1 billion points in a 12-byte record) an
+     * OutOfMemoryError. Both must be rejected as a RecordFormatException before allocation,
+     * consistent with the sibling EmfPlusDrawDriverString record.
+     */
+    @Test
+    void pathPointCountIsValidatedBeforeAllocation() {
+        // high-bit count -> would be new Point2D[negative] -> NegativeArraySizeException (checked first,
+        // so unpatched code fails here without attempting any large allocation)
+        assertThrows(RecordFormatException.class, () -> initPath(0x80000000));
+        // ~1 billion points claimed in a 12-byte record -> would be a multi-GB allocation -> OutOfMemoryError
+        assertThrows(RecordFormatException.class, () -> initPath(0x40000000));
+    }
+
+    private static void initPath(int pointCount) throws Exception {
+        byte[] data = new byte[12];
+        int pos = 0;
+        // EmfPlusGraphicsVersion: metafile signature 0xDBC01, graphics version 1
+        LittleEndian.putInt(data, pos, 0xDBC01001); pos += 4;
+        LittleEndian.putInt(data, pos, pointCount); pos += 4;
+        // pointFlags + skipped reserved short (the allocation happens right after these)
+        LittleEndian.putShort(data, pos, (short) 0); pos += 2;
+        LittleEndian.putShort(data, pos, (short) 0);
+
+        EmfPlusPath path = new EmfPlusPath();
+        try (LittleEndianInputStream leis = new LittleEndianInputStream(new ByteArrayInputStream(data))) {
+            path.init(leis, data.length, EmfPlusObjectType.PATH, 0);
         }
     }
 }


### PR DESCRIPTION
## Summary

Validate `PointCount` before allocating path arrays in `EmfPlusPath`.

## Problem

* `PointCount` is read directly from EMF+ input.
* The value is used as the length of both `pathPoints` and `pointTypes` arrays.
* Invalid values can trigger allocation failures before any path data is processed.

## Fix

* Add validation for `PointCount` using `IOUtils.safelyAllocateCheck(...)`.
* Reject negative and oversized values before array allocation.
* Align `EmfPlusPath` with the existing allocation-safety pattern used elsewhere in HEMF parsing.