### PR TITLE
apply allocation bounds check to EmfExtCreatePen style entries

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emf/HemfMisc.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emf/HemfMisc.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 
 import org.apache.poi.hemf.draw.HemfDrawProperties;
 import org.apache.poi.hemf.draw.HemfGraphics;
+import org.apache.poi.hemf.usermodel.HemfPicture;
 import org.apache.poi.hwmf.draw.HwmfDrawProperties;
 import org.apache.poi.hwmf.draw.HwmfGraphics;
 import org.apache.poi.hwmf.record.HwmfBinaryRasterOp;
@@ -624,6 +625,7 @@ public class HemfMisc {
             // If the pen type in the PenStyle field is PS_GEOMETRIC, the lengths are specified in logical
             // units; otherwise, the lengths are specified in device units.
 
+            HemfPicture.safelyAllocateCheck(numStyleEntries);
             float[] dashPattern = new float[numStyleEntries];
 
             for (int i = 0; i < numStyleEntries; i++) {

--- a/poi-scratchpad/src/test/java/org/apache/poi/hemf/record/emf/TestHemfMisc.java
+++ b/poi-scratchpad/src/test/java/org/apache/poi/hemf/record/emf/TestHemfMisc.java
@@ -1,0 +1,54 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.hemf.record.emf;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.poi.hemf.record.emf.HemfMisc.EmfExtCreatePen;
+import org.apache.poi.util.LittleEndian;
+import org.apache.poi.util.LittleEndianInputStream;
+import org.apache.poi.util.RecordFormatException;
+import org.junit.jupiter.api.Test;
+
+class TestHemfMisc {
+
+    /**
+     * EMR_EXTCREATEPEN reads the unsigned NumStyleEntries field straight from the
+     * record and uses it as the length of the dash-pattern array. A crafted count
+     * of 0x40000000 makes that allocation enormous, and a high-bit value turns
+     * negative when narrowed to int, so the count has to be capped before the
+     * array is created.
+     */
+    @Test
+    void numStyleEntriesIsBounded() throws Exception {
+        byte[] data = new byte[44];
+        for (int i = 0; i < 10; i++) {
+            LittleEndian.putInt(data, i * 4, 0);    // penIndex .. hatchStyle
+        }
+        LittleEndian.putInt(data, 20, 0x7);         // penStyle with PS_USERSTYLE line dash
+        LittleEndian.putInt(data, 40, 0x40000000);  // numStyleEntries
+
+        EmfExtCreatePen record = new EmfExtCreatePen();
+        try (LittleEndianInputStream leis = new LittleEndianInputStream(new ByteArrayInputStream(data))) {
+            assertThrows(RecordFormatException.class,
+                    () -> record.init(leis, (long) data.length, (long) 0x5F));
+        }
+    }
+}


### PR DESCRIPTION
**Unbounded dash array in EmfExtCreatePen**

NumStyleEntries is read straight from the EMR_EXTCREATEPEN record and used as the length of the dash-pattern array with no cap, so a crafted metafile allocates an arbitrary float array, and a high-bit value goes negative once narrowed by the (int) cast. I added the same safelyAllocateCheck the sibling pen and poly decoders already use, so an oversize count raises RecordFormatException like the rest of the record.