### PR TITLE
Fix two OPC part-name handling issues (percent-escape bounds check, marshaller round-trip)

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackagePartName.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackagePartName.java
@@ -317,7 +317,7 @@ public final class PackagePartName implements Comparable<PackagePartName> {
 
             // We certainly found an encoded character, check for length
             // now ( '%' HEXDIGIT HEXDIGIT)
-            if ((length - i) < 2 || !isHexDigit(segment.charAt(i+1)) || !isHexDigit(segment.charAt(i+2))) {
+            if ((length - i) < 3 || !isHexDigit(segment.charAt(i+1)) || !isHexDigit(segment.charAt(i+2))) {
                 throw new InvalidFormatException("The segment " + segment + " contain invalid encoded character !");
             }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/marshallers/ZipPartMarshaller.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/marshallers/ZipPartMarshaller.java
@@ -79,9 +79,12 @@ public final class ZipPartMarshaller implements PartMarshaller {
         }
 
         ZipArchiveOutputStream zos = (ZipArchiveOutputStream) os;
+        // Use getName() (the ASCII part name, preserving any percent-encoding) rather than the
+        // decoded getURI().getPath(): the zip item name is round-tripped verbatim on read
+        // (see ZipHelper.getOPCNameFromZipItemName), so a decoded name would corrupt a part name
+        // containing percent-encoded characters.
         ZipArchiveEntry partEntry = new ZipArchiveEntry(ZipHelper
-                .getZipItemNameFromOPCName(part.getPartName().getURI()
-                        .getPath()));
+                .getZipItemNameFromOPCName(part.getPartName().getName()));
         try {
             ZipHelper.adjustEntryTime(partEntry);
 

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestPackage.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestPackage.java
@@ -170,6 +170,37 @@ public final class TestPackage {
     }
 
     /**
+     * A part name containing percent-encoded characters must survive a save/open round-trip.
+     * The zip item name is written verbatim and re-read verbatim, so the marshaller has to use the
+     * ASCII part name (getName()) rather than the decoded URI path - otherwise the part is renamed
+     * (and here, being an invalid escape after decoding, silently dropped) on reload.
+     */
+    @Test
+    void percentEncodedPartNameRoundTrips() throws IOException, InvalidFormatException {
+        // "%40" is a valid percent-encoded part-name character (encodes '@', which is an authorized
+        // pchar, so it is neither a separator [M1.7] nor an unreserved character [M1.8]).
+        final PackagePartName partName = createPartName("/foo/a%40b.xml");
+        final String content = "hello";
+
+        UnsynchronizedByteArrayOutputStream bos = UnsynchronizedByteArrayOutputStream.builder().get();
+        try (OPCPackage pkg = OPCPackage.create(bos)) {
+            PackagePart part = pkg.createPart(partName, "application/xml");
+            try (OutputStream out = part.getOutputStream()) {
+                out.write(content.getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        try (OPCPackage pkg = OPCPackage.open(bos.toInputStream())) {
+            PackagePart part = pkg.getPart(partName);
+            assertNotNull(part, "part with a percent-encoded name should survive a save/open round-trip");
+            assertEquals("/foo/a%40b.xml", part.getPartName().getName());
+            try (InputStream in = part.getInputStream()) {
+                assertEquals(content, new String(IOUtils.toByteArray(in), StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+    /**
      * Test package creation.
      */
     @Test


### PR DESCRIPTION
Two small fixes to OPC part-name handling, surfaced during a review of the zip/OPC layer.

### 1. Off-by-one in `PackagePartName.checkPCharCompliant`

The percent-escape length check was:

```java
if ((length - i) < 2 || !isHexDigit(segment.charAt(i+1)) || !isHexDigit(segment.charAt(i+2))) {
```

A valid escape is `%` plus **two** hex digits, so it needs three characters — the guard should be `< 3`. With `i == length-2` the guard passes and the code then indexes `charAt(i+2) == charAt(length)`, throwing `StringIndexOutOfBoundsException` instead of a clean `InvalidFormatException`.

This is **not reachable** from a parsed part name today, because every path constructs the name via `new URI(...)`, which rejects a truncated escape (`URISyntaxException: Malformed escape pair`) before validation runs. Corrected defensively; no test, since no input reaches it.

### 2. `ZipPartMarshaller` corrupts percent-encoded part names on save

The marshaller derived the zip item name from the **decoded** `getPartName().getURI().getPath()`:

```java
new ZipArchiveEntry(ZipHelper.getZipItemNameFromOPCName(part.getPartName().getURI().getPath()));
```

On read, the zip item name is turned back into a part name verbatim (`ZipHelper.getOPCNameFromZipItemName` just prepends `/`), and the content-type registration uses the ASCII `getName()`. So a part whose name contains a percent-encoded character (e.g. `/foo/a%40b.xml`) was written as the decoded `foo/a@b.xml` and came back with a different name after a save/open round-trip. Switched to `getName()` for consistency with the read path and the content-type manager.

Added `TestPackage.percentEncodedPartNameRoundTrips`, which fails before this change and passes after. (For normal, unencoded part names `getName()` and `getURI().getPath()` are identical, so there is no behaviour change there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)