### PR TITLE
Bug 919: Ensure clearText() produces valid XML by adding default empty paragraph

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextShape.java
@@ -117,6 +117,9 @@ public abstract class XSLFTextShape extends XSLFSimpleShape
         _paragraphs.clear();
         CTTextBody txBody = getTextBody(true);
         txBody.setPArray(null); // remove any existing paragraphs
+        // add a default empty paragraph to keep the XML valid
+        txBody.addNewP();
+        _paragraphs.add(newTextParagraph(txBody.getPArray(0)));
     }
 
     @Override

--- a/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTextShape.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xslf/usermodel/TestXSLFTextShape.java
@@ -30,6 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.awt.Color;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -980,6 +982,28 @@ class TestXSLFTextShape {
             String textExp = " ___ ___ ___ ________ __  _______ ___  ___________  __________ __ _____ ___ ___ ___ _______ ____ ______ ___________  _____________ ___ _______ ______  ____ ______ __ ___________  __________ ___ _________  _____ ________ __________  ___ _______ __________ ";
             textAct = xsh.getText();
             assertEquals(textExp, textAct);
+        }
+    }
+
+    @Test
+    void testClearTextWithEmptyParagraph() throws IOException {
+        try (XMLSlideShow ppt = new XMLSlideShow()) {
+            XSLFSlide slide = ppt.createSlide();
+            XSLFTextBox textBox = slide.createTextBox();
+            textBox.clearText();
+            // After clearText, the shape should still produce valid XML
+            // when re-read from a byte stream
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ppt.write(bos);
+            byte[] pptBytes = bos.toByteArray();
+            try (XMLSlideShow readBack = new XMLSlideShow(new ByteArrayInputStream(pptBytes))) {
+                XSLFSlide readSlide = readBack.getSlides().get(0);
+                XSLFTextBox readTextBox = (XSLFTextBox) readSlide.getShapes().get(0);
+                assertNotNull(readTextBox);
+                // The shape should have at least one empty paragraph
+                assertFalse(readTextBox.getTextParagraphs().isEmpty());
+                assertEquals("", readTextBox.getText());
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

When `clearText()` is called on a text shape (e.g., `XSLFTextBox`), it removes all paragraphs from the `CTTextBody`. If the shape is saved without adding new content, the resulting OOXML document is invalid because the OOXML spec requires at least one paragraph in a text body.

## Fix

After clearing all paragraphs, add a default empty paragraph to ensure the XML remains valid. This allows `clearText()` to be used safely without immediately adding new content.

## Test

Added `testClearTextWithEmptyParagraph()` that:
1. Creates a slide with a text box
2. Calls `clearText()`
3. Saves and re-reads the presentation
4. Verifies the shape has at least one empty paragraph
5. Verifies the text is empty string

Fixes #919