### PR TITLE
Adjusting clearText() to avoid leaving shapes with no paragraphs

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextParagraph.java
@@ -1026,9 +1026,6 @@ public class XSLFTextParagraph implements TextParagraph<XSLFShape,XSLFTextParagr
         for (int i=thisP.sizeOfFldArray(); i>0; i--) {
             thisP.removeFld(i-1);
         }
-        // _runs.size() counts fields too, but fields and runs are removed from
-        // separate XML arrays - remove exactly what's actually there instead of
-        // relying on _runs.size() as the bound.
         for (int i=thisP.sizeOfRArray(); i>0; i--) {
             thisP.removeR(i-1);
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextParagraph.java
@@ -1002,15 +1002,14 @@ public class XSLFTextParagraph implements TextParagraph<XSLFShape,XSLFTextParagr
      */
     /* package */ void clearButKeepProperties() {
         CTTextParagraph thisP = getXmlObject();
-        for (int i=thisP.sizeOfBrArray(); i>0; i--) {
-            thisP.removeBr(i-1);
-        }
-        for (int i=thisP.sizeOfFldArray(); i>0; i--) {
-            thisP.removeFld(i-1);
-        }
+
+        // Capture the last run's properties before removing anything - _runs can
+        // include field-backed runs (<a:fld>, e.g. slide number/date placeholders),
+        // and reading from one after its underlying XML has already been removed
+        // throws XmlValueDisconnectedException. See
+        // https://github.com/apache/poi/issues/919
         if (!_runs.isEmpty()) {
-            int size = _runs.size();
-            XSLFTextRun lastRun = _runs.get(size-1);
+            XSLFTextRun lastRun = _runs.get(_runs.size() - 1);
             CTTextCharacterProperties cpOther = lastRun.getRPr(false);
             if (cpOther != null) {
                 if (thisP.isSetEndParaRPr()) {
@@ -1019,11 +1018,21 @@ public class XSLFTextParagraph implements TextParagraph<XSLFShape,XSLFTextParagr
                 CTTextCharacterProperties cp = thisP.addNewEndParaRPr();
                 cp.set(cpOther);
             }
-            for (int i=size; i>0; i--) {
-                thisP.removeR(i-1);
-            }
-            _runs.clear();
         }
+
+        for (int i=thisP.sizeOfBrArray(); i>0; i--) {
+            thisP.removeBr(i-1);
+        }
+        for (int i=thisP.sizeOfFldArray(); i>0; i--) {
+            thisP.removeFld(i-1);
+        }
+        // _runs.size() counts fields too, but fields and runs are removed from
+        // separate XML arrays - remove exactly what's actually there instead of
+        // relying on _runs.size() as the bound.
+        for (int i=thisP.sizeOfRArray(); i>0; i--) {
+            thisP.removeR(i-1);
+        }
+        _runs.clear();
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
@@ -114,9 +114,23 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
      * unset text from this shape
      */
     public void clearText() {
-        _paragraphs.clear();
+        // Removing every paragraph leaves the text body with zero <a:p> elements,
+        // which violates the OOXML schema requirement that a text body contain at
+        // least one paragraph. Keep the first paragraph and just clear its content
+        // instead, same approach setText() below already relies on. See
+        // https://github.com/apache/poi/issues/919
+        if (_paragraphs.isEmpty()) {
+            return;
+        }
+
         CTTextBody txBody = getTextBody(true);
-        txBody.setPArray(null); // remove any existing paragraphs
+        int cntPs = txBody.sizeOfPArray();
+        for (int i = cntPs; i > 1; i--) {
+            txBody.removeP(i - 1);
+            _paragraphs.remove(i - 1);
+        }
+
+        _paragraphs.get(0).clearButKeepProperties();
     }
 
     @Override
@@ -743,7 +757,20 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
 
         clearText();
 
-        for (XSLFTextParagraph srcP : otherTS.getTextParagraphs()) {
+        // clearText() leaves one empty paragraph behind to satisfy the OOXML
+        // requirement of at least one paragraph. If the source has paragraphs of
+        // its own to copy in, remove that leftover empty one first so it doesn't
+        // end up as a stray leading paragraph in front of the real copied content.
+        // If the source has no paragraphs either, leave it - it's already exactly
+        // the state clearText() is supposed to produce. See
+        // https://github.com/apache/poi/issues/919
+        List<XSLFTextParagraph> srcParagraphs = otherTS.getTextParagraphs();
+        if (!srcParagraphs.isEmpty()) {
+            getTextBody(true).removeP(0);
+            _paragraphs.remove(0);
+        }
+
+        for (XSLFTextParagraph srcP : srcParagraphs) {
             XSLFTextParagraph tgtP = addNewTextParagraph();
             tgtP.copy(srcP);
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
@@ -116,8 +116,8 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
     public void clearText() {
         // Removing every paragraph leaves the text body with zero <a:p> elements,
         // which violates the OOXML schema requirement that a text body contain at
-        // least one paragraph. Keep the first paragraph and just clear its content
-        // instead, same approach setText() below already relies on. See
+        // least one paragraph. Here we keep the first paragraph and clear its
+        // contents instead, similarly to the approach in setText(). See
         // https://github.com/apache/poi/issues/919
         if (_paragraphs.isEmpty()) {
             return;
@@ -761,8 +761,8 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
         // requirement of at least one paragraph. If the source has paragraphs of
         // its own to copy in, remove that leftover empty one first so it doesn't
         // end up as a stray leading paragraph in front of the real copied content.
-        // If the source has no paragraphs either, leave it - it's already exactly
-        // the state clearText() is supposed to produce. See
+        // If the source has no paragraphs either, leave it as that's already the
+        // state clearText() is supposed to produce. See
         // https://github.com/apache/poi/issues/919
         List<XSLFTextParagraph> srcParagraphs = otherTS.getTextParagraphs();
         if (!srcParagraphs.isEmpty()) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTextShape.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTextShape.java
@@ -956,6 +956,28 @@ class TestXSLFTextShape {
         }
     }
 
+    // https://github.com/apache/poi/issues/919
+    @Test
+    void testClearTextLeavesOneEmptyParagraph() throws IOException {
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            XSLFSlide slide = ppt.createSlide();
+            XSLFAutoShape shape = slide.createAutoShape();
+            XSLFTextParagraph p = shape.addNewTextParagraph();
+            XSLFTextRun r = p.addNewTextRun();
+            r.setText("some text");
+
+            shape.clearText();
+
+            assertEquals(1, shape.getTextParagraphs().size());
+            assertTrue(shape.getTextParagraphs().get(0).getTextRuns().isEmpty());
+
+            try (XMLSlideShow ppt2 = XSLFTestDataSamples.writeOutAndReadBack(ppt)) {
+                XSLFTextShape reloaded = (XSLFTextShape) ppt2.getSlides().get(0).getShapes().get(0);
+                assertEquals(1, reloaded.getTextParagraphs().size());
+            }
+        }
+    }
+
     @Test
     void metroBlob() throws IOException, ReflectiveOperationException {
         assumeFalse(xslfOnly);


### PR DESCRIPTION
XSLFTextShape.clearText() currently removes every paragraph from a text body, leaving zero <a:p> elements. Since the OOXML schema requires at least one paragraph, PowerPoint opens presentations saved after a clearText() call in repair mode.

This change brings clearText() in line with how setText() already behaves: instead of removing every paragraph, it keeps the first paragraph and clears its contents. That preserves a valid text body while still removing all text.

Making this change exposed two existing bugs that clearText() had never hit before:

1. XSLFTextParagraph.clearButKeepProperties() removed field elements (<a:fld>, such as slide number or date placeholders) before reading the last run's formatting. If the last run was a field, this resulted in an XmlValueDisconnectedException. It also used _runs.size() to determine how many <a:r> elements to remove, even though _runs includes field runs, which could lead to an IndexOutOfBoundsException. The fix captures the last run's formatting before removing anything and removes only the runs that actually exist in the XML.

2. XSLFTextShape.copy() called clearText() and then appended the source paragraphs, leaving an extra empty paragraph at the beginning and shifting all paragraph indices by one. The fix removes that placeholder paragraph before copying whenever the source contains paragraphs. If the source is empty, the single empty paragraph is left intact, which is already the correct state.

I also added a regression test that verifies both the in-memory state and a save/reopen round trip.  

Fixes [#919.](https://github.com/apache/poi/issues/919)