### PR TITLE
Fix resource leak in ZipSecureFile constructors and correct path logging in ZipPackage

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/ZipPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/ZipPackage.java
@@ -591,7 +591,7 @@ public final class ZipPackage extends OPCPackage {
             } finally {
                 // Either the save operation succeed or not, we delete the temporary file
                 if (!tempFile.delete()) {
-                    LOG.atWarn().log("The temporary file: '{}' cannot be deleted ! Make sure that no other application use it.", targetFile.getAbsolutePath());
+                    LOG.atWarn().log("The temporary file: '{}' cannot be deleted ! Make sure that no other application use it.", tempFile.getAbsolutePath());
                 }
             }
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
@@ -210,7 +210,12 @@ public class ZipSecureFile extends ZipFile {
     public ZipSecureFile(File file) throws IOException {
         super(file);
         this.fileName = file.getAbsolutePath();
-        validateEntryNames();
+        try {
+            validateEntryNames();
+        } catch (IOException | RuntimeException | Error e) {
+            super.close();
+            throw e;
+        }
     }
 
     /**
@@ -220,7 +225,12 @@ public class ZipSecureFile extends ZipFile {
     public ZipSecureFile(String name) throws IOException {
         super(name);
         this.fileName = new File(name).getAbsolutePath();
-        validateEntryNames();
+        try {
+            validateEntryNames();
+        } catch (IOException | RuntimeException | Error e) {
+            super.close();
+            throw e;
+        }
     }
 
     /**

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
@@ -19,11 +19,19 @@ package org.apache.poi.openxml4j.util;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.TempFile;
 import org.apache.poi.xssf.XSSFTestDataSamples;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -100,5 +108,27 @@ class TestZipSecureFile {
         } finally {
             ZipSecureFile.setMaxFileCount(ZipSecureFile.DEFAULT_MAX_FILE_COUNT);
         }
+    }
+
+    @Test
+    void testConstructorExceptionReleasesFileHandle() throws Exception {
+        File tempFile = TempFile.createTempFile("duplicate-entries", ".zip");
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(tempFile)) {
+            ZipArchiveEntry entry1 = new ZipArchiveEntry("test.txt");
+            zos.putArchiveEntry(entry1);
+            zos.write("hello".getBytes(StandardCharsets.UTF_8));
+            zos.closeArchiveEntry();
+
+            ZipArchiveEntry entry2 = new ZipArchiveEntry("test.txt");
+            zos.putArchiveEntry(entry2);
+            zos.write("world".getBytes(StandardCharsets.UTF_8));
+            zos.closeArchiveEntry();
+        }
+
+        // The constructor should throw an IOException (specifically InvalidZipException)
+        assertThrows(IOException.class, () -> new ZipSecureFile(tempFile));
+
+        // If the file descriptor was correctly closed, we should be able to delete the file
+        assertTrue(tempFile.delete(), "Temporary file should be successfully deleted after constructor failure");
     }
 }


### PR DESCRIPTION

This PR fixes two issues in the `poi-ooxml` module:

1. Prevents a file descriptor leak in `ZipSecureFile` when `validateEntryNames()` fails during construction by ensuring the opened ZIP file is properly closed on initialization failure.
2. Corrects the warning log in `ZipPackage.closeImpl()` to report the actual temporary file path instead of the target document path when temporary file deletion fails.

 Verification

* Added a regression test covering invalid ZIP archives with duplicate entry names and verifying proper resource cleanup.
* All unit tests pass successfully.
