### PR TITLE
Remove dead SchemaFactory-hardening code from XSSFExportToXml

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFExportToXml.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFExportToXml.java
@@ -81,13 +81,6 @@ import org.xml.sax.SAXException;
 public class XSSFExportToXml implements Comparator<String>{
     private static final Logger LOG = PoiLogManager.getLogger(XSSFExportToXml.class);
 
-
-    @FunctionalInterface
-    private interface SecurityFeature {
-        void accept(String name) throws SAXException;
-    }
-
-
     private XSSFMap map;
     private final HashMap<String, Integer> indexMap = new HashMap<>();
     /**
@@ -548,15 +541,5 @@ public class XSSFExportToXml implements Comparator<String>{
             node = node.getNextSibling();
         }
         return complexTypeNode;
-    }
-
-    private static void trySet(String name, SecurityFeature securityFeature) {
-        try {
-            securityFeature.accept(name);
-        } catch (Exception e) {
-            LOG.atWarn().withThrowable(e).log("SchemaFactory feature ({}) unsupported", name);
-        } catch (AbstractMethodError ame) {
-            LOG.atWarn().withThrowable(ame).log("Cannot set SchemaFactory feature ({}) because outdated XML parser in classpath", name);
-        }
     }
 }


### PR DESCRIPTION
Small cleanup spotted during a review of the XML-mapping export path.

`XSSFExportToXml` still declares a private `SecurityFeature` functional interface and a `trySet(String, SecurityFeature)` helper. Both are unreferenced — they date from when this class hardened the `SchemaFactory` itself. That logic now lives in `XMLHelper.getSchemaFactory()` (which disables `ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA`/`ACCESS_EXTERNAL_STYLESHEET` and enables secure processing), and `XSSFExportToXml` already obtains its factory from there.

Removing the dead members. No behaviour change; `TestXSSFExportToXML` and `TestXSSFImportFromXML` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)