### PR TITLE
Fix temporary file leak in ZipInputStreamZipEntrySource on constructor failure

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
@@ -98,21 +98,33 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
      */
     public ZipInputStreamZipEntrySource(ZipArchiveThresholdInputStream inp) throws IOException {
         final Set<String> filenames = new HashSet<>();
-        for (;;) {
-            final ZipArchiveEntry zipEntry = inp.getNextEntry();
-            if (zipEntry == null) {
-                break;
+        try {
+            for (;;) {
+                final ZipArchiveEntry zipEntry = inp.getNextEntry();
+                if (zipEntry == null) {
+                    break;
+                }
+                String name = zipEntry.getName();
+                if (name == null || name.isEmpty()) {
+                    throw new InvalidZipException("Input file contains an entry with an empty name");
+                }
+                name = IOUtils.normalizePath(name).toLowerCase(Locale.ROOT);
+                if (filenames.contains(name)) {
+                    throw new InvalidZipException("Input file contains more than 1 entry with the name " + zipEntry.getName());
+                }
+                filenames.add(name);
+                zipEntries.put(name, new ZipArchiveFakeEntry(zipEntry, inp));
             }
-            String name = zipEntry.getName();
-            if (name == null || name.isEmpty()) {
-                throw new InvalidZipException("Input file contains an entry with an empty name");
+        } catch (IOException | RuntimeException | Error e) {
+            for (ZipArchiveFakeEntry entry : zipEntries.values()) {
+                try {
+                    entry.close();
+                } catch (IOException ioex) {
+                    // ignore
+                }
             }
-            name = IOUtils.normalizePath(name).toLowerCase(Locale.ROOT);
-            if (filenames.contains(name)) {
-                throw new InvalidZipException("Input file contains more than 1 entry with the name " + zipEntry.getName());
-            }
-            filenames.add(name);
-            zipEntries.put(name, new ZipArchiveFakeEntry(zipEntry, inp));
+            zipEntries.clear();
+            throw e;
         }
 
         streamToClose = inp;

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
@@ -20,6 +20,7 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.TempFile;
+import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.XSSFTestDataSamples;
 import org.junit.jupiter.api.Test;
 
@@ -28,10 +29,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.poi.openxml4j.opc.internal.ZipHelper;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -130,6 +135,63 @@ class TestZipSecureFile {
 
         // If the file descriptor was correctly closed, we should be able to delete the file
         assertTrue(tempFile.delete(), "Temporary file should be successfully deleted after constructor failure");
+     }
+
+    @Test
+    void testZipInputStreamZipEntrySourceExceptionReleasesResources() throws Exception {
+        List<File> createdFiles = new ArrayList<>();
+        TempFileCreationStrategy customStrategy = new TempFileCreationStrategy() {
+            @Override
+            public File createTempFile(String prefix, String suffix) throws IOException {
+                File f = Files.createTempFile(prefix, suffix).toFile();
+                createdFiles.add(f);
+                return f;
+            }
+            @Override
+            public File createTempDirectory(String prefix) throws IOException {
+                return Files.createTempDirectory(prefix).toFile();
+            }
+        };
+
+        TempFile.withStrategy(customStrategy, () -> {
+            try {
+                int oldThreshold = ZipInputStreamZipEntrySource.getThresholdBytesForTempFiles();
+                ZipInputStreamZipEntrySource.setThresholdBytesForTempFiles(0);
+                try {
+                    File tempZipFile = TempFile.createTempFile("test-leak", ".zip");
+                    try {
+                        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(tempZipFile)) {
+                            ZipArchiveEntry entry1 = new ZipArchiveEntry("first.txt");
+                            zos.putArchiveEntry(entry1);
+                            zos.write("hello".getBytes(StandardCharsets.UTF_8));
+                            zos.closeArchiveEntry();
+
+                            ZipArchiveEntry entry2 = new ZipArchiveEntry("first.txt");
+                            zos.putArchiveEntry(entry2);
+                            zos.write("world".getBytes(StandardCharsets.UTF_8));
+                            zos.closeArchiveEntry();
+                        }
+
+                        try (InputStream is = Files.newInputStream(tempZipFile.toPath());
+                             ZipArchiveThresholdInputStream zis = ZipHelper.openZipStream(is)) {
+                            assertThrows(IOException.class, () -> new ZipInputStreamZipEntrySource(zis));
+                        }
+                    } finally {
+                        tempZipFile.delete();
+                    }
+                } finally {
+                    ZipInputStreamZipEntrySource.setThresholdBytesForTempFiles(oldThreshold);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        });
+
+        assertFalse(createdFiles.isEmpty(), "At least one temporary file should have been created for the zip entries");
+        for (File f : createdFiles) {
+            assertFalse(f.exists(), "Temporary file " + f.getAbsolutePath() + " should have been deleted");
+        }
     }
 
     @Test

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/util/TestZipSecureFile.java
@@ -19,6 +19,7 @@ package org.apache.poi.openxml4j.util;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.poi.util.IOUtils;
+import org.apache.poi.util.DefaultTempFileCreationStrategy;
 import org.apache.poi.util.TempFile;
 import org.apache.poi.util.TempFileCreationStrategy;
 import org.apache.poi.xssf.XSSFTestDataSamples;
@@ -141,15 +142,16 @@ class TestZipSecureFile {
     void testZipInputStreamZipEntrySourceExceptionReleasesResources() throws Exception {
         List<File> createdFiles = new ArrayList<>();
         TempFileCreationStrategy customStrategy = new TempFileCreationStrategy() {
+            private final TempFileCreationStrategy delegate = new DefaultTempFileCreationStrategy();
             @Override
             public File createTempFile(String prefix, String suffix) throws IOException {
-                File f = Files.createTempFile(prefix, suffix).toFile();
+                File f = delegate.createTempFile(prefix, suffix);
                 createdFiles.add(f);
                 return f;
             }
             @Override
             public File createTempDirectory(String prefix) throws IOException {
-                return Files.createTempDirectory(prefix).toFile();
+                return delegate.createTempDirectory(prefix);
             }
         };
 


### PR DESCRIPTION

This PR fixes a temporary file leak in `ZipInputStreamZipEntrySource` when constructor initialization fails after temporary-backed entries have already been created.

Changes

* Added exception-safe cleanup to `ZipInputStreamZipEntrySource`.
* If initialization fails due to a duplicate ZIP entry, I/O error, or other unexpected exception, all previously created `ZipArchiveFakeEntry` instances are closed to ensure their temporary files are deleted.
* Cleans up internal state before rethrowing the original exception.
* Added `testZipInputStreamZipEntrySourceExceptionReleasesResources` to verify that temporary files are properly removed when constructor initialization fails.

Verification

* Executed the new unit test and confirmed that temporary files are cleaned up on constructor failure.
* Verified that the original exception is still propagated after resources are released.
