### PR TITLE
Harden duplicate ZIP entry validation against path separator bypasses

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
@@ -106,7 +106,7 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
             if (name == null || name.isEmpty()) {
                 throw new InvalidZipException("Input file contains an entry with an empty name");
             }
-            name = name.toLowerCase(Locale.ROOT);
+            name = name.replace('\\', '/').toLowerCase(Locale.ROOT);
             if (filenames.contains(name)) {
                 throw new InvalidZipException("Input file contains more than 1 entry with the name " + zipEntry.getName());
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipSecureFile.java
@@ -274,7 +274,7 @@ public class ZipSecureFile extends ZipFile {
             if (name == null || name.isEmpty()) {
                 throw new InvalidZipException("Input file contains an entry with an empty name");
             }
-            name = name.toLowerCase(Locale.ROOT);
+            name = name.replace('\\', '/').toLowerCase(Locale.ROOT);
             if (filenames.contains(name)) {
                 throw new InvalidZipException("Input file contains more than 1 entry with the name " + entry.getName());
             }

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
@@ -131,4 +131,33 @@ class TestZipSecureFile {
         // If the file descriptor was correctly closed, we should be able to delete the file
         assertTrue(tempFile.delete(), "Temporary file should be successfully deleted after constructor failure");
     }
+
+    @Test
+    void testValidateMixedSeparatorDuplicateEntryNames() throws Exception {
+        File tempFile = TempFile.createTempFile("mixed-duplicate-entries", ".zip");
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(tempFile)) {
+            ZipArchiveEntry entry1 = new ZipArchiveEntry("sub/test.txt");
+            zos.putArchiveEntry(entry1);
+            zos.write("hello".getBytes(StandardCharsets.UTF_8));
+            zos.closeArchiveEntry();
+
+            ZipArchiveEntry entry2 = new ZipArchiveEntry("sub\\test.txt");
+            zos.putArchiveEntry(entry2);
+            zos.write("world".getBytes(StandardCharsets.UTF_8));
+            zos.closeArchiveEntry();
+        }
+
+        try {
+            // ZipSecureFile should detect the duplicate entries (mixed path separators)
+            assertThrows(IOException.class, () -> new ZipSecureFile(tempFile));
+
+            // ZipInputStreamZipEntrySource should also detect the duplicate entries
+            try (InputStream is = java.nio.file.Files.newInputStream(tempFile.toPath());
+                 ZipArchiveThresholdInputStream zis = org.apache.poi.openxml4j.opc.internal.ZipHelper.openZipStream(is)) {
+                assertThrows(IOException.class, () -> new ZipInputStreamZipEntrySource(zis));
+            }
+        } finally {
+            assertTrue(tempFile.delete(), "Temporary file should be successfully deleted");
+        }
+    }
 }


### PR DESCRIPTION
Normalizes backslash separators ('\') to forward slashes ('/') in ZipSecureFile and ZipInputStreamZipEntrySource during duplicate entry validation.

When validating ZIP archives against duplicate entry names (introduced for CVE-2025-31672), entry names were matched without normalizing path separators. Because some Windows zip utilities output backslashes (`\`) instead of forward slashes (`/`), an attacker could craft an archive containing both `xl/workbook.xml` and `xl\workbook.xml`. This would bypass the duplicate check but could lead to path lookup shadowing during file parsing.

 Normalizes path separators in `ZipSecureFile.validateEntryNames()`.
 Normalizes path separators in the `ZipInputStreamZipEntrySource` constructor map index.
 Added `testValidateMixedSeparatorDuplicateEntryNames()` in `TestZipSecureFile` to verify correct detection and rejection of mixed-separator duplicates.
