### PR TITLE
Harden integer conversions and arithmetic in HwmfBitmapDib, AggregateFunction, and DStarRunner

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hwmf/record/HwmfBitmapDib.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwmf/record/HwmfBitmapDib.java
@@ -458,7 +458,7 @@ public class HwmfBitmapDib implements GenericRecord {
         }
 
         // sometimes there are missing bytes after the imageData which will be 0-filled
-        int imageSize = (int)Math.max(imageData.length, introSize+headerImageSize);
+        int imageSize = Math.toIntExact(Math.max(imageData.length, introSize + headerImageSize));
 
         // create the image data and leave the parsing to the ImageIO api
         byte[] buf = IOUtils.safelyAllocate(BMP_HEADER_SIZE + (long)imageSize, HwmfPicture.getMaxRecordLength());

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/AggregateFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/AggregateFunction.java
@@ -49,7 +49,7 @@ public abstract class AggregateFunction extends MultiOperandNumericFunction {
                 return ErrorEval.NUM_ERROR;
             }
             // all other values are rounded up to the next integer
-            int k = (int) Math.ceil(dn);
+            int k = MathUtil.safeDoubleToInt(Math.ceil(dn));
 
             double result;
             try {

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DStarRunner.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DStarRunner.java
@@ -123,7 +123,7 @@ public final class DStarRunner implements Function3Arg {
             filterColumn = OperandResolver.getSingleValue(filterColumn, srcRowIndex, srcColumnIndex);
             if (filterColumn instanceof NumericValueEval) {
                 //fc is zero based while Excel uses 1 based column numbering
-                fc = (int) Math.round(((NumericValueEval)filterColumn).getNumberValue()) - 1;
+                fc = Math.toIntExact(Math.round(((NumericValueEval)filterColumn).getNumberValue())) - 1;
             } else {
                 fc = getColumnForName(filterColumn, db);
             }


### PR DESCRIPTION
This PR hardens integer conversions in `HwmfBitmapDib`, `AggregateFunction`, and `DStarRunner` by replacing narrowing casts with safe conversion methods that fail fast on overflow instead of silently truncating values.
HwmfBitmapDib
  * Replace `(int) Math.max(imageData.length, introSize + headerImageSize)` with `Math.toIntExact(...)`.
  * Prevents silent truncation when image size calculations exceed the integer range.

AggregateFunction
 * Replace `(int) Math.ceil(dn)` with `MathUtil.safeDoubleToInt(...)`.
  * Uses POI's existing utility method to validate double-to-int conversions.
DStarRunner
  * Replace `(int) Math.round(...)` with `Math.toIntExact(...)`.
  * Prevents silent overflow when converting rounded `long` values to `int`.

These changes preserve existing behavior for valid inputs while improving safety and consistency with recent integer-conversion hardening updates across the codebase.
Executed the relevant test suites:
bash
./gradlew :poi:test :poi-scratchpad:test -PjdkVersion=17

* 7270 tests executed
* 0 failures
* 30 skipped
