### PR TITLE
Keep cell number formats when plotting chart data from a sheet range

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
@@ -57,6 +57,14 @@ public interface XDDFDataSource<T> {
     String getFormatCode();
 
     /**
+     * @return number format for the point, or {@code null} to use {@link #getFormatCode()}
+     * @since 6.0.0
+     */
+    default String getPointFormatCode(int index) {
+        return null;
+    }
+
+    /**
      * @since 5.0.0
      */
     @Internal
@@ -78,6 +86,10 @@ public interface XDDFDataSource<T> {
                 CTNumVal ctNumVal = cache.addNewPt();
                 ctNumVal.setIdx(i);
                 ctNumVal.setV(value.toString());
+                String pointFormat = getPointFormatCode(i);
+                if (pointFormat != null && !pointFormat.equals(formatCode)) {
+                    ctNumVal.setFormatCode(pointFormat);
+                }
                 effectiveNumOfPoints++;
             }
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
@@ -65,7 +65,7 @@ public interface XDDFDataSource<T> {
      * </p>
      *
      * @param index zero-based point index
-     * @return the point's format code, or {@code null} to fall back to {@link #getFormatCode()}
+     * @return the data point's format code, or {@code null} if the underlying class does not support this method or if there is no format code set for this data point - NumericalCellRangeDataSource is one class that implements this method.
      * @since 6.0.0
      */
     default String getPointFormatCode(int index) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
@@ -57,7 +57,15 @@ public interface XDDFDataSource<T> {
     String getFormatCode();
 
     /**
-     * @return number format for the point, or {@code null} to use {@link #getFormatCode()}
+     * Optional number format for a single data point in the numerical cache.
+     * <p>
+     * Return {@code null} when this point has no point-specific format and should
+     * inherit the series format from {@link #getFormatCode()}. Implementations that
+     * never use per-point formats can keep the default.
+     * </p>
+     *
+     * @param index zero-based point index
+     * @return the point's format code, or {@code null} to fall back to {@link #getFormatCode()}
      * @since 6.0.0
      */
     default String getPointFormatCode(int index) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSource.java
@@ -61,11 +61,13 @@ public interface XDDFDataSource<T> {
      * <p>
      * Return {@code null} when this point has no point-specific format and should
      * inherit the series format from {@link #getFormatCode()}. Implementations that
-     * never use per-point formats can keep the default.
+     * never use per-point formats can keep the default ({@code null}).
+     * NumericalCellRangeDataSource is one class that implements this method.
      * </p>
      *
      * @param index zero-based point index
-     * @return the data point's format code, or {@code null} if the underlying class does not support this method or if there is no format code set for this data point - NumericalCellRangeDataSource is one class that implements this method.
+     * @return the data point's format code, or {@code null} if the underlying class
+     * does not support this method or if there is no format code set for this data point.
      * @since 6.0.0
      */
     default String getPointFormatCode(int index) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSourcesFactory.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSourcesFactory.java
@@ -23,6 +23,7 @@ import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.CellValue;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.util.Beta;
+import org.apache.poi.xssf.usermodel.XSSFCell;
 import org.apache.poi.xssf.usermodel.XSSFFormulaEvaluator;
 import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
@@ -500,7 +501,7 @@ public class XDDFDataSourcesFactory {
             return cellRangeAddress.formatAsString(sheet.getSheetName(), true);
         }
 
-        protected CellValue getCellValueAt(int index) {
+        protected XSSFCell getCellAt(int index) {
             if (index < 0 || index >= numOfCells) {
                 throw new IndexOutOfBoundsException(
                         "Index must be between 0 and " + (numOfCells - 1) + " (inclusive), given: " + index);
@@ -512,26 +513,54 @@ public class XDDFDataSourcesFactory {
             int rowIndex = firstRow + index / width;
             int cellIndex = firstCol + index % width;
             XSSFRow row = sheet.getRow(rowIndex);
-            return (row == null) ? null : evaluator.evaluate(row.getCell(cellIndex));
+            return (row == null) ? null : row.getCell(cellIndex);
+        }
+
+        protected CellValue getCellValueAt(int index) {
+            XSSFCell cell = getCellAt(index);
+            return (cell == null) ? null : evaluator.evaluate(cell);
+        }
+
+        protected String getCellFormatCodeAt(int index) {
+            XSSFCell cell = getCellAt(index);
+            return (cell == null) ? null : cell.getCellStyle().getDataFormatString();
         }
     }
 
     private static class NumericalCellRangeDataSource extends AbstractCellRangeDataSource<Double>
             implements XDDFNumericalDataSource<Double> {
+        private String formatCode;
+        private boolean formatCodeSet;
+
         protected NumericalCellRangeDataSource(XSSFSheet sheet, CellRangeAddress cellRangeAddress) {
             super(sheet, cellRangeAddress);
         }
 
-        private String formatCode;
-
         @Override
         public String getFormatCode() {
-            return formatCode;
+            if (formatCodeSet) {
+                return formatCode;
+            }
+            for (int i = 0; i < getPointCount(); i++) {
+                if (getPointAt(i) != null) {
+                    String cellFormat = getCellFormatCodeAt(i);
+                    if (cellFormat != null) {
+                        return cellFormat;
+                    }
+                }
+            }
+            return null;
         }
 
         @Override
         public void setFormatCode(String formatCode) {
             this.formatCode = formatCode;
+            this.formatCodeSet = true;
+        }
+
+        @Override
+        public String getPointFormatCode(int index) {
+            return getCellFormatCodeAt(index);
         }
 
         @Override

--- a/poi-ooxml/src/test/java/org/apache/poi/xddf/usermodel/chart/TestXDDFDataSourcesFactory.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xddf/usermodel/chart/TestXDDFDataSourcesFactory.java
@@ -23,8 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.SheetBuilder;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFDataFormat;
+import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
@@ -184,6 +190,60 @@ class TestXDDFDataSourcesFactory {
         numLitDS.addNewNumLit().addNewPtCount().setVal(oversized);
         XDDFNumericalDataSource<Double> numLitSource = XDDFDataSourcesFactory.fromDataSource(numLitDS);
         assertThrows(ArithmeticException.class, numLitSource::getPointCount);
+    }
+
+    @Test
+    void testNumericCellRangeFormatCodes() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFSheet sheet = wb.createSheet();
+            XSSFDataFormat dataFormat = wb.createDataFormat();
+
+            XSSFCellStyle decimalStyle = wb.createCellStyle();
+            decimalStyle.setDataFormat(dataFormat.getFormat("#,##0.###"));
+            XSSFCellStyle intStyle = wb.createCellStyle();
+            intStyle.setDataFormat(dataFormat.getFormat("#,##0"));
+
+            XSSFRow row = sheet.createRow(0);
+            XSSFCell c0 = row.createCell(0);
+            c0.setCellValue(1000.5);
+            c0.setCellStyle(decimalStyle);
+            XSSFCell c1 = row.createCell(1);
+            c1.setCellValue(1200);
+            c1.setCellStyle(intStyle);
+            XSSFCell c2 = row.createCell(2);
+            c2.setCellValue(2000.034);
+            c2.setCellStyle(decimalStyle);
+
+            CellRangeAddress range = new CellRangeAddress(0, 0, 0, 2);
+            XDDFNumericalDataSource<Double> ds = XDDFDataSourcesFactory.fromNumericCellRange(sheet, range);
+
+            assertEquals("#,##0.###", ds.getFormatCode());
+            assertEquals("#,##0.###", ds.getPointFormatCode(0));
+            assertEquals("#,##0", ds.getPointFormatCode(1));
+            assertEquals("#,##0.###", ds.getPointFormatCode(2));
+
+            ds.setFormatCode("0.00");
+            assertEquals("0.00", ds.getFormatCode());
+            assertEquals("#,##0", ds.getPointFormatCode(1));
+
+            ds = XDDFDataSourcesFactory.fromNumericCellRange(sheet, range);
+            CTNumData cache = CTNumData.Factory.newInstance();
+            cache.setFormatCode("General");
+            ds.fillNumericalCache(cache);
+
+            assertEquals("#,##0.###", cache.getFormatCode());
+            assertEquals(3, cache.sizeOfPtArray());
+            assertFalse(cache.getPtArray(0).isSetFormatCode());
+            assertEquals("#,##0", cache.getPtArray(1).getFormatCode());
+            assertFalse(cache.getPtArray(2).isSetFormatCode());
+
+            ds.setFormatCode(null);
+            cache = CTNumData.Factory.newInstance();
+            cache.setFormatCode("General");
+            ds.fillNumericalCache(cache);
+            assertFalse(cache.isSetFormatCode());
+            assertEquals("#,##0.###", cache.getPtArray(0).getFormatCode());
+        }
     }
 
     private <T> void assertDataSourceIsEqualToArray(XDDFDataSource<T> ds, T[] array) {


### PR DESCRIPTION
When chart data is built with `fromNumericCellRange` and then `plot()` is called, the series format code in the chart `numCache` was left empty (and any existing format was cleared). PowerPoint then shows unformatted data labels if they are linked to source, until the embedded workbook is opened in Excel and the cache is refreshed.

This change reads number formats from the cells, uses the first non-blank numeric cell as the series format, and writes a per-point format when it differs. `setFormatCode(...)` still overrides the series format. Includes a regression test.

Fixes #1007