### PR TITLE
Fix equals() and hashCode() contract violation in XSSFColor

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFColor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFColor.java
@@ -382,7 +382,13 @@ public class XSSFColor extends ExtendedColor {
 
     @Override
     public int hashCode() {
-        return ctColor.toString().hashCode();
+        int result = 17;
+        result = 31 * result + (isAuto() ? 1 : 0);
+        result = 31 * result + (isIndexed() ? Short.hashCode(getIndex()) : 0);
+        result = 31 * result + (isRGB() ? java.util.Arrays.hashCode(getARGB()) : 0);
+        result = 31 * result + (isThemed() ? Integer.hashCode(getTheme()) : 0);
+        result = 31 * result + (hasTint() ? Double.hashCode(getTint()) : 0);
+        return result;
     }
 
     // Helper methods for {@link #equals(Object)}

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFColor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFColor.java
@@ -17,6 +17,7 @@
 package org.apache.poi.xssf.usermodel;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.poi.ss.usermodel.Color;
 import org.apache.poi.ss.usermodel.ExtendedColor;
@@ -382,13 +383,12 @@ public class XSSFColor extends ExtendedColor {
 
     @Override
     public int hashCode() {
-        int result = 17;
-        result = 31 * result + (isAuto() ? 1 : 0);
-        result = 31 * result + (isIndexed() ? Short.hashCode(getIndex()) : 0);
-        result = 31 * result + (isRGB() ? java.util.Arrays.hashCode(getARGB()) : 0);
-        result = 31 * result + (isThemed() ? Integer.hashCode(getTheme()) : 0);
-        result = 31 * result + (hasTint() ? Double.hashCode(getTint()) : 0);
-        return result;
+        return Objects.hash(
+                isAuto(),
+                isIndexed() ? getIndex() : null,
+                isRGB() ? Arrays.hashCode(getARGB()) : null,
+                isThemed() ? getTheme() : null,
+                hasTint() ? getTint() : null);
     }
 
     // Helper methods for {@link #equals(Object)}

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFColor.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFColor.java
@@ -198,4 +198,26 @@ public final class TestXSSFColor {
           assertEquals(hexRgb, color.getARGBHex());
        }
    }
+
+    @Test
+    void testEqualsAndHashCodeContract() throws Exception {
+        // Create programmatic CTColor
+        org.openxmlformats.schemas.spreadsheetml.x2006.main.CTColor ct1 = 
+                org.openxmlformats.schemas.spreadsheetml.x2006.main.CTColor.Factory.newInstance();
+        ct1.setRgb(new byte[]{1, 2, 3});
+
+        // Parse equivalent CTColor from string with custom namespace attribute to simulate different document contexts
+        org.openxmlformats.schemas.spreadsheetml.x2006.main.CTColor ct2 = 
+                org.openxmlformats.schemas.spreadsheetml.x2006.main.CTColor.Factory.parse(
+                        "<xml-fragment rgb=\"010203\" xmlns:custom=\"http://custom-namespace\"/>");
+
+        XSSFColor color1 = XSSFColor.from(ct1);
+        XSSFColor color2 = XSSFColor.from(ct2);
+
+        // They must be logically equal
+        assertEquals(color1, color2, "Colors must be logically equal");
+
+        // The hashCodes must be identical under the Java equals-hashCode contract
+        assertEquals(color1.hashCode(), color2.hashCode(), "Equal colors must have the same hashCode");
+    }
 }


### PR DESCRIPTION
This pull request fixes an equals()/hashCode() contract violation in XSSFColor.

equals() compares the logical color properties (ARGB, theme, index, tint, and auto), while hashCode() was based on the underlying CTColor XML string representation. As a result, two logically equal XSSFColor instances could produce different hash codes when created from different XML representations, causing incorrect behavior in hash-based collections and caches.

The fix replaces the XML-based hash code calculation with a field-based implementation consistent with the properties used by equals(). A unit test was added to verify that logically equivalent XSSFColor instances created from different XML contexts remain equal and produce identical hash codes.