### PR TITLE
Modernize test assertions using JUnit 5 assertInstanceOf

### DIFF
--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFDrawing.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFDrawing.java
@@ -933,8 +933,7 @@ class TestXSSFDrawing {
             List<XSSFShape> shapes = drawing.getShapes();
             assertEquals(1, shapes.size());
 
-            assertTrue(shapes.get(0).getAnchor() instanceof ClientAnchor);
-            ClientAnchor anchor = (ClientAnchor) shapes.get(0).getAnchor();
+            ClientAnchor anchor = assertInstanceOf(ClientAnchor.class, shapes.get(0).getAnchor());
             assertEquals(3, anchor.getCol1());
             assertEquals(38, anchor.getRow1());
             assertEquals(19, anchor.getCol2());

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestBugs.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestBugs.java
@@ -226,7 +226,11 @@ public final class TestBugs {
             for (HSLFSlide slide : ppt.getSlides()) {
                 HSLFMasterSheet master = slide.getMasterSheet();
                 // the first slide follows TitleMaster
-                assertTrue(isFirst ? master instanceof HSLFTitleMaster : master instanceof HSLFSlideMaster);
+                if (isFirst) {
+                    assertInstanceOf(HSLFTitleMaster.class, master);
+                } else {
+                    assertInstanceOf(HSLFSlideMaster.class, master);
+                }
                 isFirst = false;
             }
         }

--- a/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestTextShape.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hslf/usermodel/TestTextShape.java
@@ -77,8 +77,7 @@ public final class TestTextShape {
             List<String> lst1 = new ArrayList<>();
             HSLFSlide slide = ppt.getSlides().get(0);
             for (HSLFShape shape : slide.getShapes()) {
-                assertTrue(shape instanceof HSLFTextShape, "Expected TextShape but found " + shape.getClass().getName());
-                HSLFTextShape tx = (HSLFTextShape) shape;
+                HSLFTextShape tx = assertInstanceOf(HSLFTextShape.class, shape, () -> "Expected TextShape but found " + shape.getClass().getName());
                 List<HSLFTextParagraph> paras = tx.getTextParagraphs();
                 assertNotNull(paras);
                 int runType = paras.get(0).getRunType();

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/SanityChecker.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/SanityChecker.java
@@ -179,7 +179,7 @@ public class SanityChecker {
     private void checkWorkbookRecords(InternalWorkbook workbook) {
         List<org.apache.poi.hssf.record.Record> records = workbook.getRecords();
         assertInstanceOf(BOFRecord.class, records.get(0));
-        assertTrue(records.get(records.size() - 1) instanceof EOFRecord);
+        assertInstanceOf(EOFRecord.class, records.get(records.size() - 1));
 
         checkRecordOrder(records, workbookRecords);
     }
@@ -187,7 +187,7 @@ public class SanityChecker {
     private void checkSheetRecords(InternalSheet sheet) {
         List<RecordBase> records = sheet.getRecords();
         assertInstanceOf(BOFRecord.class, records.get(0));
-        assertTrue(records.get(records.size() - 1) instanceof EOFRecord);
+        assertInstanceOf(EOFRecord.class, records.get(records.size() - 1));
 
         checkRecordOrder(records, sheetRecords);
     }

--- a/poi/src/test/java/org/apache/poi/hssf/usermodel/TestReadWriteChart.java
+++ b/poi/src/test/java/org/apache/poi/hssf/usermodel/TestReadWriteChart.java
@@ -58,7 +58,7 @@ final class TestReadWriteChart {
         List<RecordBase> records  = newSheet.getRecords();
 
         assertInstanceOf(BOFRecord.class, records.get(0));
-        assertTrue(records.get(records.size() - 1) instanceof EOFRecord);
+        assertInstanceOf(EOFRecord.class, records.get(records.size() - 1));
 
         workbook.close();
     }

--- a/poi/src/test/java/org/apache/poi/poifs/property/TestPropertyFactory.java
+++ b/poi/src/test/java/org/apache/poi/poifs/property/TestPropertyFactory.java
@@ -18,6 +18,7 @@
 package org.apache.poi.poifs.property;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -149,13 +150,13 @@ final class TestPropertyFactory {
             } else {
                 assertNotNull(properties.get(j), "Checking property " + j);
                 if (isRoot[j]) {
-                    assertTrue(properties.get(j) instanceof RootProperty, "Checking property " + j);
+                    assertInstanceOf(RootProperty.class, properties.get(j), "Checking property " + j);
                 }
                 if (isDirectory[j]) {
-                    assertTrue(properties.get(j) instanceof DirectoryProperty, "Checking property " + j);
+                    assertInstanceOf(DirectoryProperty.class, properties.get(j), "Checking property " + j);
                 }
                 if (isDocument[j]) {
-                    assertTrue(properties.get(j) instanceof DocumentProperty, "Checking property " + j);
+                    assertInstanceOf(DocumentProperty.class, properties.get(j), "Checking property " + j);
                 }
                 assertEquals(names[j], properties.get(j).getName(), "Checking property " + j);
             }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestDays360.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestDays360.java
@@ -19,6 +19,7 @@ package org.apache.poi.ss.formula.functions;
 
 import static org.apache.poi.ss.util.Utils.assertDouble;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
@@ -166,9 +167,7 @@ final class TestDays360 {
         } else {
             ve = invokeDays360(convert(firstArg), convert(secondArg));
         }
-        assertTrue(ve instanceof NumberEval, "wrong return type (" + ve.getClass().getName() + ")");
-
-        NumberEval numberEval = (NumberEval) ve;
+        NumberEval numberEval = assertInstanceOf(NumberEval.class, ve, () -> "wrong return type (" + ve.getClass().getName() + ")");
         String err = String.format(Locale.ROOT, "days360(%tF,%tF,%b) wrong result", firstArg, secondArg, method);
         assertEquals(expResult, numberEval.getNumberValue(), 0, err);
     }

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMatch.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestMatch.java
@@ -18,6 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -53,8 +54,7 @@ final class TestMatch {
     }
 
     private static void confirmInt(int expected, ValueEval actualEval) {
-        assertTrue(actualEval instanceof NumericValueEval, "Expected numeric result but had " + actualEval);
-        NumericValueEval nve = (NumericValueEval)actualEval;
+        NumericValueEval nve = assertInstanceOf(NumericValueEval.class, actualEval, () -> "Expected numeric result but had " + actualEval);
         assertEquals(expected, nve.getNumberValue(), 0);
     }
 

--- a/poi/src/test/java/org/apache/poi/ss/formula/functions/TestText.java
+++ b/poi/src/test/java/org/apache/poi/ss/formula/functions/TestText.java
@@ -18,6 +18,7 @@
 package org.apache.poi.ss.formula.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.DateFormatSymbols;
@@ -297,15 +298,15 @@ final class TestText {
         ValueEval[] args = { valueArg, formatArg };
         ValueEval result = TextFunction.TEXT.evaluate(args, -1, -1);
 
-        assertTrue(result instanceof StringEval, "Expected StringEval got " + result.getClass().getSimpleName());
-        assertEquals(expectedResult, ((StringEval) result).getStringValue());
+        StringEval stringEval = assertInstanceOf(StringEval.class, result, () -> "Expected StringEval got " + result.getClass().getSimpleName());
+        assertEquals(expectedResult, stringEval.getStringValue());
     }
 
     private void testText(ValueEval valueArg, ValueEval formatArg, ErrorEval expectedResult) {
         ValueEval[] args = { valueArg, formatArg };
         ValueEval result = TextFunction.TEXT.evaluate(args, -1, -1);
 
-        assertTrue(result instanceof ErrorEval, "Expected ErrorEval got " + result.getClass().getSimpleName());
+        assertInstanceOf(ErrorEval.class, result, () -> "Expected ErrorEval got " + result.getClass().getSimpleName());
         assertEquals(expectedResult, result);
     }
 }


### PR DESCRIPTION
Replace legacy instanceof assertions with JUnit 5's assertInstanceOf across selected tests in the poi, poi-ooxml, and poi-scratchpad modules.
This modernizes the test suite, improves assertion readability, and eliminates several redundant casts while preserving existing test behavior.

Changes
Replaced assertTrue(obj instanceof Type) patterns with assertInstanceOf(Type.class, obj).
Removed redundant casts made unnecessary by assertInstanceOf.

Updated tests in:
poi
poi-ooxml
poi-scratchpad

Verification
Executed the affected test suites locally using Gradle and verified that all updated tests pass.