### PR TITLE
Use unsigned element count when parsing EscherArrayProperty

### DIFF
--- a/poi/src/main/java/org/apache/poi/ddf/EscherArrayProperty.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherArrayProperty.java
@@ -175,7 +175,7 @@ public final class EscherArrayProperty extends EscherComplexProperty implements 
         if (emptyComplexPart) {
             resizeComplexData(0);
         } else {
-            short numElements = LittleEndian.getShort(data, offset);
+            int numElements = LittleEndian.getUShort(data, offset);
             // LittleEndian.getShort(data, offset + 2); // numReserved
             short sizeOfElements = LittleEndian.getShort(data, offset + 4);
 

--- a/poi/src/test/java/org/apache/poi/ddf/TestEscherArrayProperty.java
+++ b/poi/src/test/java/org/apache/poi/ddf/TestEscherArrayProperty.java
@@ -1,0 +1,58 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+package org.apache.poi.ddf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.poi.util.LittleEndian;
+import org.junit.jupiter.api.Test;
+
+class TestEscherArrayProperty {
+
+    /**
+     * {@code OfficeArtArrayPropertyData.nElems} is an unsigned 16-bit integer
+     * ([MS-ODRAW] 2.3.7.2). {@link EscherArrayProperty#setArrayData} must read it
+     * with {@code getUShort}, consistently with the
+     * {@link EscherArrayProperty#getNumberOfElementsInArray()} and
+     * {@link EscherArrayProperty#getNumberOfElementsInMemory()} accessors (both
+     * {@code getUShort}). Reading it as a signed short makes the
+     * {@code arraySize == complexSize} "size excludes header" detection fail for
+     * arrays with 32768..65535 elements, leaving {@code sizeIncludesHeaderSize}
+     * wrong and mis-sizing the property when it is serialized again.
+     */
+    @Test
+    void setArrayDataReadsElementCountAsUnsigned() {
+        final int nElems = 0x8000;              // 32768 -> negative when read as signed short
+        final short cbElem = 2;                 // bytes per element
+        final int arraySize = nElems * cbElem;  // 65536
+
+        // "size excludes header" layout: the simple-part complexSize equals arraySize
+        EscherArrayProperty prop = new EscherArrayProperty((short) 0x0145, arraySize);
+
+        byte[] data = new byte[6];
+        LittleEndian.putUShort(data, 0, nElems);   // nElems
+        LittleEndian.putUShort(data, 2, nElems);   // nElemsInMemory
+        LittleEndian.putShort(data, 4, cbElem);    // cbElem
+
+        prop.setArrayData(data, 0);
+
+        // With nElems read as unsigned, arraySize == complexSize is detected and the
+        // 6-byte array header is added back; read as signed, that detection fails.
+        assertEquals(arraySize + 6, prop.getComplexSize());
+    }
+}


### PR DESCRIPTION
## Summary

Use an unsigned element count when parsing `EscherArrayProperty`.

## Changes

* Replace `LittleEndian.getShort()` with `LittleEndian.getUShort()` when reading the array element count (`nElems`) in `EscherArrayProperty#setArrayData`.
* Align parsing behavior with the existing unsigned accessors in the same class.
* Ensure values in the full unsigned range (`0-65535`) are interpreted correctly.

## Why

* The element count field is treated as unsigned elsewhere in `EscherArrayProperty`.
* Reading the field as a signed value can misinterpret counts greater than `32767`.
* This creates inconsistent behavior between parsing and subsequent access to the property data.

## Tests

* Added a regression test covering an element count larger than `32767`.
* Verified that the parsed complex data size is calculated correctly using the unsigned value.