### PR TITLE
Apply DEFAULT_XML_OPTIONS to remaining XMLBeans parses in xslf/xdgf

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFMasterContents.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFMasterContents.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 
 import com.microsoft.schemas.office.visio.x2012.main.MasterContentsDocument;
 import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.xdgf.exceptions.XDGFException;
 import org.apache.xmlbeans.XmlException;
@@ -46,7 +47,7 @@ public class XDGFMasterContents extends XDGFBaseContents {
         try {
 
             try (InputStream stream = getPackagePart().getInputStream()) {
-                _pageContents = MasterContentsDocument.Factory.parse(stream).getMasterContents();
+                _pageContents = MasterContentsDocument.Factory.parse(stream, POIXMLTypeLoader.DEFAULT_XML_OPTIONS).getMasterContents();
             } catch (XmlException | IOException e) {
                 throw new POIXMLException(e);
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFMasters.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFMasters.java
@@ -31,6 +31,7 @@ import com.microsoft.schemas.office.visio.x2012.main.RelType;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.util.Internal;
 import org.apache.poi.xdgf.exceptions.XDGFException;
@@ -63,7 +64,7 @@ public class XDGFMasters extends XDGFXMLDocumentPart {
     protected void onDocumentRead() {
         try {
             try (InputStream stream = getPackagePart().getInputStream()) {
-                _mastersObject = MastersDocument.Factory.parse(stream).getMasters();
+                _mastersObject = MastersDocument.Factory.parse(stream, POIXMLTypeLoader.DEFAULT_XML_OPTIONS).getMasters();
             } catch (XmlException | IOException e) {
                 throw new POIXMLException(e);
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFPageContents.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFPageContents.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import com.microsoft.schemas.office.visio.x2012.main.PageContentsDocument;
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.xdgf.exceptions.XDGFException;
 import org.apache.xmlbeans.XmlException;
@@ -45,7 +46,7 @@ public class XDGFPageContents extends XDGFBaseContents {
     protected void onDocumentRead() {
         try {
             try (InputStream stream = getPackagePart().getInputStream()) {
-                _pageContents = PageContentsDocument.Factory.parse(stream).getPageContents();
+                _pageContents = PageContentsDocument.Factory.parse(stream, POIXMLTypeLoader.DEFAULT_XML_OPTIONS).getPageContents();
             } catch (XmlException | IOException e) {
                 throw new POIXMLException(e);
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFPages.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XDGFPages.java
@@ -29,6 +29,7 @@ import com.microsoft.schemas.office.visio.x2012.main.RelType;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.util.Internal;
 import org.apache.poi.xdgf.exceptions.XDGFException;
@@ -62,7 +63,7 @@ public class XDGFPages extends XDGFXMLDocumentPart {
     protected void onDocumentRead() {
         try {
             try (InputStream stream = getPackagePart().getInputStream()) {
-                _pagesObject = PagesDocument.Factory.parse(stream).getPages();
+                _pagesObject = PagesDocument.Factory.parse(stream, POIXMLTypeLoader.DEFAULT_XML_OPTIONS).getPages();
             } catch (XmlException | IOException e) {
                 throw new POIXMLException(e);
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XmlVisioDocument.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XmlVisioDocument.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.poi.ooxml.POIXMLDocument;
 import org.apache.poi.ooxml.POIXMLDocumentPart;
 import org.apache.poi.ooxml.POIXMLException;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.openxml4j.opc.PackageRelationshipTypes;
@@ -70,7 +71,7 @@ public class XmlVisioDocument extends POIXMLDocument {
         VisioDocumentType document;
 
         try (InputStream stream = getPackagePart().getInputStream()){
-            document = VisioDocumentDocument1.Factory.parse(stream).getVisioDocument();
+            document = VisioDocumentDocument1.Factory.parse(stream, POIXMLTypeLoader.DEFAULT_XML_OPTIONS).getVisioDocument();
         } catch (XmlException | IOException e) {
             throw new POIXMLException(e);
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFDiagramDrawing.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFDiagramDrawing.java
@@ -18,6 +18,7 @@ package org.apache.poi.xslf.usermodel;
 
 import com.microsoft.schemas.office.drawing.x2008.diagram.DrawingDocument;
 import org.apache.poi.ooxml.POIXMLDocumentPart;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.util.Beta;
 import org.apache.xmlbeans.XmlException;
@@ -45,7 +46,7 @@ public class XSLFDiagramDrawing extends POIXMLDocumentPart {
 
     private static DrawingDocument readPackagePart(PackagePart part) throws IOException, XmlException {
         try (InputStream is = part.getInputStream()) {
-            return DrawingDocument.Factory.parse(is);
+            return DrawingDocument.Factory.parse(is, POIXMLTypeLoader.DEFAULT_XML_OPTIONS);
         }
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTableStyles.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTableStyles.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.poi.ooxml.POIXMLDocumentPart;
+import org.apache.poi.ooxml.POIXMLTypeLoader;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.util.Beta;
 import org.apache.xmlbeans.XmlException;
@@ -48,7 +49,7 @@ public class XSLFTableStyles extends POIXMLDocumentPart implements Iterable<XSLF
 
         TblStyleLstDocument styleDoc;
         try (InputStream is = getPackagePart().getInputStream()) {
-            styleDoc = TblStyleLstDocument.Factory.parse(is);
+            styleDoc = TblStyleLstDocument.Factory.parse(is, POIXMLTypeLoader.DEFAULT_XML_OPTIONS);
         }
         _tblStyleLst = styleDoc.getTblStyleLst();
         List<CTTableStyle> tblStyles = _tblStyleLst.getTblStyleList();


### PR DESCRIPTION
A consistency/defense-in-depth follow-up from a review of the OOXML parsing paths.

Nearly every `*.Factory.parse(...)` on an untrusted document part in POI passes `POIXMLTypeLoader.DEFAULT_XML_OPTIONS`, which sets `setDisallowDocTypeDeclaration(true)` and `setEntityExpansionLimit(1)`. Seven parse sites did not:

- `xslf/usermodel/XSLFDiagramDrawing` (SmartArt drawing part)
- `xslf/usermodel/XSLFTableStyles` (table styles part)
- `xdgf/usermodel/XmlVisioDocument` (Visio document part)
- `xdgf/usermodel/XDGFMasters`, `XDGFMasterContents`, `XDGFPageContents`, `XDGFPages`

This routes those parses through `DEFAULT_XML_OPTIONS` too.

### Not an XXE fix — defense-in-depth for consistency

xmlbeans 5.x already blocks external-entity resolution by default (its default loader installs an empty-`InputSource` entity resolver and enables secure processing — the CVE-2021-23926 hardening), so these sites were **not** exposed to external-entity XXE (local file read / SSRF). This change disallows DOCTYPE declarations and tightens the internal entity-expansion bound on these parts so they match every other OOXML parse in POI.

No behaviour change for valid documents; the existing xdgf/xslf tests (`TestXmlVisioDocument`, `TestXDGFVisioExtractor`, `TestXSLFDiagram`, `TestXSLFTableStyles`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)