### PR TITLE
Escape relationship id interpolated into drawing fragment in XWPFRun.addChart

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -1380,11 +1380,16 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
 
             CTInline inline = run.addNewDrawing().addNewInline();
 
+            // chartRelId is interpolated into an XML attribute value below, so escape it.
+            // A relationship id is an xsd:ID and cannot legitimately contain these characters,
+            // but escaping keeps a malformed id from corrupting or injecting into the fragment.
+            String escapedRelId = XMLHelper.escapeXml(chartRelId);
+
             //xml part of chart in document
             String xml =
                     "<a:graphic xmlns:a=\"" + CTGraphicalObject.type.getName().getNamespaceURI() + "\">" +
                             "<a:graphicData uri=\"" + CTChart.type.getName().getNamespaceURI() + "\">" +
-                            "<c:chart xmlns:c=\"" + CTChart.type.getName().getNamespaceURI() + "\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" r:id=\"" + chartRelId + "\" />" +
+                            "<c:chart xmlns:c=\"" + CTChart.type.getName().getNamespaceURI() + "\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" r:id=\"" + escapedRelId + "\" />" +
                             "</a:graphicData>" +
                             "</a:graphic>";
 

--- a/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xwpf/usermodel/TestXWPFRun.java
@@ -47,6 +47,7 @@ import org.openxmlformats.schemas.drawingml.x2006.main.CTBlipFillProperties;
 import org.openxmlformats.schemas.drawingml.x2006.picture.CTPicture;
 import org.openxmlformats.schemas.officeDocument.x2006.sharedTypes.STOnOff1;
 import org.openxmlformats.schemas.officeDocument.x2006.sharedTypes.STVerticalAlignRun;
