### PR TITLE
Optimize getEntry performance in ZipInputStreamZipEntrySource using O(1) case-insensitive lookups

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipInputStreamZipEntrySource.java
@@ -164,17 +164,6 @@ public class ZipInputStreamZipEntrySource implements ZipEntrySource {
     @Override
     public ZipArchiveEntry getEntry(final String path) {
         final String normalizedPath = IOUtils.normalizePath(path);
-        final ZipArchiveEntry ze = zipEntries.get(normalizedPath);
-        if (ze != null) {
-            return ze;
-        }
-
-        for (final Map.Entry<String, ZipArchiveFakeEntry> fze : zipEntries.entrySet()) {
-            if (StringUtil.equalsIgnoreCase(normalizedPath, IOUtils.normalizePath(fze.getKey()))) {
-                return fze.getValue();
-            }
-        }
-
-        return null;
+        return zipEntries.get(normalizedPath.toLowerCase(Locale.ROOT));
     }
 }


### PR DESCRIPTION
Entry names are normalized and lowercased before being stored in the zipEntries map:

name = IOUtils.normalizePath(name).toLowerCase(Locale.ROOT);

However, getEntry() performs its initial lookup using a non-lowercased key:

final ZipArchiveEntry ze = zipEntries.get(normalizedPath);

As a result, lookups for mixed-case paths may miss the direct map lookup and fall back to a linear case-insensitive scan of all entries, degrading lookup performance from O(1) to O(N).

Solution

Apply the same normalization strategy during lookup:

return zipEntries.get(normalizedPath.toLowerCase(Locale.ROOT));

This makes lookup behavior consistent with key storage, restores O(1) retrieval, and removes the need for the fallback linear scan.