### PR TITLE
Apply allocation bounds checks to EmfPolyDraw and WmfCreateRegion

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emf/HemfDraw.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emf/HemfDraw.java
@@ -37,6 +37,7 @@ import org.apache.poi.hemf.draw.HemfGraphics;
 import org.apache.poi.hwmf.draw.HwmfGraphics.FillDrawStyle;
 import org.apache.poi.hwmf.record.HwmfDraw;
 import org.apache.poi.hwmf.record.HwmfDraw.WmfSelectObject;
+import org.apache.poi.hwmf.usermodel.HwmfPicture;
 import org.apache.poi.util.GenericRecordJsonWriter;
 import org.apache.poi.util.GenericRecordUtil;
 import org.apache.poi.util.IOUtils;
@@ -947,6 +948,7 @@ public final class HemfDraw {
             long size = readRectL(leis, bounds);
             int count = Math.toIntExact(leis.readUInt());
             size += LittleEndianConsts.INT_SIZE;
+            IOUtils.safelyAllocateCheck(count, HwmfPicture.getMaxRecordLength());
             Point2D[] points = new Point2D[count];
             for (int i=0; i<count; i++) {
                 points[i] = new Point2D.Double();

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwmf/record/HwmfWindowing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwmf/record/HwmfWindowing.java
@@ -37,9 +37,11 @@ import java.util.function.Supplier;
 import org.apache.poi.common.usermodel.GenericRecord;
 import org.apache.poi.hwmf.draw.HwmfDrawProperties;
 import org.apache.poi.hwmf.draw.HwmfGraphics;
+import org.apache.poi.hwmf.usermodel.HwmfPicture;
 import org.apache.poi.util.Dimension2DDouble;
 import org.apache.poi.util.GenericRecordJsonWriter;
 import org.apache.poi.util.GenericRecordUtil;
+import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LittleEndianConsts;
 import org.apache.poi.util.LittleEndianInputStream;
 
@@ -741,7 +743,7 @@ public class HwmfWindowing {
             bounds.setRect(left, top, right-left, bottom-top);
 
             int size = 9*LittleEndianConsts.SHORT_SIZE+LittleEndianConsts.INT_SIZE;
-
+            IOUtils.safelyAllocateCheck(scanCount, HwmfPicture.getMaxRecordLength());
             scanObjects = new WmfScanObject[scanCount];
             for (int i=0; i<scanCount; i++) {
                 size += (scanObjects[i] = new WmfScanObject()).init(leis);

--- a/poi-scratchpad/src/test/java/org/apache/poi/hemf/usermodel/TestHemfPicture.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hemf/usermodel/TestHemfPicture.java
@@ -40,6 +40,7 @@ import org.apache.poi.hemf.record.emf.HemfComment;
 import org.apache.poi.hemf.record.emf.HemfComment.EmfComment;
 import org.apache.poi.hemf.record.emf.HemfComment.EmfCommentDataFormat;
 import org.apache.poi.hemf.record.emf.HemfComment.EmfCommentDataMultiformats;
+import org.apache.poi.hemf.record.emf.HemfDraw;
 import org.apache.poi.hemf.record.emf.HemfHeader;
 import org.apache.poi.hemf.record.emf.HemfRecord;
 import org.apache.poi.hemf.record.emf.HemfRecordType;
@@ -251,6 +252,17 @@ public class TestHemfPicture {
         try (LittleEndianInputStream leis = new LittleEndianInputStream(new ByteArrayInputStream(data))) {
             header.init(leis, data.length, HemfRecordType.header.id);
             assertEquals("POI", header.getDescription());
+        }
+    }
+
+    @Test
+    void testEmfPolyDrawInvalidCount() throws Exception {
+        HemfDraw.EmfPolyDraw record = new HemfDraw.EmfPolyDraw();
+        byte[] data = new byte[20];
+        org.apache.poi.util.LittleEndian.putInt(data, 16, Integer.MAX_VALUE);
+        try (LittleEndianInputStream leis = new LittleEndianInputStream(new ByteArrayInputStream(data))) {
+            assertThrows(RecordFormatException.class,
+                () -> record.init(leis, data.length, HemfRecordType.polyDraw.id));
         }
     }
 

--- a/poi-scratchpad/src/test/java/org/apache/poi/hwmf/TestHwmfParsing.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hwmf/TestHwmfParsing.java
@@ -41,9 +41,11 @@ import org.apache.poi.hwmf.record.HwmfPlaceableHeader;
 import org.apache.poi.hwmf.record.HwmfRecord;
 import org.apache.poi.hwmf.record.HwmfRecordType;
 import org.apache.poi.hwmf.record.HwmfText;
+import org.apache.poi.hwmf.record.HwmfWindowing;
 import org.apache.poi.hwmf.usermodel.HwmfPicture;
 import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.LittleEndianInputStream;
 import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.util.RecordFormatException;
 import org.junit.jupiter.api.Disabled;
@@ -181,6 +183,17 @@ public class TestHwmfParsing {
             () -> new HwmfPicture(new ByteArrayInputStream(malicious))
         );
         assertContains(ex.getMessage(), "unitsPerInch");
+    }
+
+    @Test
+    void testWmfCreateRegionInvalidScanCount() throws Exception {
+        HwmfWindowing.WmfCreateRegion record = new HwmfWindowing.WmfCreateRegion();
+        byte[] data = new byte[34];
+        org.apache.poi.util.LittleEndian.putShort(data, 10, (short) -1);
+        try (LittleEndianInputStream leis = new LittleEndianInputStream(new ByteArrayInputStream(data))) {
+            assertThrows(RecordFormatException.class,
+                () -> record.init(leis, data.length, 0));
+        }
     }
 
     @Test


### PR DESCRIPTION
EmfPolyDraw and WmfCreateRegion allocate arrays directly from count fields read from the input stream.

This change applies POI's existing allocation safety checks before the following count-driven allocations:

Point arrays in EmfPolyDraw
Scan object arrays in WmfCreateRegion

Invalid, excessively large, or negative counts are now rejected through POI's standard allocation validation path instead of attempting unchecked array allocations.

Tests

Added regression tests covering:

Integer.MAX_VALUE count in EmfPolyDraw
Negative count in WmfCreateRegion

These tests verify that malformed inputs are rejected before array allocation occurs.

Executed the automated unit tests:

./gradlew :poi-scratchpad:test -PjdkVersion=17