### PR TITLE
Close unclosed HSSFWorkbook in HSSF model/eventusermodel tests

### DIFF
--- a/poi/src/test/java/org/apache/poi/hssf/eventusermodel/TestEventWorkbookBuilder.java
+++ b/poi/src/test/java/org/apache/poi/hssf/eventusermodel/TestEventWorkbookBuilder.java
@@ -94,7 +94,7 @@ final class TestEventWorkbookBuilder {
     }
 
     @Test
-    void testFormulas() {
+    void testFormulas() throws IOException {
 
         // Check our formula records
         assertEquals(6, fRecs.size());
@@ -152,8 +152,9 @@ final class TestEventWorkbookBuilder {
 
 
         // Now, load via Usermodel and re-check
-        HSSFWorkbook wb = HSSFTestDataSamples.openSampleWorkbook("3dFormulas.xls");
-        assertEquals("Sheet1!A1", wb.getSheetAt(0).getRow(1).getCell(0).getCellFormula());
-        assertEquals("SUM(Sh3!A1:A4)", wb.getSheetAt(0).getRow(6).getCell(0).getCellFormula());
+        try (HSSFWorkbook wb = HSSFTestDataSamples.openSampleWorkbook("3dFormulas.xls")) {
+            assertEquals("Sheet1!A1", wb.getSheetAt(0).getRow(1).getCell(0).getCellFormula());
+            assertEquals("SUM(Sh3!A1:A4)", wb.getSheetAt(0).getRow(6).getCell(0).getCellFormula());
+        }
     }
 }

--- a/poi/src/test/java/org/apache/poi/hssf/model/TestEscherRecordFactory.java
+++ b/poi/src/test/java/org/apache/poi/hssf/model/TestEscherRecordFactory.java
@@ -48,24 +48,25 @@ class TestEscherRecordFactory {
     }
 
     @Test
-    void testDgContainerMustBeRootOfHSSFSheetEscherRecords() {
-        HSSFWorkbook wb = HSSFTestDataSamples.openSampleWorkbook("47251.xls");
-        HSSFSheet sh = wb.getSheetAt(0);
-        InternalSheet ish = HSSFTestHelper.getSheetForTest(sh);
-        List<RecordBase> records = ish.getRecords();
-        // records to be aggregated
-        List<RecordBase> dgRecords = records.subList(19, 23);
-        byte[] dgBytes = toByteArray(dgRecords);
-        sh.getDrawingPatriarch();
-        EscherAggregate agg = (EscherAggregate) ish.findFirstRecordBySid(EscherAggregate.sid);
-        assertNotNull(agg);
-        assertInstanceOf(EscherContainerRecord.class, agg.getEscherRecords().get(0));
-        assertEquals(EscherContainerRecord.DG_CONTAINER, agg.getEscherRecords().get(0).getRecordId());
-        assertEquals((short) 0x0, agg.getEscherRecords().get(0).getOptions());
-        agg = (EscherAggregate) ish.findFirstRecordBySid(EscherAggregate.sid);
-        assertNotNull(agg);
-        byte[] dgBytesAfterSave = agg.serialize();
-        assertEquals(dgBytes.length, dgBytesAfterSave.length, "different size of drawing data before and after save");
-        assertArrayEquals(dgBytes, dgBytesAfterSave, "drawing data before and after save is different");
+    void testDgContainerMustBeRootOfHSSFSheetEscherRecords() throws IOException {
+        try (HSSFWorkbook wb = HSSFTestDataSamples.openSampleWorkbook("47251.xls")) {
+            HSSFSheet sh = wb.getSheetAt(0);
+            InternalSheet ish = HSSFTestHelper.getSheetForTest(sh);
+            List<RecordBase> records = ish.getRecords();
+            // records to be aggregated
+            List<RecordBase> dgRecords = records.subList(19, 23);
+            byte[] dgBytes = toByteArray(dgRecords);
+            sh.getDrawingPatriarch();
+            EscherAggregate agg = (EscherAggregate) ish.findFirstRecordBySid(EscherAggregate.sid);
+            assertNotNull(agg);
+            assertInstanceOf(EscherContainerRecord.class, agg.getEscherRecords().get(0));
+            assertEquals(EscherContainerRecord.DG_CONTAINER, agg.getEscherRecords().get(0).getRecordId());
+            assertEquals((short) 0x0, agg.getEscherRecords().get(0).getOptions());
+            agg = (EscherAggregate) ish.findFirstRecordBySid(EscherAggregate.sid);
+            assertNotNull(agg);
+            byte[] dgBytesAfterSave = agg.serialize();
+            assertEquals(dgBytes.length, dgBytesAfterSave.length, "different size of drawing data before and after save");
+            assertArrayEquals(dgBytes, dgBytesAfterSave, "drawing data before and after save is different");
+        }
     }
 }


### PR DESCRIPTION
Close unclosed HSSFWorkbook resources in HSSF model/eventusermodel test classes: TestEscherRecordFactory and TestEventWorkbookBuilder, to avoid resource leaks.