### PR TITLE
Fix `findColumnIndex()` to handle newline characters in column headers

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFTable.java
@@ -877,10 +877,15 @@ public class XSSFTable extends POIXMLDocumentPart implements Table {
             }
         }
         // Table column names with special characters need a single quote escape
-        // but the escape is not present in the column definition
+        // but the escape is not present in the column definition.
+        // Also replace newline and carriage return characters with their _x000a_
+        // and _x000d_ escape sequences to match the encoding applied by
+        // updateHeaders(), which uses the OOXML _xXXXX_ escape convention.
         String unescapedString = columnHeader
                 .replace("''", "'")
-                .replace("'#", "#");
+                .replace("'#", "#")
+                .replace("\n", "_x000a_")
+                .replace("\r", "_x000d_");
         Integer idx = columnMap.get(unescapedString);
         return idx == null ? -1 : idx;
     }

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFTable.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFTable.java
@@ -29,6 +29,9 @@ import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.CellValue;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.util.AreaReference;
 import org.apache.poi.ss.util.CellReference;
@@ -709,6 +712,50 @@ public final class TestXSSFTable {
                 List<XSSFTableColumn> tabColumns = wb2Table.getColumns();
                 assertEquals(2, tabColumns.size());
                 assertEquals("Column1_x000a_with a line break", tabColumns.get(0).getName());
+                assertEquals(0, wb2Table.findColumnIndex("Column1\nwith a line break"));
+            }
+        }
+    }
+
+    @Test
+    void testFormulaWithNewlineColumnName() throws IOException {
+        try (
+                XSSFWorkbook wb = new XSSFWorkbook();
+                UnsynchronizedByteArrayOutputStream bos = UnsynchronizedByteArrayOutputStream.builder().get()
+        ) {
+            XSSFSheet sheet = wb.createSheet();
+            XSSFRow headersRow = sheet.createRow(0);
+            headersRow.createCell(0).setCellValue("Value\nA");
+            headersRow.createCell(1).setCellValue("Value\nB");
+
+            XSSFRow row1 = sheet.createRow(1);
+            row1.createCell(0).setCellValue(100);
+            row1.createCell(1).setCellValue(50);
+
+            XSSFRow row2 = sheet.createRow(2);
+            row2.createCell(0).setCellValue(200);
+            row2.createCell(1).setCellValue(75);
+
+            AreaReference area = wb.getCreationHelper().createAreaReference(
+                    new CellReference(0, 0), new CellReference(2, 1));
+            XSSFTable table = sheet.createTable(area);
+            table.setName("Table1");
+
+            // write and reload so updateHeaders() encodes \n to _x000a_
+            wb.write(bos);
+            try (XSSFWorkbook wb2 = new XSSFWorkbook(bos.toInputStream())) {
+                XSSFSheet wb2Sheet = wb2.getSheetAt(0);
+                XSSFTable wb2Table = wb2Sheet.getTables().get(0);
+
+                assertEquals(0, wb2Table.findColumnIndex("Value\nA"));
+
+                XSSFRow formulaRow = wb2Sheet.createRow(3);
+                XSSFCell formulaCell = formulaRow.createCell(0, CellType.FORMULA);
+                formulaCell.setCellFormula("SUM(Table1[Value\nA])");
+
+                FormulaEvaluator evaluator = wb2.getCreationHelper().createFormulaEvaluator();
+                CellValue value = evaluator.evaluate(formulaCell);
+                assertEquals(300.0, value.getNumberValue(), 0.001);
             }
         }
     }


### PR DESCRIPTION
When a table column header contains a newline character (`\n`), `updateHeaders()` encodes it as `_x000a_` (the OOXML `_xXXXX_` escape convention) before storing in the column definition. However, `findColumnIndex()` did not perform the reverse encoding when looking up column names, causing lookups against multi-line column headers to always return `-1`.

This fix adds `\n` → `_x000a_` and `\r` → `_x000d_` replacements to the `findColumnIndex()` string normalization chain, matching the encoding already applied by `updateHeaders()`.

**Changes:**
- `XSSFTable.java` — `findColumnIndex()` now replaces `\n` with `_x000a_` and `\r` with `_x000d_` before looking up the column name in the map
- `TestXSSFTable.java` — Added `findColumnIndex` assertion to `testNamesWithNewLines()` and new `testFormulaWithNewlineColumnName()` test that verifies `SUM(Table1[Value\nA])` evaluates correctly with newline column names