+import org.openxmlformats.schemas.drawingml.x2006.wordprocessingDrawing.CTInline;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTOnOff;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
@@ -80,6 +81,22 @@ class TestXWPFRun {
     @AfterEach
     void tearDown() throws Exception {
         doc.close();
+    }
+
+    @Test
+    void addChartEscapesRelationshipId() {
+        XWPFRun run = p.createRun();
+        // A relationship id is an xsd:ID and can never legitimately contain XML metacharacters,
+        // but a hostile/malformed id must not break out of the r:id attribute of the generated
+        // drawing fragment (which would otherwise throw on parse, or inject markup).
+        final String craftedId = "rId1\"/><evil>";
+        CTInline inline = assertDoesNotThrow(() -> run.addChart(craftedId));
+        String xml = inline.getGraphic().xmlText();
+        assertFalse(xml.contains("<evil>"), "relationship id must not inject markup: " + xml);
+
+        // a normal relationship id still round-trips
+        CTInline ok = assertDoesNotThrow(() -> p.createRun().addChart("rId42"));
+        assertTrue(ok.getGraphic().xmlText().contains("rId42"));
     }
 
     @Test

--- a/poi/src/main/java/org/apache/poi/util/XMLHelper.java
+++ b/poi/src/main/java/org/apache/poi/util/XMLHelper.java
@@ -267,6 +267,48 @@ public final class XMLHelper {
         return getDepthOfChildNodes(node, maxSupportedDepth, 0);
     }
 
+    /**
+     * Escapes the five predefined XML entities ({@code & < > " '}) in the supplied string so it
+     * can be safely embedded as XML element text or as a single- or double-quoted attribute value.
+     * <p>
+     * This is intended for the rare cases where XML is assembled by hand; prefer building XML
+     * through a DOM/{@link javax.xml.stream.XMLStreamWriter} where practical.
+     *
+     * @param value the string to escape, may be {@code null}
+     * @return the escaped string, or {@code null} if {@code value} was {@code null}
+     * @since POI 6.0.0
+     */
+    public static String escapeXml(final String value) {
+        if (value == null) {
+            return null;
+        }
+        StringBuilder sb = null;
+        for (int i = 0; i < value.length(); i++) {
+            final char c = value.charAt(i);
+            final String replacement;
+            switch (c) {
+                case '&':  replacement = "&amp;";  break;
+                case '<':  replacement = "&lt;";   break;
+                case '>':  replacement = "&gt;";   break;
+                case '"':  replacement = "&quot;"; break;
+                case '\'': replacement = "&apos;"; break;
+                default:   replacement = null;     break;
+            }
+            if (replacement == null) {
+                if (sb != null) {
+                    sb.append(c);
+                }
+            } else {
+                if (sb == null) {
+                    sb = new StringBuilder(value.length() + 16);
+                    sb.append(value, 0, i);
+                }
+                sb.append(replacement);
+            }
+        }
+        return sb == null ? value : sb.toString();
+    }
+
     private static int getDepthOfChildNodes(final Node node, final int maxSupportedDepth,
                                             final int nodeDepth) throws POIException {
         final int currentDepth = nodeDepth + 1;

--- a/poi/src/test/java/org/apache/poi/util/TestXMLHelper.java
+++ b/poi/src/test/java/org/apache/poi/util/TestXMLHelper.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -169,5 +171,46 @@ class TestXMLHelper {
     @Test
     void testNewTransformer() throws Exception {
         assertNotNull(XMLHelper.newTransformer());
+    }
+
+    @Test
+    void testEscapeXmlNull() {
+        assertNull(XMLHelper.escapeXml(null));
+    }
+
+    @Test
+    void testEscapeXmlNoSpecialCharsReturnsSameInstance() {
+        // fast path: nothing to escape, so the original string is returned unchanged
+        String s = "no special chars here 123";
+        assertSame(s, XMLHelper.escapeXml(s));
+        String empty = "";
+        assertSame(empty, XMLHelper.escapeXml(empty));
+    }
+
+    @Test
+    void testEscapeXmlEachPredefinedEntity() {
+        assertEquals("&amp;", XMLHelper.escapeXml("&"));
+        assertEquals("&lt;", XMLHelper.escapeXml("<"));
+        assertEquals("&gt;", XMLHelper.escapeXml(">"));
+        assertEquals("&quot;", XMLHelper.escapeXml("\""));
+        assertEquals("&apos;", XMLHelper.escapeXml("'"));
+    }
+
+    @Test
+    void testEscapeXmlAmpersandNotDoubleEscaped() {
+        // '&' must be escaped exactly once, even when adjacent to another special char
+        assertEquals("a&amp;&lt;b", XMLHelper.escapeXml("a&<b"));
+        assertEquals("&amp;amp;", XMLHelper.escapeXml("&amp;"));
+    }
+
+    @Test
+    void testEscapeXmlMixedContentPreservesNormalChars() {
+        assertEquals("x &lt;y&gt; &amp; &quot;z&quot; 1", XMLHelper.escapeXml("x <y> & \"z\" 1"));
+    }
+
+    @Test
+    void testEscapeXmlAttributeInjectionIsNeutralised() {
+        // a value that would otherwise break out of an r:id="..." attribute
+        assertEquals("rId1&quot;/&gt;&lt;evil&gt;", XMLHelper.escapeXml("rId1\"/><evil>"));
     }
 }


### PR DESCRIPTION
Defensive hardening spotted during a review of the XWPF write path.

`XWPFRun.addChart(String chartRelId)` builds the inline-drawing XML by concatenating `chartRelId` directly into the `r:id` attribute value, then parses the result:

```java
"... r:id=\"" + chartRelId + "\" />" ...
```

A relationship id is an `xsd:ID` and cannot legitimately contain `"`/`<`/`&`, and this method is `@Internal` with the id generated by POI (`XWPFChart.attach` → `createChart`), so **this is not reachable from an untrusted document**. But a malformed or hostile id would break out of the attribute — corrupting the fragment or throwing `IllegalStateException` on parse. Escaping `&`, `<`, and `"` in the value closes that off.

Added `TestXWPFRun.addChartEscapesRelationshipId`, which fails before this change (the crafted id throws) and passes after; it also checks a normal id still round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)