### PR TITLE
Use more Java 17 idioms in poi-ooxml

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/ooxml/POIXMLDocumentPart.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/ooxml/POIXMLDocumentPart.java
@@ -686,8 +686,8 @@ public class POIXMLDocumentPart {
                         }
                         //here we are checking if part is embedded and excel then set it to chart class
                         //so that at the time to writing we can also write updated embedded part
-                        if (this instanceof XDDFChart && childPart instanceof XSSFWorkbook) {
-                            ((XDDFChart) this).setWorkbook((XSSFWorkbook) childPart);
+                        if (this instanceof XDDFChart chart && childPart instanceof XSSFWorkbook workbook) {
+                            chart.setWorkbook(workbook);
                         }
                         childPart.parent = this;
                         // already add child to context, so other children can reference it

--- a/poi-ooxml/src/main/java/org/apache/poi/ooxml/util/NumberHelper.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/ooxml/util/NumberHelper.java
@@ -37,10 +37,10 @@ public class NumberHelper {
      * @throws IllegalArgumentException if the number cannot be converted
      */
     public static double toDouble(Object number) {
-        if (number instanceof Number) {
-            return ((Number) number).doubleValue();
-        } else if (number instanceof String) {
-            return Double.parseDouble((String) number);
+        if (number instanceof Number num) {
+            return num.doubleValue();
+        } else if (number instanceof String str) {
+            return Double.parseDouble(str);
         }
         throw new IllegalArgumentException("Cannot convert of class" + number.getClass().getName() +
                 " to double");

--- a/poi-ooxml/src/main/java/org/apache/poi/ooxml/util/PackageHelper.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/ooxml/util/PackageHelper.java
@@ -65,8 +65,8 @@ public final class PackageHelper {
             return OPCPackage.open(stream, closeStream);
         } catch (InvalidFormatException e) {
             final Throwable cause = e.getCause();
-            if (cause instanceof InvalidZipException) {
-                throw (InvalidZipException) cause;
+            if (cause instanceof InvalidZipException ize) {
+                throw ize;
             }
             throw new POIXMLException(e);
         } finally {

--- a/poi-ooxml/src/main/java/org/apache/poi/ooxml/util/XPathHelper.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/ooxml/util/XPathHelper.java
@@ -160,8 +160,8 @@ public final class XPathHelper {
         // otherwise check first the choice then the fallback content
         XmlObject xo = cur.getObject();
         AlternateContentDocument.AlternateContent alterCont;
-        if (xo instanceof AlternateContentDocument.AlternateContent) {
-            alterCont = (AlternateContentDocument.AlternateContent)xo;
+        if (xo instanceof AlternateContentDocument.AlternateContent ac) {
+            alterCont = ac;
         } else {
             // Pesky XmlBeans bug - see Bugzilla #49934
             // it never happens when using poi-ooxml-full jar but may happen with the abridged poi-ooxml-lite jar

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackagePartName.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackagePartName.java
@@ -449,8 +449,8 @@ public final class PackagePartName implements Comparable<PackagePartName> {
      */
     @Override
     public boolean equals(Object other) {
-        return (other instanceof PackagePartName) &&
-            compare(this.getName(), ((PackagePartName)other).getName()) == 0;
+        return (other instanceof PackagePartName otherName) &&
+            compare(this.getName(), otherName.getName()) == 0;
     }
 
     @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackageRelationship.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackageRelationship.java
@@ -110,10 +110,9 @@ public final class PackageRelationship {
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof PackageRelationship)) {
+        if (!(obj instanceof PackageRelationship rel)) {
             return false;
         }
-        PackageRelationship rel = (PackageRelationship) obj;
         return (this.id.equals(rel.id)
                 && this.relationshipType.equals(rel.relationshipType)
                 && (rel.source == null || rel.source.equals(this.source))

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/ZipPackage.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/ZipPackage.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
@@ -422,7 +421,7 @@ public final class ZipPackage extends OPCPackage {
                         .map(zae -> new EntryTriple(zae, contentTypeManager))
                         .filter(mm -> mm.partName != null)
                         .sorted()
-                        .collect(Collectors.toList());
+                        .toList();
 
         for (final EntryTriple et : entries) {
             et.register(newPartList);
@@ -644,8 +643,8 @@ public final class ZipPackage extends OPCPackage {
         // Check that the document was open in write mode
         throwExceptionIfReadOnly();
 
-        final ZipArchiveOutputStream zos = (outputStream instanceof ZipArchiveOutputStream)
-            ? (ZipArchiveOutputStream) outputStream : new ZipArchiveOutputStream(outputStream);
+        final ZipArchiveOutputStream zos = (outputStream instanceof ZipArchiveOutputStream zaos)
+            ? zaos : new ZipArchiveOutputStream(outputStream);
 
         try {
             // If the core properties part does not exist in the part list,

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/ZipContentTypeManager.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/ZipContentTypeManager.java
@@ -56,8 +56,8 @@ public class ZipContentTypeManager extends ContentTypeManager {
     @SuppressWarnings("resource")
     @Override
     public boolean saveImpl(Document content, OutputStream out) {
-        final ZipArchiveOutputStream zos = (out instanceof ZipArchiveOutputStream)
-                ? (ZipArchiveOutputStream) out : new ZipArchiveOutputStream(out);
+        final ZipArchiveOutputStream zos = (out instanceof ZipArchiveOutputStream zaos)
+                ? zaos : new ZipArchiveOutputStream(out);
 
         ZipArchiveEntry partEntry = new ZipArchiveEntry(CONTENT_TYPES_PART_NAME);
         try {

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/marshallers/PackagePropertiesMarshaller.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/marshallers/PackagePropertiesMarshaller.java
@@ -87,11 +87,11 @@ public class PackagePropertiesMarshaller implements PartMarshaller {
     @Override
     public boolean marshall(PackagePart part, OutputStream out)
             throws OpenXML4JException {
-        if (!(part instanceof PackagePropertiesPart))
+        if (!(part instanceof PackagePropertiesPart packagePropertiesPart))
             throw new IllegalArgumentException(
                     "'part' must be a PackagePropertiesPart instance, but had: " + part.getClass() +
                             ", check logs while reading.");
-        propsPart = (PackagePropertiesPart) part;
+        propsPart = packagePropertiesPart;
 
         // Configure the document
         xmlDoc = DocumentHelper.createDocument();

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/marshallers/ZipPackagePropertiesMarshaller.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/marshallers/ZipPackagePropertiesMarshaller.java
@@ -35,10 +35,9 @@ public final class ZipPackagePropertiesMarshaller extends PackagePropertiesMarsh
     @Override
     public boolean marshall(PackagePart part, OutputStream out)
             throws OpenXML4JException {
-        if (!(out instanceof ZipArchiveOutputStream)) {
+        if (!(out instanceof ZipArchiveOutputStream zos)) {
             throw new IllegalArgumentException("ZipOutputStream expected!");
         }
-        ZipArchiveOutputStream zos = (ZipArchiveOutputStream) out;
 
         // Saving the part in the zip file
         ZipArchiveEntry ctEntry = new ZipArchiveEntry(ZipHelper

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveThresholdInputStream.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/util/ZipArchiveThresholdInputStream.java
@@ -149,12 +149,12 @@ public class ZipArchiveThresholdInputStream extends FilterInputStream {
     }
 
     public ZipArchiveEntry getNextEntry() throws IOException {
-        if (!(in instanceof ZipArchiveInputStream)) {
+        if (!(in instanceof ZipArchiveInputStream zis)) {
             throw new IllegalStateException("getNextEntry() is only allowed for stream based zip processing.");
         }
 
         try {
-            entry = ((ZipArchiveInputStream) in).getNextEntry();
+            entry = zis.getNextEntry();
             if (guardState && entry != null) {
                 if (++entryCount > MAX_FILE_COUNT) {
                     throw new IOException(String.format(Locale.ROOT, MAX_FILE_COUNT_MSG, MAX_FILE_COUNT));

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/KeyInfoKeySelector.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/KeyInfoKeySelector.java
@@ -61,16 +61,14 @@ public class KeyInfoKeySelector extends KeySelector implements KeySelectorResult
         List<XMLStructure> keyInfoContent = keyInfo.getContent();
         certChain.clear();
         for (XMLStructure keyInfoStructure : keyInfoContent) {
-            if (!(keyInfoStructure instanceof X509Data)) {
+            if (!(keyInfoStructure instanceof X509Data x509Data)) {
                 continue;
             }
-            X509Data x509Data = (X509Data) keyInfoStructure;
             List<?> x509DataList = x509Data.getContent();
             for (Object x509DataObject : x509DataList) {
-                if (!(x509DataObject instanceof X509Certificate)) {
+                if (!(x509DataObject instanceof X509Certificate certificate)) {
                     continue;
                 }
-                X509Certificate certificate = (X509Certificate) x509DataObject;
                 LOG.atDebug().log("certificate: {}", certificate.getSubjectX500Principal());
                 certChain.add(certificate);
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/SignatureInfo.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/SignatureInfo.java
@@ -424,10 +424,9 @@ public class SignatureInfo {
             List<XMLStructure> objectContentList = object.getContent();
             for (XMLStructure objectContent : objectContentList) {
                 LOG.atDebug().log("object content java type: {}", objectContent.getClass().getName());
-                if (!(objectContent instanceof Manifest)) {
+                if (!(objectContent instanceof Manifest manifest)) {
                     continue;
                 }
-                Manifest manifest = (Manifest) objectContent;
                 List<Reference> manifestReferences = manifest.getReferences();
                 for (Reference manifestReference : manifestReferences) {
                     if (manifestReference.getDigestValue() != null) {
@@ -642,8 +641,8 @@ public class SignatureInfo {
         if (uriDereferencer == null) {
             uriDereferencer = new OOXMLURIDereferencer();
         }
-        if (uriDereferencer instanceof OOXMLURIDereferencer) {
-            ((OOXMLURIDereferencer)uriDereferencer).setSignatureInfo(this);
+        if (uriDereferencer instanceof OOXMLURIDereferencer ooxmlUriDereferencer) {
+            ooxmlUriDereferencer.setSignatureInfo(this);
         }
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/SignatureMarshalDefaultListener.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/SignatureMarshalDefaultListener.java
@@ -74,8 +74,8 @@ public class SignatureMarshalDefaultListener implements SignatureMarshalListener
         int len = nl.getLength();
         for(int i=0; i<len; i++) {
             Node n = nl.item(i);
-            if (n instanceof Element) {
-                consumer.accept((Element)n);
+            if (n instanceof Element element) {
+                consumer.accept(element);
             }
         }
     }
@@ -114,8 +114,8 @@ public class SignatureMarshalDefaultListener implements SignatureMarshalListener
     }
 
     private static void setXmlns(Node node, String prefix, String ns) {
-        if (node instanceof Element && !ns.equals(node.getParentNode().getNamespaceURI())) {
-            ((Element)node).setAttributeNS(XML_NS, XMLConstants.XMLNS_ATTRIBUTE + (prefix == null ? "" : ":"+prefix), ns);
+        if (node instanceof Element element && !ns.equals(node.getParentNode().getNamespaceURI())) {
+            element.setAttributeNS(XML_NS, XMLConstants.XMLNS_ATTRIBUTE + (prefix == null ? "" : ":"+prefix), ns);
         }
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/services/RelationshipTransformService.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/services/RelationshipTransformService.java
@@ -129,10 +129,9 @@ public class RelationshipTransformService extends TransformService {
     @Override
     public void init(TransformParameterSpec params) throws InvalidAlgorithmParameterException {
         LOG.atDebug().log("init(params)");
-        if (!(params instanceof RelationshipTransformParameterSpec)) {
+        if (!(params instanceof RelationshipTransformParameterSpec relParams)) {
             throw new InvalidAlgorithmParameterException();
         }
-        RelationshipTransformParameterSpec relParams = (RelationshipTransformParameterSpec) params;
         this.sourceIds.addAll(relParams.sourceIds);
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/services/TSPTimeStampService.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/services/TSPTimeStampService.java
@@ -246,7 +246,7 @@ public class TSPTimeStampService implements TimeStampService {
                 return Stream.concat(ul.stream(), cl).map(CRLEntry::getCrlBytes);
             })
             .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     protected boolean matchCRLbyUrl(CRLEntry other, X509Certificate holder, String url) {

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/services/TimeStampSimpleHttpClient.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/services/TimeStampSimpleHttpClient.java
@@ -267,10 +267,9 @@ public class TimeStampSimpleHttpClient implements TimeStampHttpClient {
     }
 
     protected void recklessConnection(HttpURLConnection conn) throws IOException {
-        if (!(conn instanceof HttpsURLConnection)) {
+        if (!(conn instanceof HttpsURLConnection conns)) {
             return;
         }
-        HttpsURLConnection conns = (HttpsURLConnection)conn;
 
         try {
             SSLContext sc = SSLContext.getInstance("TLS");

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFCustomGeometry2D.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFCustomGeometry2D.java
@@ -19,7 +19,6 @@ package org.apache.poi.xddf.usermodel;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
@@ -91,7 +90,7 @@ public class XDDFCustomGeometry2D {
                 .getAhPolarList()
                 .stream()
                 .map(guide -> new XDDFAdjustHandlePolar(guide))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }
@@ -132,7 +131,7 @@ public class XDDFCustomGeometry2D {
                 .getAhXYList()
                 .stream()
                 .map(guide -> new XDDFAdjustHandleXY(guide))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }
@@ -173,7 +172,7 @@ public class XDDFCustomGeometry2D {
                 .getGdList()
                 .stream()
                 .map(guide -> new XDDFGeometryGuide(guide))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }
@@ -214,7 +213,7 @@ public class XDDFCustomGeometry2D {
                 .getCxnList()
                 .stream()
                 .map(guide -> new XDDFConnectionSite(guide))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }
@@ -255,7 +254,7 @@ public class XDDFCustomGeometry2D {
                 .getGdList()
                 .stream()
                 .map(guide -> new XDDFGeometryGuide(guide))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }
@@ -283,6 +282,6 @@ public class XDDFCustomGeometry2D {
             .getPathList()
             .stream()
             .map(ds -> new XDDFPath(ds))
-            .collect(Collectors.toList()));
+            .toList());
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFGradientFillProperties.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFGradientFillProperties.java
@@ -19,7 +19,6 @@ package org.apache.poi.xddf.usermodel;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
@@ -113,7 +112,7 @@ public class XDDFGradientFillProperties implements XDDFFillProperties {
                 .getGsList()
                 .stream()
                 .map(XDDFGradientStop::new)
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFLineProperties.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFLineProperties.java
@@ -19,7 +19,6 @@ package org.apache.poi.xddf.usermodel;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
@@ -143,7 +142,7 @@ public class XDDFLineProperties {
                 .getDsList()
                 .stream()
                 .map(ds -> new XDDFDashStop(ds))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFPresetGeometry2D.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/XDDFPresetGeometry2D.java
@@ -19,7 +19,6 @@ package org.apache.poi.xddf.usermodel;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
@@ -81,7 +80,7 @@ public class XDDFPresetGeometry2D {
                 .getGdList()
                 .stream()
                 .map(guide -> new XDDFGeometryGuide(guide))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFParagraphBulletProperties.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFParagraphBulletProperties.java
@@ -159,12 +159,12 @@ public class XDDFParagraphBulletProperties {
             props.unsetBuSzTx();
         }
         if (size != null) {
-            if (size instanceof XDDFBulletSizeFollowText) {
-                props.setBuSzTx(((XDDFBulletSizeFollowText) size).getXmlObject());
-            } else if (size instanceof XDDFBulletSizePercent) {
-                props.setBuSzPct(((XDDFBulletSizePercent) size).getXmlObject());
-            } else if (size instanceof XDDFBulletSizePoints) {
-                props.setBuSzPts(((XDDFBulletSizePoints) size).getXmlObject());
+            if (size instanceof XDDFBulletSizeFollowText xsize) {
+                props.setBuSzTx(xsize.getXmlObject());
+            } else if (size instanceof XDDFBulletSizePercent xsize) {
+                props.setBuSzPct(xsize.getXmlObject());
+            } else if (size instanceof XDDFBulletSizePoints xsize) {
+                props.setBuSzPts(xsize.getXmlObject());
             }
         }
     }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFParagraphProperties.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFParagraphProperties.java
@@ -19,7 +19,6 @@ package org.apache.poi.xddf.usermodel.text;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
@@ -266,7 +265,7 @@ public class XDDFParagraphProperties {
                 .getTabList()
                 .stream()
                 .map(gs -> new XDDFTabStop(gs))
-                .collect(Collectors.toList()));
+                .toList());
         } else {
             return Collections.emptyList();
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFTextBody.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/text/XDDFTextBody.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
@@ -102,7 +101,7 @@ public class XDDFTextBody {
 
     public List<XDDFTextParagraph> getParagraphs() {
         return Collections.unmodifiableList(
-            _body.getPList().stream().map(ds -> new XDDFTextParagraph(ds, this)).collect(Collectors.toList()));
+            _body.getPList().stream().map(ds -> new XDDFTextParagraph(ds, this)).toList());
     }
 
     public XDDFBodyProperties getBodyProperties() {

--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XmlVisioDocument.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/XmlVisioDocument.java
@@ -110,10 +110,10 @@ public class XmlVisioDocument extends POIXMLDocument {
 
         for (POIXMLDocumentPart part : getRelations()) {
             // organize the document pieces
-            if (part instanceof XDGFPages) {
-                _pages = (XDGFPages) part;
-            } else if (part instanceof XDGFMasters) {
-                _masters = (XDGFMasters) part;
+            if (part instanceof XDGFPages pages) {
+                _pages = pages;
+            } else if (part instanceof XDGFMasters masters) {
+                _masters = masters;
             }
         }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/section/GeometrySection.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xdgf/usermodel/section/GeometrySection.java
@@ -137,14 +137,14 @@ public class GeometrySection extends XDGFSection {
                     row = rows.next();
                 }
 
-                if (row instanceof SplineStart) {
+                if (row instanceof SplineStart splineStart) {
                     if (renderer != null)
                         throw new POIXMLException("SplineStart found multiple times!");
-                    renderer = new SplineCollector((SplineStart) row);
-                } else if (row instanceof SplineKnot) {
+                    renderer = new SplineCollector(splineStart);
+                } else if (row instanceof SplineKnot splineKnot) {
                     if (renderer == null)
                         throw new POIXMLException("SplineKnot found without SplineStart!");
-                    renderer.addKnot((SplineKnot) row);
+                    renderer.addKnot(splineKnot);
                 } else {
                     if (renderer != null) {
                         renderer.addToPath(path, parent);

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/draw/SVGRenderExtension.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/draw/SVGRenderExtension.java
@@ -103,20 +103,20 @@ public class SVGRenderExtension extends DefaultExtensionHandler {
 
     @Override
     public SVGPaintDescriptor handlePaint(Paint paint, SVGGeneratorContext generatorContext) {
-        if (paint instanceof LinearGradientPaint) {
-            return getLgpDescriptor((LinearGradientPaint)paint, generatorContext);
+        if (paint instanceof LinearGradientPaint lgp) {
+            return getLgpDescriptor(lgp, generatorContext);
         }
 
-        if (paint instanceof RadialGradientPaint) {
-            return getRgpDescriptor((RadialGradientPaint)paint, generatorContext);
+        if (paint instanceof RadialGradientPaint rgp) {
+            return getRgpDescriptor(rgp, generatorContext);
         }
 
-        if (paint instanceof PathGradientPaint) {
-            return getPathDescriptor((PathGradientPaint)paint, generatorContext);
+        if (paint instanceof PathGradientPaint pgp) {
+            return getPathDescriptor(pgp, generatorContext);
         }
 
-        if (paint instanceof DrawTexturePaint) {
-            return getDtpDescriptor((DrawTexturePaint)paint, generatorContext);
+        if (paint instanceof DrawTexturePaint dtp) {
+            return getDtpDescriptor(dtp, generatorContext);
         }
 
         return super.handlePaint(paint, generatorContext);
@@ -291,8 +291,7 @@ public class SVGRenderExtension extends DefaultExtensionHandler {
 
         byte[] imgData = null;
         String contentType = null;
-        if (imgRdr instanceof BitmapImageRenderer) {
-            BitmapImageRenderer bir = (BitmapImageRenderer)imgRdr;
+        if (imgRdr instanceof BitmapImageRenderer bir) {
             String ct = bir.getCachedContentType();
             if (PNG.contentType.equals(ct) ||
                 JPEG.contentType.equals(ct) ||
@@ -360,10 +359,10 @@ public class SVGRenderExtension extends DefaultExtensionHandler {
             String name = (String)params[i+1];
             Object oval = params[i+2];
             String val;
-            if (oval instanceof String) {
-                val = (String)oval;
-            } else if (oval instanceof Number) {
-                val = genCtx.doubleString(((Number) oval).doubleValue());
+            if (oval instanceof String str) {
+                val = str;
+            } else if (oval instanceof Number number) {
+                val = genCtx.doubleString(number.doubleValue());
             } else if (oval == null) {
                 val = "";
             } else {

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/draw/geom/XSLFPath.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/draw/geom/XSLFPath.java
@@ -60,16 +60,16 @@ public class XSLFPath implements PathIf {
             for (boolean hasNext = cur.toFirstChild(); hasNext; hasNext = cur.toNextSibling()) {
                 XmlObject xo = cur.getObject();
                 PathCommand pc;
-                if (xo instanceof CTPath2DArcTo) {
-                    pc = new XSLFArcTo((CTPath2DArcTo) xo);
-                } else if (xo instanceof CTPath2DCubicBezierTo) {
-                    pc = new XSLFCurveTo((CTPath2DCubicBezierTo) xo);
-                } else if (xo instanceof CTPath2DMoveTo) {
-                    pc = new XSLFMoveTo((CTPath2DMoveTo) xo);
-                } else if (xo instanceof CTPath2DLineTo) {
-                    pc = new XSLFLineTo((CTPath2DLineTo) xo);
-                } else if (xo instanceof CTPath2DQuadBezierTo) {
-                    pc = new XSLFQuadTo((CTPath2DQuadBezierTo) xo);
+                if (xo instanceof CTPath2DArcTo arcTo) {
+                    pc = new XSLFArcTo(arcTo);
+                } else if (xo instanceof CTPath2DCubicBezierTo cubicBezierTo) {
+                    pc = new XSLFCurveTo(cubicBezierTo);
+                } else if (xo instanceof CTPath2DMoveTo moveTo) {
+                    pc = new XSLFMoveTo(moveTo);
+                } else if (xo instanceof CTPath2DLineTo lineTo) {
+                    pc = new XSLFLineTo(lineTo);
+                } else if (xo instanceof CTPath2DQuadBezierTo quadBezierTo) {
+                    pc = new XSLFQuadTo(quadBezierTo);
                 } else if (xo instanceof CTPath2DClose) {
                     pc = new ClosePathCommand();
                 } else {

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XMLSlideShow.java
@@ -508,18 +508,15 @@ public class XMLSlideShow extends POIXMLDocument
         removeRelation(slide);
         _presentation.getSldIdLst().removeSldId(index);
         for (POIXMLDocumentPart p : slide.getRelations()) {
-            if (p instanceof XSLFChart) {
-                XSLFChart chart = (XSLFChart) p;
+            if (p instanceof XSLFChart chart) {
                 slide.removeChartRelation(chart);
                 _charts.remove(chart);
-            } else if (p instanceof XSLFSlideLayout) {
-                XSLFSlideLayout layout = (XSLFSlideLayout) p;
+            } else if (p instanceof XSLFSlideLayout layout) {
                 slide.removeLayoutRelation(layout);
             } else if (p instanceof XSLFNotes) {
                 XSLFNotes notes = slide.removeNotes(_notesMaster);
                 removeRelation(notes);
-            } else if (p instanceof XSLFPictureData) {
-                XSLFPictureData picture = (XSLFPictureData) p;
+            } else if (p instanceof XSLFPictureData picture) {
                 removePictureRelations(slide, picture);
                 _pictures.remove(picture);
             }
@@ -534,12 +531,11 @@ public class XMLSlideShow extends POIXMLDocument
     private void removePictureRelations(XSLFSlide slide, XSLFShapeContainer container, XSLFPictureData picture) {
         for (XSLFShape shape : container.getShapes()) {
             // Find either group shapes (and recurse) ...
-            if (shape instanceof XSLFGroupShape) {
-                removePictureRelations(slide, (XSLFGroupShape)shape, picture);
+            if (shape instanceof XSLFGroupShape group) {
+                removePictureRelations(slide, group, picture);
             }
             // ... or the picture shape with this picture data and remove its relation to the picture data.
-            if (shape instanceof XSLFPictureShape) {
-                XSLFPictureShape pic = (XSLFPictureShape) shape;
+            if (shape instanceof XSLFPictureShape pic) {
                 if (pic.getPictureData() == picture) {
                     slide.removePictureRelation(pic);
                 }
@@ -734,8 +730,8 @@ public class XMLSlideShow extends POIXMLDocument
         }
         final POIXMLDocumentPart docPart = parent.getRelationPartById(blipId).getDocumentPart();
         XSLFPictureData parData;
-        if (docPart instanceof XSLFPictureData) {
-            parData = (XSLFPictureData)docPart;
+        if (docPart instanceof XSLFPictureData pd) {
+            parData = pd;
         } else {
             throw new IllegalStateException("cannot import blip " + blipId + " - its document part is not XSLFPictureData");
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFColor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFColor.java
@@ -146,18 +146,18 @@ public class XSLFColor {
         try (XmlCursor cur = obj.newCursor()) {
             XmlObject ch;
             for (int idx=0; color == null && (ch = nextObject(obj, cur, idx)) != null; idx++) {
-                if (ch instanceof CTHslColor) {
-                    color = toColor((CTHslColor)ch);
-                } else if (ch instanceof CTPresetColor) {
-                    color = toColor((CTPresetColor)ch);
-                } else if (ch instanceof CTSchemeColor) {
-                    color = toColor((CTSchemeColor)ch, theme);
-                } else if (ch instanceof CTScRgbColor) {
-                    color = toColor((CTScRgbColor)ch);
-                } else if (ch instanceof CTSRgbColor) {
-                    color = toColor((CTSRgbColor)ch);
-                } else if (ch instanceof CTSystemColor) {
-                    color = toColor((CTSystemColor)ch);
+                if (ch instanceof CTHslColor hsl) {
+                    color = toColor(hsl);
+                } else if (ch instanceof CTPresetColor prst) {
+                    color = toColor(prst);
+                } else if (ch instanceof CTSchemeColor scheme) {
+                    color = toColor(scheme, theme);
+                } else if (ch instanceof CTScRgbColor scrgb) {
+                    color = toColor(scrgb);
+                } else if (ch instanceof CTSRgbColor srgb) {
+                    color = toColor(srgb);
+                } else if (ch instanceof CTSystemColor sys) {
+                    color = toColor(sys);
                 } else if (!(ch instanceof CTFontReference) && idx > 0) {
                     throw new IllegalArgumentException("Unexpected color choice: " + ch.getClass());
                 }
@@ -181,11 +181,10 @@ public class XSLFColor {
      */
     @Internal
     protected void setColor(Color color) {
-        if (!(_xmlObject instanceof CTSolidColorFillProperties)) {
+        if (!(_xmlObject instanceof CTSolidColorFillProperties fill)) {
             LOGGER.atError().log("XSLFColor.setColor currently only supports CTSolidColorFillProperties");
             return;
         }
-        CTSolidColorFillProperties fill = (CTSolidColorFillProperties)_xmlObject;
         if (fill.isSetSrgbClr()) {
             fill.unsetSrgbClr();
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFFontInfo.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFFontInfo.java
@@ -26,7 +26,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.poi.common.usermodel.fonts.FontCharset;
@@ -270,7 +269,7 @@ public class XSLFFontInfo implements FontInfo {
 
         return pres.isSetEmbeddedFontLst()
             ? Stream.of(pres.getEmbeddedFontLst().getEmbeddedFontArray())
-                .map(fe -> new XSLFFontInfo(ppt, fe)).collect(Collectors.toList())
+                .map(fe -> new XSLFFontInfo(ppt, fe)).toList()
             : Collections.emptyList();
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFFreeformShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFFreeformShape.java
@@ -78,27 +78,14 @@ public class XSLFFreeformShape extends XSLFAutoShape
         final double[] vals = new double[6];
         while (!it.isDone()) {
             final int type = it.currentSegment(vals);
-            final CTAdjPoint2D[] points;
-            switch (type) {
-                case PathIterator.SEG_MOVETO:
-                    points = addMoveTo(ctPath);
-                    break;
-                case PathIterator.SEG_LINETO:
-                    points = addLineTo(ctPath);
-                    break;
-                case PathIterator.SEG_QUADTO:
-                    points = addQuadBezierTo(ctPath);
-                    break;
-                case PathIterator.SEG_CUBICTO:
-                    points = addCubicBezierTo(ctPath);
-                    break;
-                case PathIterator.SEG_CLOSE:
-                    points = addClosePath(ctPath);
-                    break;
-                default: {
-                    throw new IllegalStateException("Unrecognized path segment type: " + type);
-                }
-            }
+            final CTAdjPoint2D[] points = switch (type) {
+                case PathIterator.SEG_MOVETO -> addMoveTo(ctPath);
+                case PathIterator.SEG_LINETO -> addLineTo(ctPath);
+                case PathIterator.SEG_QUADTO -> addQuadBezierTo(ctPath);
+                case PathIterator.SEG_CUBICTO -> addCubicBezierTo(ctPath);
+                case PathIterator.SEG_CLOSE -> addClosePath(ctPath);
+                default -> throw new IllegalStateException("Unrecognized path segment type: " + type);
+            };
 
             int i=0;
             for (final CTAdjPoint2D point : points) {
@@ -111,11 +98,11 @@ public class XSLFFreeformShape extends XSLFAutoShape
         }
 
         XmlObject xo = getShapeProperties();
-        if (!(xo instanceof CTShapeProperties)) {
+        if (!(xo instanceof CTShapeProperties spr)) {
             return -1;
         }
 
-        ((CTShapeProperties)xo).getCustGeom().getPathLst().setPathArray(new CTPath2D[]{ctPath});
+        spr.getCustGeom().getPathLst().setPathArray(new CTPath2D[]{ctPath});
         setAnchor(bounds);
         return numPoints;
     }
@@ -126,11 +113,11 @@ public class XSLFFreeformShape extends XSLFAutoShape
     @Override
     public CustomGeometry getGeometry() {
         final XmlObject xo = getShapeProperties();
-        if (!(xo instanceof CTShapeProperties)) {
+        if (!(xo instanceof CTShapeProperties spr)) {
             return null;
         }
 
-        return XSLFCustomGeometry.convertCustomGeometry(((CTShapeProperties)xo).getCustGeom());
+        return XSLFCustomGeometry.convertCustomGeometry(spr.getCustGeom());
     }
 
     @Override
@@ -138,24 +125,24 @@ public class XSLFFreeformShape extends XSLFAutoShape
         final Path2D.Double path = new Path2D.Double();
 
         final XmlObject xo = getShapeProperties();
-        if (!(xo instanceof CTShapeProperties)) {
+        if (!(xo instanceof CTShapeProperties spr)) {
             return null;
         }
 
-        final CTCustomGeometry2D geom = ((CTShapeProperties)xo).getCustGeom();
+        final CTCustomGeometry2D geom = spr.getCustGeom();
         for(CTPath2D spPath : geom.getPathLst().getPathArray()) {
             try (XmlCursor cursor = spPath.newCursor()) {
                 if (cursor.toFirstChild()) {
                     do {
                         final XmlObject ch = cursor.getObject();
-                        if (ch instanceof CTPath2DMoveTo) {
-                            addMoveTo(path, (CTPath2DMoveTo)ch);
-                        } else if (ch instanceof CTPath2DLineTo) {
-                            addLineTo(path, (CTPath2DLineTo)ch);
-                        } else if (ch instanceof CTPath2DQuadBezierTo) {
-                            addQuadBezierTo(path, (CTPath2DQuadBezierTo)ch);
-                        } else if (ch instanceof CTPath2DCubicBezierTo) {
-                            addCubicBezierTo(path, (CTPath2DCubicBezierTo)ch);
+                        if (ch instanceof CTPath2DMoveTo moveTo) {
+                            addMoveTo(path, moveTo);
+                        } else if (ch instanceof CTPath2DLineTo lineTo) {
+                            addLineTo(path, lineTo);
+                        } else if (ch instanceof CTPath2DQuadBezierTo quadBezierTo) {
+                            addQuadBezierTo(path, quadBezierTo);
+                        } else if (ch instanceof CTPath2DCubicBezierTo cubicBezierTo) {
+                            addCubicBezierTo(path, cubicBezierTo);
                         } else if (ch instanceof CTPath2DClose) {
                             addClosePath(path);
                         } else {

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFGroupShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFGroupShape.java
@@ -263,10 +263,10 @@ implements XSLFShapeContainer, GroupShape<XSLFShape,XSLFTextParagraph> {
 
     @Override
     public XSLFPictureShape createPicture(PictureData pictureData){
-        if (!(pictureData instanceof XSLFPictureData)) {
+        if (!(pictureData instanceof XSLFPictureData xPictureData)) {
             throw new IllegalArgumentException("pictureData needs to be of type XSLFPictureData");
         }
-        RelationPart rp = getSheet().addRelation(null, XSLFRelation.IMAGES, (XSLFPictureData)pictureData);
+        RelationPart rp = getSheet().addRelation(null, XSLFRelation.IMAGES, xPictureData);
 
         XSLFPictureShape sh = getDrawing().createPicture(rp.getRelationship().getId());
         new DrawPictureShape(sh).resize();
@@ -277,11 +277,11 @@ implements XSLFShapeContainer, GroupShape<XSLFShape,XSLFTextParagraph> {
 
     @Override
     public XSLFObjectShape createOleShape(PictureData pictureData) {
-        if (!(pictureData instanceof XSLFPictureData)) {
+        if (!(pictureData instanceof XSLFPictureData xPictureData)) {
             throw new IllegalArgumentException("pictureData needs to be of type XSLFPictureData");
         }
 
-        RelationPart rp = getSheet().addRelation(null, XSLFRelation.IMAGES, (XSLFPictureData)pictureData);
+        RelationPart rp = getSheet().addRelation(null, XSLFRelation.IMAGES, xPictureData);
 
         XSLFObjectShape sh = getDrawing().createOleShape(rp.getRelationship().getId());
         CTOleObject oleObj = sh.getCTOleObject();
@@ -386,8 +386,7 @@ implements XSLFShapeContainer, GroupShape<XSLFShape,XSLFTextParagraph> {
                     newShape = createAutoShape();
                 } else if (shape instanceof XSLFConnectorShape) {
                     newShape = createConnector();
-                } else if (shape instanceof XSLFPictureShape) {
-                    XSLFPictureShape p = (XSLFPictureShape)shape;
+                } else if (shape instanceof XSLFPictureShape p) {
                     XSLFPictureData pd = p.getPictureData();
                     XSLFPictureData pdNew = getSheet().getSlideShow().addPicture(pd.getData(), pd.getType());
                     newShape = createPicture(pdNew);

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFPlaceholderDetails.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFPlaceholderDetails.java
@@ -117,20 +117,13 @@ public class XSLFPlaceholderDetails implements PlaceholderDetails {
         }
         final Function<CTHeaderFooter,Consumer<Boolean>> fun;
         switch (ph) {
-            case DATETIME:
-                fun = (hf) -> hf::setDt;
-                break;
-            case FOOTER:
-                fun = (hf) -> hf::setFtr;
-                break;
-            case HEADER:
-                fun = (hf) -> hf::setHdr;
-                break;
-            case SLIDE_NUMBER:
-                fun = (hf) -> hf::setSldNum;
-                break;
-            default:
+            case DATETIME -> fun = (hf) -> hf::setDt;
+            case FOOTER -> fun = (hf) -> hf::setFtr;
+            case HEADER -> fun = (hf) -> hf::setHdr;
+            case SLIDE_NUMBER -> fun = (hf) -> hf::setSldNum;
+            default -> {
                 return;
+            }
         }
         // only create a header, if we need to, i.e. the placeholder type is eligible
         final CTHeaderFooter hf = getHeaderFooter(true);
@@ -165,15 +158,9 @@ public class XSLFPlaceholderDetails implements PlaceholderDetails {
             return;
         }
         switch (size) {
-            case full:
-                ph.setSz(STPlaceholderSize.FULL);
-                break;
-            case half:
-                ph.setSz(STPlaceholderSize.HALF);
-                break;
-            case quarter:
-                ph.setSz(STPlaceholderSize.QUARTER);
-                break;
+            case full -> ph.setSz(STPlaceholderSize.FULL);
+            case half -> ph.setSz(STPlaceholderSize.HALF);
+            case quarter -> ph.setSz(STPlaceholderSize.QUARTER);
         }
     }
 
@@ -221,11 +208,11 @@ public class XSLFPlaceholderDetails implements PlaceholderDetails {
     private CTHeaderFooter getHeaderFooter(final boolean create) {
         final XSLFSheet sheet = shape.getSheet();
         final XSLFSheet master = (sheet instanceof MasterSheet && !(sheet instanceof XSLFSlideLayout)) ? sheet : (XSLFSheet)sheet.getMasterSheet();
-        if (master instanceof XSLFSlideMaster) {
-            final CTSlideMaster ct = ((XSLFSlideMaster) master).getXmlObject();
+        if (master instanceof XSLFSlideMaster slideMaster) {
+            final CTSlideMaster ct = slideMaster.getXmlObject();
             return (ct.isSetHf() || !create) ? ct.getHf() : ct.addNewHf();
-        } else if (master instanceof  XSLFNotesMaster) {
-            final CTNotesMaster ct = ((XSLFNotesMaster) master).getXmlObject();
+        } else if (master instanceof  XSLFNotesMaster notesMaster) {
+            final CTNotesMaster ct = notesMaster.getXmlObject();
             return (ct.isSetHf() || !create) ? ct.getHf() : ct.addNewHf();
         } else {
             return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFPropertiesDelegate.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFPropertiesDelegate.java
@@ -1826,14 +1826,14 @@ import org.openxmlformats.schemas.presentationml.x2006.main.CTBackgroundProperti
         Object obj = null;
         if (props == null) {
             return null;
-        } else if (props instanceof CTShapeProperties) {
-            obj = new ShapeDelegate((CTShapeProperties)props);
-        } else if (props instanceof CTBackgroundProperties) {
-            obj = new BackgroundDelegate((CTBackgroundProperties)props);
-        } else if (props instanceof CTStyleMatrixReference) {
-            obj = new StyleMatrixDelegate((CTStyleMatrixReference)props);
-        } else if (props instanceof CTTableCellProperties) {
-            obj = new TableCellDelegate((CTTableCellProperties)props);
+        } else if (props instanceof CTShapeProperties shapeProps) {
+            obj = new ShapeDelegate(shapeProps);
+        } else if (props instanceof CTBackgroundProperties bgProps) {
+            obj = new BackgroundDelegate(bgProps);
+        } else if (props instanceof CTStyleMatrixReference styleRef) {
+            obj = new StyleMatrixDelegate(styleRef);
+        } else if (props instanceof CTTableCellProperties cellProps) {
+            obj = new TableCellDelegate(cellProps);
         } else if (props instanceof CTNoFillProperties
             || props instanceof CTSolidColorFillProperties
             || props instanceof CTGradientFillProperties
@@ -1841,12 +1841,12 @@ import org.openxmlformats.schemas.presentationml.x2006.main.CTBackgroundProperti
             || props instanceof CTPatternFillProperties
             || props instanceof CTGroupFillProperties) {
             obj = new FillPartDelegate(props);
-        } else if (props instanceof CTFillProperties) {
-            obj = new FillDelegate((CTFillProperties)props);
-        } else if (props instanceof CTLineProperties) {
-            obj = new LineStyleDelegate((CTLineProperties)props);
-        } else if (props instanceof CTTextCharacterProperties) {
-            obj = new TextCharDelegate((CTTextCharacterProperties)props);
+        } else if (props instanceof CTFillProperties fillProps) {
+            obj = new FillDelegate(fillProps);
+        } else if (props instanceof CTLineProperties lineProps) {
+            obj = new LineStyleDelegate(lineProps);
+        } else if (props instanceof CTTextCharacterProperties textProps) {
+            obj = new TextCharDelegate(textProps);
         } else {
             LOG.atError().log("{} is an unknown properties type", props.getClass());
             return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSheet.java
@@ -106,8 +106,8 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
     public XMLSlideShow getSlideShow() {
         POIXMLDocumentPart p = getParent();
         while(p != null) {
-            if(p instanceof XMLSlideShow){
-                return (XMLSlideShow)p;
+            if(p instanceof XMLSlideShow slideShow){
+                return slideShow;
             }
             p = p.getParent();
         }
@@ -139,24 +139,24 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
 
     @SuppressWarnings("WeakerAccess")
     protected static List<XSLFShape> buildShapes(CTGroupShape spTree, XSLFShapeContainer parent){
-        final XSLFSheet sheet = (parent instanceof XSLFSheet) ? (XSLFSheet)parent : ((XSLFShape)parent).getSheet();
+        final XSLFSheet sheet = (parent instanceof XSLFSheet s) ? s : ((XSLFShape)parent).getSheet();
 
         List<XSLFShape> shapes = new ArrayList<>();
         try (XmlCursor cur = spTree.newCursor()) {
             for (boolean b = cur.toFirstChild(); b; b = cur.toNextSibling()) {
                 XmlObject ch = cur.getObject();
-                if(ch instanceof CTShape){
+                if(ch instanceof CTShape sp){
                     // simple shape
-                    XSLFAutoShape shape = XSLFAutoShape.create((CTShape)ch, sheet);
+                    XSLFAutoShape shape = XSLFAutoShape.create(sp, sheet);
                     shapes.add(shape);
-                } else if (ch instanceof CTGroupShape){
-                    shapes.add(new XSLFGroupShape((CTGroupShape)ch, sheet));
-                } else if (ch instanceof CTConnector){
-                    shapes.add(new XSLFConnectorShape((CTConnector)ch, sheet));
-                } else if (ch instanceof CTPicture){
-                    shapes.add(new XSLFPictureShape((CTPicture)ch, sheet));
-                } else if (ch instanceof CTGraphicalObjectFrame){
-                    XSLFGraphicFrame shape = XSLFGraphicFrame.create((CTGraphicalObjectFrame)ch, sheet);
+                } else if (ch instanceof CTGroupShape grpSp){
+                    shapes.add(new XSLFGroupShape(grpSp, sheet));
+                } else if (ch instanceof CTConnector cxnSp){
+                    shapes.add(new XSLFConnectorShape(cxnSp, sheet));
+                } else if (ch instanceof CTPicture pic){
+                    shapes.add(new XSLFPictureShape(pic, sheet));
+                } else if (ch instanceof CTGraphicalObjectFrame frame){
+                    XSLFGraphicFrame shape = XSLFGraphicFrame.create(frame, sheet);
                     shapes.add(shape);
                 } else if (ch instanceof XmlAnyTypeImpl) {
                     // TODO: the link of the XLSF classes to the xml beans objects will
@@ -265,11 +265,11 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
 
     @Override
     public XSLFPictureShape createPicture(PictureData pictureData){
-        if (!(pictureData instanceof XSLFPictureData)) {
+        if (!(pictureData instanceof XSLFPictureData xPictureData)) {
             throw new IllegalArgumentException("pictureData needs to be of type XSLFPictureData");
         }
 
-        RelationPart rp = addRelation(null, XSLFRelation.IMAGES, (XSLFPictureData)pictureData);
+        RelationPart rp = addRelation(null, XSLFRelation.IMAGES, xPictureData);
 
         XSLFPictureShape sh = getDrawing().createPicture(rp.getRelationship().getId());
         new DrawPictureShape(sh).resize();
@@ -305,10 +305,10 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
 
     @Override
     public XSLFObjectShape createOleShape(PictureData pictureData) {
-        if (!(pictureData instanceof XSLFPictureData)) {
+        if (!(pictureData instanceof XSLFPictureData xPictureData)) {
             throw new IllegalArgumentException("pictureData needs to be of type XSLFPictureData");
         }
-        RelationPart rp = addRelation(null, XSLFRelation.IMAGES, (XSLFPictureData)pictureData);
+        RelationPart rp = addRelation(null, XSLFRelation.IMAGES, xPictureData);
 
         XSLFObjectShape sh = getDrawing().createOleShape(rp.getRelationship().getId());
         CTOleObject oleObj = sh.getCTOleObject();
@@ -403,10 +403,10 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
                 throw new IllegalStateException("CTGroupShape was not found");
             }
             XmlObject xmlObject = sp[0];
-            if (!(xmlObject instanceof CTGroupShape)) {
+            if (!(xmlObject instanceof CTGroupShape groupShape)) {
                 throw new IllegalArgumentException("Had unexpected type of entry: " + xmlObject.getClass());
             }
-            _spTree = (CTGroupShape) xmlObject;
+            _spTree = groupShape;
         }
         return _spTree;
     }
@@ -534,8 +534,7 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
     @SuppressWarnings("WeakerAccess")
     protected XSLFTextShape getTextShapeByType(Placeholder type){
         for(XSLFShape shape : this.getShapes()){
-            if(shape instanceof XSLFTextShape) {
-                XSLFTextShape txt = (XSLFTextShape)shape;
+            if(shape instanceof XSLFTextShape txt) {
                 if(txt.getTextType() == type) {
                     return txt;
                 }
@@ -569,8 +568,7 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
             _placeholderByTypeMap = new HashMap<>();
 
             for(final XSLFShape sh : getShapes()){
-                if(sh instanceof XSLFTextShape){
-                    final XSLFTextShape sShape = (XSLFTextShape)sh;
+                if(sh instanceof XSLFTextShape sShape){
                     final CTPlaceholder ph = sShape.getPlaceholderDetails().getCTPlaceholder(false);
                     if(ph != null) {
                         _placeholders.add(sShape);
@@ -703,8 +701,7 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
         int numberOfRelations = 0;
         String targetBlipId = pictureShape.getBlipId();
         for (XSLFShape shape : pictureShape.getSheet().getShapes()) {
-            if (shape instanceof XSLFPictureShape) {
-                XSLFPictureShape currentPictureShape = ((XSLFPictureShape) shape);
+            if (shape instanceof XSLFPictureShape currentPictureShape) {
                 String currentBlipId = currentPictureShape.getBlipId();
                 if (currentBlipId != null && currentBlipId.equals(targetBlipId)) {
                     numberOfRelations++;
@@ -760,46 +757,21 @@ public abstract class XSLFSheet extends POIXMLDocumentPart
     protected String mapSchemeColor(CTColorMapping cmap, String schemeColor) {
         STColorSchemeIndex.Enum schemeMap = null;
         if (cmap != null && schemeColor != null) {
-            switch (schemeColor) {
-                case "accent1":
-                    schemeMap = cmap.getAccent1();
-                    break;
-                case "accent2":
-                    schemeMap = cmap.getAccent2();
-                    break;
-                case "accent3":
-                    schemeMap = cmap.getAccent3();
-                    break;
-                case "accent4":
-                    schemeMap = cmap.getAccent4();
-                    break;
-                case "accent5":
-                    schemeMap = cmap.getAccent5();
-                    break;
-                case "accent6":
-                    schemeMap = cmap.getAccent6();
-                    break;
-                case "bg1":
-                    schemeMap = cmap.getBg1();
-                    break;
-                case "bg2":
-                    schemeMap = cmap.getBg2();
-                    break;
-                case "folHlink":
-                    schemeMap = cmap.getFolHlink();
-                    break;
-                case "hlink":
-                    schemeMap = cmap.getHlink();
-                    break;
-                case "tx1":
-                    schemeMap = cmap.getTx1();
-                    break;
-                case "tx2":
-                    schemeMap = cmap.getTx2();
-                    break;
-                default:
-                    break;
-            }
+            schemeMap = switch (schemeColor) {
+                case "accent1" -> cmap.getAccent1();
+                case "accent2" -> cmap.getAccent2();
+                case "accent3" -> cmap.getAccent3();
+                case "accent4" -> cmap.getAccent4();
+                case "accent5" -> cmap.getAccent5();
+                case "accent6" -> cmap.getAccent6();
+                case "bg1" -> cmap.getBg1();
+                case "bg2" -> cmap.getBg2();
+                case "folHlink" -> cmap.getFolHlink();
+                case "hlink" -> cmap.getHlink();
+                case "tx1" -> cmap.getTx1();
+                case "tx2" -> cmap.getTx2();
+                default -> null;
+            };
         }
         return (schemeMap == null) ? null : schemeMap.toString();
     }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSimpleShape.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSimpleShape.java
@@ -96,8 +96,8 @@ public abstract class XSLFSimpleShape extends XSLFShape
             @Override
             public boolean fetch(XSLFShape shape) {
                 XmlObject xo = shape.getShapeProperties();
-                if (xo instanceof CTShapeProperties && ((CTShapeProperties)xo).isSetXfrm()) {
-                    setValue(((CTShapeProperties)xo).getXfrm());
+                if (xo instanceof CTShapeProperties spr && spr.isSetXfrm()) {
+                    setValue(spr.getXfrm());
                     return true;
                 }
                 return false;
@@ -110,8 +110,8 @@ public abstract class XSLFSimpleShape extends XSLFShape
             return xfrm;
         } else {
             XmlObject xo = getShapeProperties();
-            if (xo instanceof CTShapeProperties) {
-                return ((CTShapeProperties)xo).addNewXfrm();
+            if (xo instanceof CTShapeProperties spr) {
+                return spr.addNewXfrm();
             } else {
                 // ... group shapes have their own getXfrm()
                 LOG.atWarn().log("{} doesn't have xfrm element.", getClass());
@@ -278,8 +278,8 @@ public abstract class XSLFSimpleShape extends XSLFShape
     @SuppressWarnings("WeakerAccess")
     public Color getLineColor() {
         PaintStyle ps = getLinePaint();
-        if (ps instanceof SolidPaint) {
-            return ((SolidPaint)ps).getSolidColor().getColor();
+        if (ps instanceof SolidPaint sp) {
+            return sp.getSolidColor().getColor();
         }
         return null;
     }
@@ -628,8 +628,8 @@ public abstract class XSLFSimpleShape extends XSLFShape
     @Override
     public Color getFillColor() {
         PaintStyle ps = getFillPaint();
-        if (ps instanceof SolidPaint) {
-            return DrawPaint.applyColorTransform(((SolidPaint)ps).getSolidColor());
+        if (ps instanceof SolidPaint sp) {
+            return DrawPaint.applyColorTransform(sp.getSolidColor());
         }
         return null;
     }
@@ -1056,16 +1056,16 @@ public abstract class XSLFSimpleShape extends XSLFShape
 
         // TODO: handle PaintStyle
         for (Object st : styles) {
-            if (st instanceof Number) {
-                setLineWidth(((Number)st).doubleValue());
-            } else if (st instanceof LineCap) {
-                setLineCap((LineCap)st);
-            } else if (st instanceof LineDash) {
-                setLineDash((LineDash)st);
-            } else if (st instanceof LineCompound) {
-                setLineCompound((LineCompound)st);
-            } else if (st instanceof Color) {
-                setLineColor((Color)st);
+            if (st instanceof Number number) {
+                setLineWidth(number.doubleValue());
+            } else if (st instanceof LineCap cap) {
+                setLineCap(cap);
+            } else if (st instanceof LineDash dash) {
+                setLineDash(dash);
+            } else if (st instanceof LineCompound compound) {
+                setLineCompound(compound);
+            } else if (st instanceof Color color) {
+                setLineColor(color);
             }
         }
     }
@@ -1091,12 +1091,11 @@ public abstract class XSLFSimpleShape extends XSLFShape
 
     private static CTLineProperties getLn(XSLFShape shape, boolean create) {
         XmlObject pr = shape.getShapeProperties();
-        if (!(pr instanceof CTShapeProperties)) {
+        if (!(pr instanceof CTShapeProperties spr)) {
             LOG.atWarn().log("{} doesn't have line properties", shape.getClass());
             return null;
         }
 
-        CTShapeProperties spr = (CTShapeProperties)pr;
         return (spr.isSetLn() || !create) ? spr.getLn() : spr.addNewLn();
     }
 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSlide.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSlide.java
@@ -148,8 +148,8 @@ implements Slide<XSLFShape,XSLFTextParagraph> {
     public XSLFSlideLayout getSlideLayout(){
         if(_layout == null){
             for (POIXMLDocumentPart p : getRelations()) {
-                if (p instanceof XSLFSlideLayout){
-                    _layout = (XSLFSlideLayout)p;
+                if (p instanceof XSLFSlideLayout layout){
+                    _layout = layout;
                 }
             }
         }
@@ -171,8 +171,8 @@ implements Slide<XSLFShape,XSLFTextParagraph> {
     public XSLFComments getCommentsPart() {
         if(_comments == null) {
             for (POIXMLDocumentPart p : getRelations()) {
-                if (p instanceof XSLFComments) {
-                    _comments = (XSLFComments)p;
+                if (p instanceof XSLFComments comments) {
+                    _comments = comments;
                     break;
                 }
             }
@@ -190,15 +190,15 @@ implements Slide<XSLFShape,XSLFTextParagraph> {
         if(_commentAuthors == null) {
             // first scan the slide relations
             for (POIXMLDocumentPart p : getRelations()) {
-                if (p instanceof XSLFCommentAuthors) {
-                    _commentAuthors = (XSLFCommentAuthors)p;
+                if (p instanceof XSLFCommentAuthors authors) {
+                    _commentAuthors = authors;
                     return _commentAuthors;
                 }
             }
             // then scan the presentation relations
             for (POIXMLDocumentPart p : getSlideShow().getRelations()) {
-                if (p instanceof XSLFCommentAuthors) {
-                    _commentAuthors = (XSLFCommentAuthors)p;
+                if (p instanceof XSLFCommentAuthors authors) {
+                    _commentAuthors = authors;
                     return _commentAuthors;
                 }
             }
@@ -226,8 +226,8 @@ implements Slide<XSLFShape,XSLFTextParagraph> {
     public XSLFNotes getNotes() {
         if(_notes == null) {
             for (POIXMLDocumentPart p : getRelations()) {
-                if (p instanceof XSLFNotes){
-                    _notes = (XSLFNotes)p;
+                if (p instanceof XSLFNotes notes){
+                    _notes = notes;
                 }
             }
         }
@@ -307,17 +307,17 @@ implements Slide<XSLFShape,XSLFTextParagraph> {
     @Override
     public XSLFSlide importContent(XSLFSheet src){
         super.importContent(src);
-        if (!(src instanceof XSLFSlide)) {
+        if (!(src instanceof XSLFSlide srcSlide)) {
             return this;
         }
 
-        XSLFNotes srcNotes = ((XSLFSlide)src).getNotes();
+        XSLFNotes srcNotes = srcSlide.getNotes();
         if (srcNotes != null) {
             getSlideShow().getNotesSlide(this).importContent(srcNotes);
         }
 
         // only copy direct backgrounds - not backgrounds of master sheet
-        CTBackground bgOther = ((XSLFSlide)src)._slide.getCSld().getBg();
+        CTBackground bgOther = srcSlide._slide.getCSld().getBg();
         if (bgOther == null) {
             return this;
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSlideLayout.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFSlideLayout.java
@@ -76,8 +76,8 @@ implements MasterSheet<XSLFShape,XSLFTextParagraph> {
     public XSLFSlideMaster getSlideMaster() {
         if (_master == null) {
             for (POIXMLDocumentPart p : getRelations()) {
-                if (p instanceof XSLFSlideMaster) {
-                    _master = (XSLFSlideMaster) p;
+                if (p instanceof XSLFSlideMaster master) {
+                    _master = master;
                 }
             }
         }
@@ -121,19 +121,14 @@ implements MasterSheet<XSLFShape,XSLFTextParagraph> {
     @SuppressWarnings("WeakerAccess")
     public void copyLayout(XSLFSlide slide) {
         for (XSLFShape sh : getShapes()) {
-            if (sh instanceof XSLFTextShape) {
-                XSLFTextShape tsh = (XSLFTextShape) sh;
+            if (sh instanceof XSLFTextShape tsh) {
                 Placeholder ph = tsh.getTextType();
                 if (ph == null) continue;
 
                 switch (ph) {
                     // these are special and not copied by default
-                    case DATETIME:
-                    case SLIDE_NUMBER:
-                    case FOOTER:
-                        break;
-                    default:
-                        slide.getSpTree().addNewSp().set(tsh.getXmlObject().copy());
+                    case DATETIME, SLIDE_NUMBER, FOOTER -> {}
+                    default -> slide.getSpTree().addNewSp().set(tsh.getXmlObject().copy());
                 }
             }
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextParagraph.java
@@ -73,8 +73,8 @@ public class XSLFTextParagraph implements TextParagraph<XSLFShape,XSLFTextParagr
             if (c.toFirstChild()) {
                 do {
                     XmlObject r = c.getObject();
-                    if (r instanceof CTTextLineBreak) {
-                        _runs.add(new XSLFLineBreak((CTTextLineBreak)r, this));
+                    if (r instanceof CTTextLineBreak br) {
+                        _runs.add(new XSLFLineBreak(br, this));
                     } else if (r instanceof CTRegularTextRun || r instanceof CTTextField) {
                         _runs.add(newTextRun(r));
                     }
@@ -310,12 +310,11 @@ public class XSLFTextParagraph implements TextParagraph<XSLFShape,XSLFTextParagr
      */
     @SuppressWarnings("WeakerAccess")
     public void setBulletFontColor(PaintStyle color) {
-        if (!(color instanceof SolidPaint)) {
+        if (!(color instanceof SolidPaint sp)) {
             throw new IllegalArgumentException("Currently XSLF only supports SolidPaint");
         }
 
         // TODO: implement setting bullet color to null
-        SolidPaint sp = (SolidPaint)color;
         Color col = DrawPaint.applyColorTransform(sp.getSolidColor());
 
         CTTextParagraphProperties pr = _p.isSetPPr() ? _p.getPPr() : _p.addNewPPr();
@@ -934,16 +933,16 @@ public class XSLFTextParagraph implements TextParagraph<XSLFShape,XSLFTextParagr
         } else {
             setBullet(true);
             for (Object ostyle : styles) {
-                if (ostyle instanceof Number) {
-                    setBulletFontSize(((Number)ostyle).doubleValue());
-                } else if (ostyle instanceof Color) {
-                    setBulletFontColor((Color)ostyle);
+                if (ostyle instanceof Number number) {
+                    setBulletFontSize(number.doubleValue());
+                } else if (ostyle instanceof Color color) {
+                    setBulletFontColor(color);
                 } else if (ostyle instanceof Character) {
                     setBulletCharacter(ostyle.toString());
-                } else if (ostyle instanceof String) {
-                    setBulletFont((String)ostyle);
-                } else if (ostyle instanceof AutoNumberingScheme) {
-                    setBulletAutoNumber((AutoNumberingScheme)ostyle, 1);
+                } else if (ostyle instanceof String str) {
+                    setBulletFont(str);
+                } else if (ostyle instanceof AutoNumberingScheme scheme) {
+                    setBulletAutoNumber(scheme, 1);
                 }
             }
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xslf/usermodel/XSLFTextRun.java
@@ -81,8 +81,8 @@ public class XSLFTextRun implements TextRun, HighlightColorSupport {
 
     @Override
     public String getRawText(){
-        if (_r instanceof CTTextField) {
-            return ((CTTextField)_r).getT();
+        if (_r instanceof CTTextField tf) {
+            return tf.getT();
         } else if (_r instanceof CTTextLineBreak) {
             return "\n";
         }
@@ -91,8 +91,8 @@ public class XSLFTextRun implements TextRun, HighlightColorSupport {
 
     @Override
     public void setText(String text){
-        if (_r instanceof CTTextField) {
-            ((CTTextField)_r).setT(text);
+        if (_r instanceof CTTextField tf) {
+            tf.setT(text);
         } else if (!(_r instanceof CTTextLineBreak)) {
             ((CTRegularTextRun)_r).setT(text);
         }
@@ -117,11 +117,10 @@ public class XSLFTextRun implements TextRun, HighlightColorSupport {
 
     @Override
     public void setFontColor(PaintStyle color) {
-        if (!(color instanceof SolidPaint)) {
+        if (!(color instanceof SolidPaint sp)) {
             LOG.atWarn().log("Currently only SolidPaint is supported!");
             return;
         }
-        SolidPaint sp = (SolidPaint)color;
         Color c = DrawPaint.applyColorTransform(sp.getSolidColor());
 
         CTTextCharacterProperties rPr = getRPr(true);
@@ -231,11 +230,10 @@ public class XSLFTextRun implements TextRun, HighlightColorSupport {
             return;
         }
 
-        if (!(color instanceof SolidPaint)) {
+        if (!(color instanceof SolidPaint sp)) {
             throw new IllegalArgumentException("Currently only SolidPaint is supported!");
         }
 
-        final SolidPaint sp = (SolidPaint)color;
         final Color c = DrawPaint.applyColorTransform(sp.getSolidColor());
 
         final CTTextCharacterProperties rPr = getRPr(true);
@@ -505,15 +503,13 @@ public class XSLFTextRun implements TextRun, HighlightColorSupport {
      */
     @Internal
     public CTTextCharacterProperties getRPr(boolean create) {
-        if (_r instanceof CTTextField) {
-            CTTextField tf = (CTTextField)_r;
+        if (_r instanceof CTTextField tf) {
             if (tf.isSetRPr()) {
                 return tf.getRPr();
             } else if (create) {
                 return tf.addNewRPr();
             }
-        } else if (_r instanceof CTTextLineBreak) {
-            CTTextLineBreak tlb = (CTTextLineBreak)_r;
+        } else if (_r instanceof CTTextLineBreak tlb) {
             if (tlb.isSetRPr()) {
                 return tlb.getRPr();
             } else if (create) {
@@ -617,8 +613,7 @@ public class XSLFTextRun implements TextRun, HighlightColorSupport {
 
     @Override
     public FieldType getFieldType() {
-        if (_r instanceof CTTextField) {
-            CTTextField tf = (CTTextField)_r;
+        if (_r instanceof CTTextField tf) {
             if ("slidenum".equals(tf.getType())) {
                 return FieldType.SLIDE_NUMBER;
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/streaming/SXSSFCell.java
@@ -213,8 +213,8 @@ public class SXSSFCell extends CellBase {
     protected void setCellValueImpl(RichTextString value) {
         ensureRichTextStringType();
 
-        if(_value instanceof RichTextStringFormulaValue) {
-            ((RichTextStringFormulaValue) _value).setPreEvaluatedValue(value);
+        if(_value instanceof RichTextStringFormulaValue richTextFormulaValue) {
+            richTextFormulaValue.setPreEvaluatedValue(value);
         } else {
             ((RichTextValue) _value).setValue(value);
         }
@@ -251,11 +251,8 @@ public class SXSSFCell extends CellBase {
             ((FormulaValue)_value).setValue(formula);
         } else {
             switch (getCellType()) {
-                case BLANK:
-                case NUMERIC:
-                    _value = new NumericFormulaValue(formula, getNumericCellValue());
-                    break;
-                case STRING:
+                case BLANK, NUMERIC -> _value = new NumericFormulaValue(formula, getNumericCellValue());
+                case STRING -> {
                     if (_value instanceof PlainStringValue) {
                         _value = new StringFormulaValue(formula, getStringCellValue());
                     } else {
@@ -264,15 +261,10 @@ public class SXSSFCell extends CellBase {
                         }
                         _value = new RichTextStringFormulaValue(formula, richTextValue.getValue());
                     }
-                    break;
-                case BOOLEAN:
-                    _value = new BooleanFormulaValue(formula, getBooleanCellValue());
-                    break;
-                case ERROR:
-                    _value = new ErrorFormulaValue(formula, getErrorCellValue());
-                    break;
-                default:
-                    throw new FormulaParseException("Cannot set a formula for a cell of type " + getCellType());
+                }
+                case BOOLEAN -> _value = new BooleanFormulaValue(formula, getBooleanCellValue());
+                case ERROR -> _value = new ErrorFormulaValue(formula, getErrorCellValue());
+                default -> throw new FormulaParseException("Cannot set a formula for a cell of type " + getCellType());
             }
         }
     }
@@ -281,28 +273,27 @@ public class SXSSFCell extends CellBase {
     protected void removeFormulaImpl() {
         assert getCellType() == CellType.FORMULA;
         switch (getCachedFormulaResultType()) {
-            case NUMERIC:
+            case NUMERIC -> {
                 double numericValue = ((NumericFormulaValue)_value).getPreEvaluatedValue();
                 _value = new NumericValue();
                 ((NumericValue) _value).setValue(numericValue);
-                break;
-            case STRING:
+            }
+            case STRING -> {
                 String stringValue = ((StringFormulaValue)_value).getPreEvaluatedValue();
                 _value = new PlainStringValue();
                 ((PlainStringValue) _value).setValue(stringValue);
-                break;
-            case BOOLEAN:
+            }
+            case BOOLEAN -> {
                 boolean booleanValue = ((BooleanFormulaValue)_value).getPreEvaluatedValue();
                 _value = new BooleanValue();
                 ((BooleanValue) _value).setValue(booleanValue);
-                break;
-            case ERROR:
+            }
+            case ERROR -> {
                 byte errorValue = ((ErrorFormulaValue)_value).getPreEvaluatedValue();
                 _value = new ErrorValue();
                 ((ErrorValue) _value).setValue(errorValue);
-                break;
-            default:
-                throw new AssertionError();
+            }
+            default -> throw new AssertionError();
         }
     }
 
@@ -335,22 +326,17 @@ public class SXSSFCell extends CellBase {
     public double getNumericCellValue()
     {
         CellType cellType = getCellType();
-        switch(cellType)
-        {
-            case BLANK:
-                return 0.0;
-            case FORMULA:
-            {
+        return switch (cellType) {
+            case BLANK -> 0.0;
+            case FORMULA -> {
                 FormulaValue fv=(FormulaValue)_value;
                 if(fv.getFormulaType()!=CellType.NUMERIC)
                       throw typeMismatch(CellType.NUMERIC, CellType.FORMULA, false);
-                return ((NumericFormulaValue)_value).getPreEvaluatedValue();
+                yield ((NumericFormulaValue)_value).getPreEvaluatedValue();
             }
-            case NUMERIC:
-                return ((NumericValue)_value).getValue();
-            default:
-                throw typeMismatch(CellType.NUMERIC, cellType, false);
-        }
+            case NUMERIC -> ((NumericValue)_value).getValue();
+            default -> throw typeMismatch(CellType.NUMERIC, cellType, false);
+        };
     }
 
     /**
@@ -437,31 +423,26 @@ public class SXSSFCell extends CellBase {
     public String getStringCellValue()
     {
         CellType cellType = getCellType();
-        switch(cellType)
-        {
-            case BLANK:
-                return "";
-            case FORMULA:
-            {
+        return switch (cellType) {
+            case BLANK -> "";
+            case FORMULA -> {
                 FormulaValue fv=(FormulaValue)_value;
                 if(fv.getFormulaType()!=CellType.STRING)
                       throw typeMismatch(CellType.STRING, CellType.FORMULA, false);
-                if(_value instanceof RichTextStringFormulaValue) {
-                    return ((RichTextStringFormulaValue) _value).getPreEvaluatedValue().getString();
+                if(_value instanceof RichTextStringFormulaValue richTextFormulaValue) {
+                    yield richTextFormulaValue.getPreEvaluatedValue().getString();
                 } else {
-                    return ((StringFormulaValue) _value).getPreEvaluatedValue();
+                    yield ((StringFormulaValue) _value).getPreEvaluatedValue();
                 }
             }
-            case STRING:
-            {
+            case STRING -> {
                 if(((StringValue)_value).isRichText())
-                    return ((RichTextValue)_value).getValue().getString();
+                    yield ((RichTextValue)_value).getValue().getString();
                 else
-                    return ((PlainStringValue)_value).getValue();
+                    yield ((PlainStringValue)_value).getValue();
             }
-            default:
-                throw typeMismatch(CellType.STRING, cellType, false);
-        }
+            default -> throw typeMismatch(CellType.STRING, cellType, false);
+        };
     }
 
     /**
@@ -513,24 +494,17 @@ public class SXSSFCell extends CellBase {
     public boolean getBooleanCellValue()
     {
         CellType cellType = getCellType();
-        switch(cellType)
-        {
-            case BLANK:
-                return false;
-            case FORMULA:
-            {
+        return switch (cellType) {
+            case BLANK -> false;
+            case FORMULA -> {
                 FormulaValue fv=(FormulaValue)_value;
                 if(fv.getFormulaType()!=CellType.BOOLEAN)
                       throw typeMismatch(CellType.BOOLEAN, CellType.FORMULA, false);
-                return ((BooleanFormulaValue)_value).getPreEvaluatedValue();
+                yield ((BooleanFormulaValue)_value).getPreEvaluatedValue();
             }
-            case BOOLEAN:
-            {
-                return ((BooleanValue)_value).getValue();
-            }
-            default:
-                throw typeMismatch(CellType.BOOLEAN, cellType, false);
-        }
+            case BOOLEAN -> ((BooleanValue)_value).getValue();
+            default -> throw typeMismatch(CellType.BOOLEAN, cellType, false);
+        };
     }
 
     /**
@@ -548,24 +522,17 @@ public class SXSSFCell extends CellBase {
     public byte getErrorCellValue()
     {
         CellType cellType = getCellType();
-        switch(cellType)
-        {
-            case BLANK:
-                return 0;
-            case FORMULA:
-            {
+        return switch (cellType) {
+            case BLANK -> 0;
+            case FORMULA -> {
                 FormulaValue fv=(FormulaValue)_value;
                 if(fv.getFormulaType()!=CellType.ERROR)
                       throw typeMismatch(CellType.ERROR, CellType.FORMULA, false);
-                return ((ErrorFormulaValue)_value).getPreEvaluatedValue();
+                yield ((ErrorFormulaValue)_value).getPreEvaluatedValue();
             }
-            case ERROR:
-            {
-                return ((ErrorValue)_value).getValue();
-            }
-            default:
-                throw typeMismatch(CellType.ERROR, cellType, false);
-        }
+            case ERROR -> ((ErrorValue)_value).getValue();
+            default -> throw typeMismatch(CellType.ERROR, cellType, false);
+        };
     }
 
     /**
@@ -803,23 +770,11 @@ public class SXSSFCell extends CellBase {
         }
         else
         {
-            switch(type)
-            {
-                case Property.COMMENT:
-                {
-                    current=new CommentProperty(value);
-                    break;
-                }
-                case Property.HYPERLINK:
-                {
-                    current=new HyperlinkProperty(value);
-                    break;
-                }
-                default:
-                {
-                    throw new IllegalArgumentException("Invalid type: " + type);
-                }
-            }
+            current = switch (type) {
+                case Property.COMMENT -> new CommentProperty(value);
+                case Property.HYPERLINK -> new HyperlinkProperty(value);
+                default -> throw new IllegalArgumentException("Invalid type: " + type);
+            };
             if(previous!=null)
             {
                 previous._next=current;
@@ -878,22 +833,13 @@ public class SXSSFCell extends CellBase {
         {
             if(((FormulaValue)_value).getFormulaType()==type)
                 return;
-            switch (type) {
-                case BOOLEAN:
-                    _value = new BooleanFormulaValue(getCellFormula(), false);
-                    break;
-                case NUMERIC:
-                    _value = new NumericFormulaValue(getCellFormula(), 0);
-                    break;
-                case STRING:
-                    _value = new StringFormulaValue(getCellFormula(), "");
-                    break;
-                case ERROR:
-                    _value = new ErrorFormulaValue(getCellFormula(), FormulaError._NO_ERROR.getCode());
-                    break;
-                default:
-                    throw new AssertionError();
-            }
+            _value = switch (type) {
+                case BOOLEAN -> new BooleanFormulaValue(getCellFormula(), false);
+                case NUMERIC -> new NumericFormulaValue(getCellFormula(), 0);
+                case STRING -> new StringFormulaValue(getCellFormula(), "");
+                case ERROR -> new ErrorFormulaValue(getCellFormula(), FormulaError._NO_ERROR.getCode());
+                default -> throw new AssertionError();
+            };
             return;
         }
         setType(type);
@@ -907,15 +853,9 @@ public class SXSSFCell extends CellBase {
      */
     /*package*/ void setType(CellType type)
     {
-        switch(type)
-        {
-            case NUMERIC:
-            {
-                _value = new NumericValue();
-                break;
-            }
-            case STRING:
-            {
+        switch (type) {
+            case NUMERIC -> _value = new NumericValue();
+            case STRING -> {
                 PlainStringValue sval = new PlainStringValue();
                 if(_value != null){
                     // if a cell is not blank then convert the old value to string
@@ -923,22 +863,14 @@ public class SXSSFCell extends CellBase {
                     sval.setValue(str);
                 }
                 _value = sval;
-                break;
             }
-            case FORMULA:
-            {
+            case FORMULA -> {
                 if (getCellType() == CellType.BLANK) {
                     _value = new NumericFormulaValue("", 0);
                 }
-                break;
             }
-            case BLANK:
-            {
-                _value = new BlankValue();
-                break;
-            }
-            case BOOLEAN:
-            {
+            case BLANK -> _value = new BlankValue();
+            case BOOLEAN -> {
                 BooleanValue bval = new BooleanValue();
                 if(_value != null){
                     // if a cell is not blank then convert the old value to string
@@ -946,17 +878,9 @@ public class SXSSFCell extends CellBase {
                     bval.setValue(val);
                 }
                 _value = bval;
-                break;
             }
-            case ERROR:
-            {
-                _value = new ErrorValue();
-                break;
-            }
-            default:
-            {
-                throw new IllegalArgumentException("Illegal type " + type);
-            }
+            case ERROR -> _value = new ErrorValue();
+            default -> throw new IllegalArgumentException("Illegal type " + type);
         }
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/BaseXSSFFormulaEvaluator.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/BaseXSSFFormulaEvaluator.java
@@ -61,8 +61,8 @@ public abstract class BaseXSSFFormulaEvaluator extends BaseFormulaEvaluator {
         try {
             EvaluationCell evalCell = toEvaluationCell(cell);
             eval = _bookEvaluator.evaluate(evalCell);
-            if (evalCell instanceof XSSFEvaluationCell)
-                cacheExternalWorkbookCells((XSSFEvaluationCell) evalCell);
+            if (evalCell instanceof XSSFEvaluationCell xssfEvalCell)
+                cacheExternalWorkbookCells(xssfEvalCell);
         } catch (IllegalStateException e) {
             // enhance IllegalStateException which can be
             // thrown somewhere deep down the evaluation
@@ -79,20 +79,17 @@ public abstract class BaseXSSFFormulaEvaluator extends BaseFormulaEvaluator {
             }
         }
 
-        if (eval instanceof NumberEval) {
-            NumberEval ne = (NumberEval) eval;
+        if (eval instanceof NumberEval ne) {
             return new CellValue(ne.getNumberValue());
         }
-        if (eval instanceof BoolEval) {
-            BoolEval be = (BoolEval) eval;
+        if (eval instanceof BoolEval be) {
             return CellValue.valueOf(be.getBooleanValue());
         }
-        if (eval instanceof StringEval) {
-            StringEval ne = (StringEval) eval;
+        if (eval instanceof StringEval ne) {
             return new CellValue(ne.getStringValue());
         }
-        if (eval instanceof ErrorEval) {
-            return CellValue.getError(((ErrorEval)eval).getErrorCode());
+        if (eval instanceof ErrorEval ee) {
+            return CellValue.getError(ee.getErrorCode());
         }
         throw new IllegalStateException("Unexpected eval class (" + eval.getClass().getName() + "): " + eval + ", cell: " +
                 new CellReference(cell.getSheet().getSheetName(), cell.getRowIndex(), cell.getColumnIndex(),
@@ -108,8 +105,7 @@ public abstract class BaseXSSFFormulaEvaluator extends BaseFormulaEvaluator {
         //
         Ptg[] formulaTokens = getEvaluationWorkbook().getFormulaTokens(evalCell);
         for (Ptg ptg : formulaTokens) {
-            if (ptg instanceof Area3DPxg) {
-                Area3DPxg area3DPxg = (Area3DPxg) ptg;
+            if (ptg instanceof Area3DPxg area3DPxg) {
                 if (area3DPxg.getExternalWorkbookNumber() > 0) {
                     EvaluationWorkbook.ExternalSheet externalSheet = getEvaluationWorkbook().getExternalSheet(area3DPxg.getSheetName(), area3DPxg.getLastSheetName(), area3DPxg.getExternalWorkbookNumber());
                     if (externalSheet != null) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFCellStyle.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFCellStyle.java
@@ -143,9 +143,7 @@ public class XSSFCellStyle implements CellStyle, Duplicatable {
      */
     @Override
     public void cloneStyleFrom(CellStyle source) {
-        if(source instanceof XSSFCellStyle) {
-            XSSFCellStyle src = (XSSFCellStyle)source;
-
+        if(source instanceof XSSFCellStyle src) {
             // Is it on our Workbook?
             if(src._stylesSource == _stylesSource) {
                // Nice and easy
@@ -1250,19 +1248,11 @@ public class XSSFCellStyle implements CellStyle, Duplicatable {
      * @param color - the color to use
      */
     public void setBorderColor(BorderSide side, XSSFColor color) {
-        switch(side){
-            case BOTTOM:
-                setBottomBorderColor(color);
-                break;
-            case RIGHT:
-                setRightBorderColor(color);
-                break;
-            case TOP:
-                setTopBorderColor(color);
-                break;
-            case LEFT:
-                setLeftBorderColor(color);
-                break;
+        switch (side) {
+            case BOTTOM -> setBottomBorderColor(color);
+            case RIGHT -> setRightBorderColor(color);
+            case TOP -> setTopBorderColor(color);
+            case LEFT -> setLeftBorderColor(color);
         }
     }
 
@@ -1337,9 +1327,8 @@ public class XSSFCellStyle implements CellStyle, Duplicatable {
      */
     @Override
     public boolean equals(Object o){
-        if(!(o instanceof XSSFCellStyle)) return false;
+        if(!(o instanceof XSSFCellStyle cf)) return false;
 
-        XSSFCellStyle cf = (XSSFCellStyle)o;
         return _cellXf.toString().equals(cf.getCoreXf().toString());
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFDrawing.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFDrawing.java
@@ -515,8 +515,8 @@ public final class XSSFDrawing extends POIXMLDocumentPart implements Drawing<XSS
     public List<XSSFChart> getCharts() {
         List<XSSFChart> charts = new ArrayList<>();
         for (POIXMLDocumentPart part : getRelations()) {
-            if (part instanceof XSSFChart) {
-                charts.add((XSSFChart) part);
+            if (part instanceof XSSFChart chart) {
+                charts.add(chart);
             }
         }
         return charts;
@@ -609,17 +609,17 @@ public final class XSSFDrawing extends POIXMLDocumentPart implements Drawing<XSS
                     if (obj instanceof CTMarker) {
                         // ignore anchor elements
                         continue;
-                    } else if (obj instanceof CTPicture) {
-                        shape = new XSSFPicture(this, (CTPicture) obj);
-                    } else if (obj instanceof CTConnector) {
-                        shape = new XSSFConnector(this, (CTConnector) obj);
-                    } else if (obj instanceof CTShape) {
-                        shape = hasOleLink(obj) ? new XSSFObjectData(this, (CTShape) obj)
-                            : new XSSFSimpleShape(this, (CTShape) obj);
-                    } else if (obj instanceof CTGraphicalObjectFrame) {
-                        shape = new XSSFGraphicFrame(this, (CTGraphicalObjectFrame) obj);
-                    } else if (obj instanceof CTGroupShape) {
-                        shape = new XSSFShapeGroup(this, (CTGroupShape) obj);
+                    } else if (obj instanceof CTPicture ctPicture) {
+                        shape = new XSSFPicture(this, ctPicture);
+                    } else if (obj instanceof CTConnector ctConnector) {
+                        shape = new XSSFConnector(this, ctConnector);
+                    } else if (obj instanceof CTShape ctShape) {
+                        shape = hasOleLink(obj) ? new XSSFObjectData(this, ctShape)
+                            : new XSSFSimpleShape(this, ctShape);
+                    } else if (obj instanceof CTGraphicalObjectFrame ctFrame) {
+                        shape = new XSSFGraphicFrame(this, ctFrame);
+                    } else if (obj instanceof CTGroupShape ctGroup) {
+                        shape = new XSSFShapeGroup(this, ctGroup);
                     } else if (obj instanceof XmlAnyTypeImpl) {
                         LOG.atWarn().log("trying to parse AlternateContent, this unlinks the returned Shapes from the underlying xml content, so those shapes can't be used to modify the drawing, i.e. modifications will be ignored!");
 
@@ -683,14 +683,11 @@ public final class XSSFDrawing extends POIXMLDocumentPart implements Drawing<XSS
             }
         }
         if (parentXbean != null) {
-            if (parentXbean instanceof CTTwoCellAnchor) {
-                CTTwoCellAnchor ct = (CTTwoCellAnchor) parentXbean;
+            if (parentXbean instanceof CTTwoCellAnchor ct) {
                 anchor = new XSSFClientAnchor(ct.getFrom(), ct.getTo());
-            } else if (parentXbean instanceof CTOneCellAnchor) {
-                CTOneCellAnchor ct = (CTOneCellAnchor) parentXbean;
+            } else if (parentXbean instanceof CTOneCellAnchor ct) {
                 anchor = new XSSFClientAnchor(getSheet(), ct.getFrom(), ct.getExt());
-            } else if (parentXbean instanceof CTAbsoluteAnchor) {
-                CTAbsoluteAnchor ct = (CTAbsoluteAnchor) parentXbean;
+            } else if (parentXbean instanceof CTAbsoluteAnchor ct) {
                 anchor = new XSSFClientAnchor(getSheet(), ct.getPos(), ct.getExt());
             }
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFSheet.java
@@ -165,15 +165,15 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet, OoxmlSheetEx
         // Look for bits we're interested in
         for(RelationPart rp : getRelationParts()){
             POIXMLDocumentPart p = rp.getDocumentPart();
-            if(p instanceof Comments) {
-                sheetComments = (Comments)p;
+            if(p instanceof Comments comments) {
+                sheetComments = comments;
                 sheetComments.setSheet(this);
             }
-            if(p instanceof XSSFTable) {
-                tables.put( rp.getRelationship().getId(), (XSSFTable)p );
+            if(p instanceof XSSFTable table) {
+                tables.put( rp.getRelationship().getId(), table );
             }
-            if(p instanceof XSSFPivotTable) {
-                getWorkbook().addPivotTable((XSSFPivotTable) p);
+            if(p instanceof XSSFPivotTable pivotTable) {
+                getWorkbook().addPivotTable(pivotTable);
             }
         }
 
@@ -1304,26 +1304,13 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet, OoxmlSheetEx
         CTPageMargins pageMargins = worksheet.isSetPageMargins() ?
                 worksheet.getPageMargins() : worksheet.addNewPageMargins();
         switch (margin) {
-            case LEFT:
-                pageMargins.setLeft(size);
-                break;
-            case RIGHT:
-                pageMargins.setRight(size);
-                break;
-            case TOP:
-                pageMargins.setTop(size);
-                break;
-            case BOTTOM:
-                pageMargins.setBottom(size);
-                break;
-            case HEADER:
-                pageMargins.setHeader(size);
-                break;
-            case FOOTER:
-                pageMargins.setFooter(size);
-                break;
-            default:
-                throw new IllegalArgumentException( "Unknown margin constant:  " + margin );
+            case LEFT -> pageMargins.setLeft(size);
+            case RIGHT -> pageMargins.setRight(size);
+            case TOP -> pageMargins.setTop(size);
+            case BOTTOM -> pageMargins.setBottom(size);
+            case HEADER -> pageMargins.setHeader(size);
+            case FOOTER -> pageMargins.setFooter(size);
+            default -> throw new IllegalArgumentException( "Unknown margin constant:  " + margin );
         }
     }
 
@@ -4912,9 +4899,9 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet, OoxmlSheetEx
      */
     protected void onSheetDelete() {
         for (RelationPart part : getRelationParts()) {
-            if (part.getDocumentPart() instanceof XSSFTable) {
+            if (part.getDocumentPart() instanceof XSSFTable table) {
                 // call table delete
-                removeTable(part.getDocumentPart());
+                removeTable(table);
                 continue;
             }
             removeRelation(part.getDocumentPart(), true);
@@ -4983,9 +4970,9 @@ public class XSSFSheet extends POIXMLDocumentPart implements Sheet, OoxmlSheetEx
                 }
 
                 XmlObject xObj = cur.getObject();
-                if (xObj instanceof CTOleObject) {
+                if (xObj instanceof CTOleObject oleObject) {
                     // the unusual case ...
-                    coo = (CTOleObject)xObj;
+                    coo = oleObject;
                 } else {
                     XMLStreamReader reader = cur.newXMLStreamReader();
                     try {

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFTextParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFTextParagraph.java
@@ -48,17 +48,14 @@ public class XSSFTextParagraph implements Iterable<XSSFTextRun>{
         _runs = new ArrayList<>();
 
         for(XmlObject ch : _p.selectPath("*")){
-            if(ch instanceof CTRegularTextRun){
-                CTRegularTextRun r = (CTRegularTextRun)ch;
+            if(ch instanceof CTRegularTextRun r){
                 _runs.add(new XSSFTextRun(r, this));
-            } else if (ch instanceof CTTextLineBreak){
-                CTTextLineBreak br = (CTTextLineBreak)ch;
+            } else if (ch instanceof CTTextLineBreak br){
                 CTRegularTextRun r = CTRegularTextRun.Factory.newInstance();
                 r.setRPr(br.getRPr());
                 r.setT("\n");
                 _runs.add(new XSSFTextRun(r, this));
-            } else if (ch instanceof CTTextField){
-                CTTextField f = (CTTextField)ch;
+            } else if (ch instanceof CTTextField f){
                 CTRegularTextRun r = CTRegularTextRun.Factory.newInstance();
                 r.setRPr(f.getRPr());
                 r.setT(f.getT());

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFVMLDrawing.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFVMLDrawing.java
@@ -159,10 +159,9 @@ public final class XSSFVMLDrawing extends POIXMLDocumentPart {
         try (XmlCursor cur = root.getXml().newCursor()) {
             for (boolean found = cur.toFirstChild(); found; found = cur.toNextSibling()) {
                 XmlObject xo = cur.getObject();
-                if (xo instanceof CTShapetype) {
-                    _shapeTypeId = ((CTShapetype)xo).getId();
-                } else if (xo instanceof CTShape) {
-                    CTShape shape = (CTShape)xo;
+                if (xo instanceof CTShapetype shapetype) {
+                    _shapeTypeId = shapetype.getId();
+                } else if (xo instanceof CTShape shape) {
                     String id = shape.getId();
                     if(id != null) {
                         Matcher m = ptrn_shapeId.matcher(id);
@@ -297,11 +296,10 @@ public final class XSSFVMLDrawing extends POIXMLDocumentPart {
     }
 
     private boolean matchCommentShape(XmlObject itm, int row, int col) {
-        if (!(itm instanceof CTShape)) {
+        if (!(itm instanceof CTShape sh)) {
             return false;
         }
 
-        CTShape sh = (CTShape)itm;
         if (sh.sizeOfClientDataArray() == 0) {
             return false;
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbook.java
@@ -693,8 +693,8 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
         for(RelationPart rp : rels) {
             POIXMLDocumentPart r = rp.getDocumentPart();
             // do not copy the drawing relationship, it will be re-created
-            if(r instanceof XSSFDrawing) {
-                dg = (XSSFDrawing)r;
+            if(r instanceof XSSFDrawing drawing) {
+                dg = drawing;
                 continue;
             }
 
@@ -758,11 +758,11 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
                 List<RelationPart> srcRels = drawingPatriarch.getRelationParts();
                 for (RelationPart rp : srcRels) {
                     POIXMLDocumentPart r = rp.getDocumentPart();
-                    if (r instanceof XSSFChart) {
+                    if (r instanceof XSSFChart srcChart) {
                         // Replace chart relation part with new relationship, cloning the chart's content
                         RelationPart chartPart = clonedDg.createChartRelationPart();
                         XSSFChart chart = chartPart.getDocumentPart();
-                        chart.importContent((XSSFChart) r);
+                        chart.importContent(srcChart);
                         chart.replaceReferences(clonedSheet);
                     } else {
                         addRelation(rp, clonedDg);
@@ -2038,17 +2038,10 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
 
         final CTSheet ctSheet = sheets.get(sheetIx).sheet;
         switch (visibility) {
-            case VISIBLE:
-                ctSheet.setState(STSheetState.VISIBLE);
-                break;
-            case HIDDEN:
-                ctSheet.setState(STSheetState.HIDDEN);
-                break;
-            case VERY_HIDDEN:
-                ctSheet.setState(STSheetState.VERY_HIDDEN);
-                break;
-            default:
-                throw new IllegalArgumentException("This should never happen");
+            case VISIBLE -> ctSheet.setState(STSheetState.VISIBLE);
+            case HIDDEN -> ctSheet.setState(STSheetState.HIDDEN);
+            case VERY_HIDDEN -> ctSheet.setState(STSheetState.VERY_HIDDEN);
+            default -> throw new IllegalArgumentException("This should never happen");
         }
     }
 
@@ -2199,8 +2192,7 @@ public class XSSFWorkbook extends POIXMLDocument implements Workbook, Date1904Su
         } else {
             List<RelationPart> relationParts = getRelationParts();
             for (RelationPart relationPart : relationParts) {
-                if (relationPart.getDocumentPart() instanceof ExternalLinksTable) {
-                    ExternalLinksTable linksTable = relationPart.getDocumentPart();
+                if (relationPart.getDocumentPart() instanceof ExternalLinksTable linksTable) {
                     String linkedFileName = linksTable.getLinkedFileName();
                     if(linkedFileName.equals(name)){
                         String s = relationPart.getRelationship().getTargetURI().toString();

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/model/XWPFHeaderFooterPolicy.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/model/XWPFHeaderFooterPolicy.java
@@ -110,8 +110,8 @@ public class XWPFHeaderFooterPolicy {
             CTHdrFtrRef ref = sectPr.getHeaderReferenceArray(i);
             POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
             XWPFHeader hdr = null;
-            if (relatedPart instanceof XWPFHeader) {
-                hdr = (XWPFHeader) relatedPart;
+            if (relatedPart instanceof XWPFHeader header) {
+                hdr = header;
             }
             // Assign it; treat invalid options as "default" POI-60293
             Enum type;
@@ -128,8 +128,8 @@ public class XWPFHeaderFooterPolicy {
             CTHdrFtrRef ref = sectPr.getFooterReferenceArray(i);
             POIXMLDocumentPart relatedPart = doc.getRelationById(ref.getId());
             XWPFFooter ftr = null;
-            if (relatedPart instanceof XWPFFooter) {
-                ftr = (XWPFFooter) relatedPart;
+            if (relatedPart instanceof XWPFFooter footer) {
+                ftr = footer;
             }
             // Assign it; treat invalid options as "default" POI-60293
             Enum type;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
@@ -252,17 +252,16 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
         try (final XmlCursor cursor = cell.newCursor()) {
             cursor.toParent();
             o = cursor.getObject();
-            if (!(o instanceof CTRow)) {
+            if (!(o instanceof CTRow ctRow)) {
                 return null;
             }
-            row = (CTRow) o;
+            row = ctRow;
             cursor.toParent();
             o = cursor.getObject();
         }
-        if (!(o instanceof CTTbl)) {
+        if (!(o instanceof CTTbl tbl)) {
             return null;
         }
-        CTTbl tbl = (CTTbl) o;
         XWPFTable table = getTable(tbl);
         if (table == null) {
             return null;
@@ -313,10 +312,10 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
             while (!(o instanceof CTTbl) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if (!(o instanceof CTTbl)) {
+            if (!(o instanceof CTTbl tbl)) {
                 tables.add(0, newT);
             } else {
-                int pos = tables.indexOf(getTable((CTTbl) o)) + 1;
+                int pos = tables.indexOf(getTable(tbl)) + 1;
                 tables.add(pos, newT);
             }
             int i = 0;
@@ -355,10 +354,10 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
             while (!(o instanceof CTP) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if ((!(o instanceof CTP)) || o == p) {
+            if ((!(o instanceof CTP ctp)) || o == p) {
                 paragraphs.add(0, newP);
             } else {
-                int pos = paragraphs.indexOf(getParagraph((CTP) o)) + 1;
+                int pos = paragraphs.indexOf(getParagraph(ctp)) + 1;
                 paragraphs.add(pos, newP);
             }
             int i = 0;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFComment.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFComment.java
@@ -168,10 +168,10 @@ public class XWPFComment implements IBody {
             while (!(o instanceof CTP) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if ((!(o instanceof CTP)) || o == p) {
+            if ((!(o instanceof CTP ctp)) || o == p) {
                 paragraphs.add(0, newP);
             } else {
-                int pos = paragraphs.indexOf(getParagraph((CTP) o)) + 1;
+                int pos = paragraphs.indexOf(getParagraph(ctp)) + 1;
                 paragraphs.add(pos, newP);
             }
             int i = 0;
@@ -214,10 +214,10 @@ public class XWPFComment implements IBody {
             while (!(o instanceof CTTbl) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if (!(o instanceof CTTbl)) {
+            if (!(o instanceof CTTbl tbl)) {
                 tables.add(0, newT);
             } else {
-                int pos = tables.indexOf(getTable((CTTbl) o)) + 1;
+                int pos = tables.indexOf(getTable(tbl)) + 1;
                 tables.add(pos, newT);
             }
             int i = 0;
@@ -260,17 +260,16 @@ public class XWPFComment implements IBody {
         try (final XmlCursor cursor = cell.newCursor()) {
             cursor.toParent();
             o = cursor.getObject();
-            if (!(o instanceof CTRow)) {
+            if (!(o instanceof CTRow ctRow)) {
                 return null;
             }
-            row = (CTRow) o;
+            row = ctRow;
             cursor.toParent();
             o = cursor.getObject();
         }
-        if (!(o instanceof CTTbl)) {
+        if (!(o instanceof CTTbl tbl)) {
             return null;
         }
-        CTTbl tbl = (CTTbl) o;
         XWPFTable table = getTable(tbl);
         if (table == null) {
             return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -326,12 +326,12 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
         for (RelationPart rp : getRelationParts()) {
             POIXMLDocumentPart p = rp.getDocumentPart();
             String relation = rp.getRelationship().getRelationshipType();
-            if (relation.equals(XWPFRelation.FOOTNOTE.getRelation()) && p instanceof XWPFFootnotes) {
-                this.footnotes = (XWPFFootnotes) p;
+            if (relation.equals(XWPFRelation.FOOTNOTE.getRelation()) && p instanceof XWPFFootnotes xwpfFootnotes) {
+                this.footnotes = xwpfFootnotes;
                 this.footnotes.onDocumentRead();
                 this.footnotes.setIdManager(footnoteIdManager);
-            } else if (relation.equals(XWPFRelation.ENDNOTE.getRelation()) && p instanceof XWPFEndnotes) {
-                this.endnotes = (XWPFEndnotes) p;
+            } else if (relation.equals(XWPFRelation.ENDNOTE.getRelation()) && p instanceof XWPFEndnotes xwpfEndnotes) {
+                this.endnotes = xwpfEndnotes;
                 this.endnotes.onDocumentRead();
                 this.endnotes.setIdManager(footnoteIdManager);
             }
@@ -802,10 +802,10 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
              * in the body. Otherwise, take the previous paragraph and calculate
              * the new index for the new paragraph.
              */
-            if ((!(o instanceof CTP)) || o == p) {
+            if ((!(o instanceof CTP ctp)) || o == p) {
                 paragraphs.add(0, newP);
             } else {
-                int pos = paragraphs.indexOf(getParagraph((CTP) o)) + 1;
+                int pos = paragraphs.indexOf(getParagraph(ctp)) + 1;
                 paragraphs.add(pos, newP);
             }
         }
@@ -835,10 +835,10 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
              * in the body. Otherwise, take the previous paragraph and calculate
              * the new index for the new paragraph.
              */
-            if (!(o instanceof CTTbl)) {
+            if (!(o instanceof CTTbl tbl)) {
                 tables.add(0, newT);
             } else {
-                int pos = tables.indexOf(getTable((CTTbl) o)) + 1;
+                int pos = tables.indexOf(getTable(tbl)) + 1;
                 tables.add(pos, newT);
             }
         }
@@ -1763,8 +1763,8 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
      */
     public XWPFPictureData getPictureDataByID(String blipID) {
         POIXMLDocumentPart relatedPart = getRelationById(blipID);
-        if (relatedPart instanceof XWPFPictureData) {
-            return (XWPFPictureData) relatedPart;
+        if (relatedPart instanceof XWPFPictureData pictureData) {
+            return pictureData;
         }
         return null;
     }
@@ -1875,17 +1875,16 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
         try (final XmlCursor cursor = cell.newCursor()) {
             cursor.toParent();
             o = cursor.getObject();
-            if (!(o instanceof CTRow)) {
+            if (!(o instanceof CTRow ctRow)) {
                 return null;
             }
-            row = (CTRow) o;
+            row = ctRow;
             cursor.toParent();
             o = cursor.getObject();
         }
-        if (!(o instanceof CTTbl)) {
+        if (!(o instanceof CTTbl tbl)) {
             return null;
         }
-        CTTbl tbl = (CTTbl) o;
         XWPFTable table = getTable(tbl);
         if (table == null) {
             return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFFooter.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFFooter.java
@@ -51,13 +51,13 @@ public class XWPFFooter extends XWPFHeaderFooter {
             cursor.selectPath("./*");
             while (cursor.toNextSelection()) {
                 XmlObject o = cursor.getObject();
-                if (o instanceof CTP) {
-                    XWPFParagraph p = new XWPFParagraph((CTP) o, this);
+                if (o instanceof CTP ctp) {
+                    XWPFParagraph p = new XWPFParagraph(ctp, this);
                     paragraphs.add(p);
                     bodyElements.add(p);
                 }
-                if (o instanceof CTTbl) {
-                    XWPFTable t = new XWPFTable((CTTbl) o, this, false);
+                if (o instanceof CTTbl tbl) {
+                    XWPFTable t = new XWPFTable(tbl, this, false);
                     tables.add(t);
                     bodyElements.add(t);
                 }
@@ -99,18 +99,18 @@ public class XWPFFooter extends XWPFHeaderFooter {
                 cursor.selectPath("./*");
                 while (cursor.toNextSelection()) {
                     XmlObject o = cursor.getObject();
-                    if (o instanceof CTP) {
-                        XWPFParagraph p = new XWPFParagraph((CTP) o, this);
+                    if (o instanceof CTP ctp) {
+                        XWPFParagraph p = new XWPFParagraph(ctp, this);
                         paragraphs.add(p);
                         bodyElements.add(p);
                     }
-                    if (o instanceof CTTbl) {
-                        XWPFTable t = new XWPFTable((CTTbl) o, this, false);
+                    if (o instanceof CTTbl tbl) {
+                        XWPFTable t = new XWPFTable(tbl, this, false);
                         tables.add(t);
                         bodyElements.add(t);
                     }
-                    if (o instanceof CTSdtBlock) {
-                        XWPFSDT c = new XWPFSDT((CTSdtBlock) o, this);
+                    if (o instanceof CTSdtBlock block) {
+                        XWPFSDT c = new XWPFSDT(block, this);
                         bodyElements.add(c);
                     }
                 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFHeader.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFHeader.java
@@ -59,12 +59,12 @@ public class XWPFHeader extends XWPFHeaderFooter {
             cursor.selectPath("./*");
             while (cursor.toNextSelection()) {
                 XmlObject o = cursor.getObject();
-                if (o instanceof CTP) {
-                    XWPFParagraph p = new XWPFParagraph((CTP) o, this);
+                if (o instanceof CTP ctp) {
+                    XWPFParagraph p = new XWPFParagraph(ctp, this);
                     paragraphs.add(p);
                 }
-                if (o instanceof CTTbl) {
-                    XWPFTable t = new XWPFTable((CTTbl) o, this, false);
+                if (o instanceof CTTbl tbl) {
+                    XWPFTable t = new XWPFTable(tbl, this, false);
                     tables.add(t);
                 }
             }
@@ -100,18 +100,18 @@ public class XWPFHeader extends XWPFHeaderFooter {
                 cursor.selectPath("./*");
                 while (cursor.toNextSelection()) {
                     XmlObject o = cursor.getObject();
-                    if (o instanceof CTP) {
-                        XWPFParagraph p = new XWPFParagraph((CTP) o, this);
+                    if (o instanceof CTP ctp) {
+                        XWPFParagraph p = new XWPFParagraph(ctp, this);
                         paragraphs.add(p);
                         bodyElements.add(p);
                     }
-                    if (o instanceof CTTbl) {
-                        XWPFTable t = new XWPFTable((CTTbl) o, this, false);
+                    if (o instanceof CTTbl tbl) {
+                        XWPFTable t = new XWPFTable(tbl, this, false);
                         tables.add(t);
                         bodyElements.add(t);
                     }
-                    if (o instanceof CTSdtBlock) {
-                        XWPFSDT c = new XWPFSDT((CTSdtBlock) o, this);
+                    if (o instanceof CTSdtBlock block) {
+                        XWPFSDT c = new XWPFSDT(block, this);
                         bodyElements.add(c);
                     }
                 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFHeaderFooter.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFHeaderFooter.java
@@ -73,17 +73,16 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
     public XWPFHeaderFooter(POIXMLDocumentPart parent, PackagePart part) {
         super(parent, part);
         final POIXMLDocumentPart p = getParent();
-        if (!(p instanceof XWPFDocument)) {
+        if (!(p instanceof XWPFDocument doc)) {
             throw new IllegalArgumentException("Had unexpected type of parent: " + (p == null ? "<null>" : p.getClass()));
         }
-        this.document = (XWPFDocument) p;
+        this.document = doc;
     }
 
     @Override
     protected void onDocumentRead() throws IOException {
         for (POIXMLDocumentPart poixmlDocumentPart : getRelations()) {
-            if (poixmlDocumentPart instanceof XWPFPictureData) {
-                XWPFPictureData xwpfPicData = (XWPFPictureData) poixmlDocumentPart;
+            if (poixmlDocumentPart instanceof XWPFPictureData xwpfPicData) {
                 pictures.add(xwpfPicData);
                 document.registerPackagePictureData(xwpfPicData);
             }
@@ -153,8 +152,8 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
         }
 
         for (IBodyElement bodyElement : getBodyElements()) {
-            if (bodyElement instanceof XWPFSDT) {
-                t.append(((XWPFSDT) bodyElement).getContent().getText()).append('\n');
+            if (bodyElement instanceof XWPFSDT sdt) {
+                t.append(sdt.getContent().getText()).append('\n');
             }
         }
         return t.toString();
@@ -328,8 +327,8 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
      */
     public XWPFPictureData getPictureDataByID(String blipID) {
         POIXMLDocumentPart relatedPart = getRelationById(blipID);
-        if (relatedPart instanceof XWPFPictureData) {
-            return (XWPFPictureData) relatedPart;
+        if (relatedPart instanceof XWPFPictureData pictureData) {
+            return pictureData;
         }
         return null;
     }
@@ -422,10 +421,10 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
             while (!(o instanceof CTP) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if ((!(o instanceof CTP)) || o == p) {
+            if ((!(o instanceof CTP ctp)) || o == p) {
                 paragraphs.add(0, newP);
             } else {
-                int pos = paragraphs.indexOf(getParagraph((CTP) o)) + 1;
+                int pos = paragraphs.indexOf(getParagraph(ctp)) + 1;
                 paragraphs.add(pos, newP);
             }
             int i = 0;
@@ -465,10 +464,10 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
             while (!(o instanceof CTTbl) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if (!(o instanceof CTTbl)) {
+            if (!(o instanceof CTTbl tbl)) {
                 tables.add(0, newT);
             } else {
-                int pos = tables.indexOf(getTable((CTTbl) o)) + 1;
+                int pos = tables.indexOf(getTable(tbl)) + 1;
                 tables.add(pos, newT);
             }
             int i = 0;
@@ -567,17 +566,16 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
         try (XmlCursor cursor = cell.newCursor()) {
             cursor.toParent();
             o = cursor.getObject();
-            if (!(o instanceof CTRow)) {
+            if (!(o instanceof CTRow ctRow)) {
                 return null;
             }
-            row = (CTRow) o;
+            row = ctRow;
             cursor.toParent();
             o = cursor.getObject();
         }
-        if (!(o instanceof CTTbl)) {
+        if (!(o instanceof CTTbl tbl)) {
             return null;
         }
-        CTTbl tbl = (CTTbl) o;
         XWPFTable table = getTable(tbl);
         if (table == null) {
             return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFPicture.java
@@ -72,8 +72,8 @@ public class XWPFPicture {
         POIXMLDocumentPart part = run.getParent().getPart();
         if (part != null) {
             POIXMLDocumentPart relatedPart = part.getRelationById(blipId);
-            if (relatedPart instanceof XWPFPictureData) {
-                return (XWPFPictureData) relatedPart;
+            if (relatedPart instanceof XWPFPictureData pictureData) {
+                return pictureData;
             }
         }
         return null;

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -143,8 +143,8 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
             }
             XmlObject[] chartRels = o.selectPath("declare namespace c='" + CTChart.type.getName().getNamespaceURI() + "' .//*/c:chart");
             for (XmlObject chartRel : chartRels) {
-                if (chartRel instanceof CTRelId) {
-                    POIXMLDocumentPart chart = getDocument().getRelationById(((CTRelId) chartRel).getId());
+                if (chartRel instanceof CTRelId relId) {
+                    POIXMLDocumentPart chart = getDocument().getRelationById(relId.getId());
                     if (chart instanceof XWPFChart xwpfChart) {
                         charts.add(xwpfChart);
                     }
@@ -926,18 +926,10 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
             }
         } else {
             switch (fcr) {
-                case ascii:
-                    fonts.setAscii(fontFamily);
-                    break;
-                case cs:
-                    fonts.setCs(fontFamily);
-                    break;
-                case eastAsia:
-                    fonts.setEastAsia(fontFamily);
-                    break;
-                case hAnsi:
-                    fonts.setHAnsi(fontFamily);
-                    break;
+                case ascii -> fonts.setAscii(fontFamily);
+                case cs -> fonts.setCs(fontFamily);
+                case eastAsia -> fonts.setEastAsia(fontFamily);
+                case hAnsi -> fonts.setHAnsi(fontFamily);
             }
         }
     }
@@ -1374,8 +1366,8 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
     public CTInline addChart(String chartRelId) throws InvalidFormatException, IOException {
         try {
             POIXMLDocumentPart chart = getDocument().getRelationById(chartRelId);
-            if (chart instanceof XWPFChart) {
-                charts.add((XWPFChart) chart);
+            if (chart instanceof XWPFChart xwpfChart) {
+                charts.add(xwpfChart);
             }
 
             CTInline inline = run.addNewDrawing().addNewInline();
@@ -1559,13 +1551,13 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
 
     private void _getText(XmlObject o, StringBuilder text) {
 
-        if (o instanceof CTText) {
+        if (o instanceof CTText ctText) {
             final Node node = o.getDomNode();
             // Field Codes (w:instrText, defined in spec sec. 17.16.23 and w:delInstrText, defined in spec sec. 17.16.13)
             //  come up as instances of CTText, but we don't want them
             //  in the normal text output
             if (!(("instrText".equals(node.getLocalName()) || "delInstrText".equals(node.getLocalName())) && XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI()))) {
-                String textValue = ((CTText) o).getStringValue();
+                String textValue = ctText.getStringValue();
                 if (textValue != null) {
                     if (isCapitalized() || isSmallCaps()) {
                         textValue = textValue.toUpperCase(LocaleUtil.getUserLocale());
@@ -1576,8 +1568,7 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         }
 
         // Complex type evaluation (currently only for extraction of check boxes)
-        if (o instanceof CTFldChar) {
-            CTFldChar ctfldChar = ((CTFldChar) o);
+        if (o instanceof CTFldChar ctfldChar) {
             if (ctfldChar.getFldCharType() == STFldCharType.BEGIN) {
                 if (ctfldChar.getFfData() != null) {
                     for (CTFFCheckBox checkBox : ctfldChar.getFfData().getCheckBoxList()) {
@@ -1604,16 +1595,9 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
             final Node node = o.getDomNode();
             if (XSSFRelation.NS_WORDPROCESSINGML.equals(node.getNamespaceURI())) {
                 switch (node.getLocalName()) {
-                    case "noBreakHyphen":
-                        text.append('‑');
-                        break;
-                    case "tab":
-                        text.append('\t');
-                        break;
-                    case "br":
-                    case "cr":
-                        text.append('\n');
-                        break;
+                    case "noBreakHyphen" -> text.append('‑');
+                    case "tab" -> text.append('\t');
+                    case "br", "cr" -> text.append('\n');
                 }
             }
         }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContent.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContent.java
@@ -48,11 +48,11 @@ public class XWPFSDTContent implements ISDTContent {
             cursor.selectPath("./*");
             while (cursor.toNextSelection()) {
                 XmlObject o = cursor.getObject();
-                if (o instanceof CTR) {
-                    XWPFRun run = new XWPFRun((CTR) o, parent);
+                if (o instanceof CTR ctr) {
+                    XWPFRun run = new XWPFRun(ctr, parent);
                     bodyElements.add(run);
-                } else if (o instanceof CTSdtRun) {
-                    XWPFSDT c = new XWPFSDT(((CTSdtRun) o), part);
+                } else if (o instanceof CTSdtRun sdt) {
+                    XWPFSDT c = new XWPFSDT(sdt, part);
                     bodyElements.add(c);
                 }
             }
@@ -67,20 +67,20 @@ public class XWPFSDTContent implements ISDTContent {
             cursor.selectPath("./*");
             while (cursor.toNextSelection()) {
                 XmlObject o = cursor.getObject();
-                if (o instanceof CTP) {
-                    XWPFParagraph p = new XWPFParagraph((CTP) o, part);
+                if (o instanceof CTP ctp) {
+                    XWPFParagraph p = new XWPFParagraph(ctp, part);
                     bodyElements.add(p);
                     // paragraphs.add(p);
-                } else if (o instanceof CTTbl) {
-                    XWPFTable t = new XWPFTable((CTTbl) o, part,false);
+                } else if (o instanceof CTTbl tbl) {
+                    XWPFTable t = new XWPFTable(tbl, part,false);
                     bodyElements.add(t);
                     // tables.add(t);
-                } else if (o instanceof CTSdtBlock) {
-                    XWPFSDT c = new XWPFSDT(((CTSdtBlock) o), part);
+                } else if (o instanceof CTSdtBlock sdtBlock) {
+                    XWPFSDT c = new XWPFSDT(sdtBlock, part);
                     bodyElements.add(c);
                     // contentControls.add(c);
-                } else if (o instanceof CTR) {
-                    XWPFRun run = new XWPFRun((CTR) o, parent);
+                } else if (o instanceof CTR ctr) {
+                    XWPFRun run = new XWPFRun(ctr, parent);
                     // runs.add(run);
                     bodyElements.add(run);
                 }
@@ -96,8 +96,8 @@ public class XWPFSDTContent implements ISDTContent {
             cursor.selectPath("./*");
             while (cursor.toNextSelection()) {
                 XmlObject o = cursor.getObject();
-                if (o instanceof CTSdtRow) {
-                    XWPFSDT c = new XWPFSDT(((CTSdtRow) o), part);
+                if (o instanceof CTSdtRow sdtRow) {
+                    XWPFSDT c = new XWPFSDT(sdtRow, part);
                     bodyElements.add(c);
                     // contentControls.add(c);
                 } else if (o instanceof CTRow) {
@@ -123,14 +123,14 @@ public class XWPFSDTContent implements ISDTContent {
         boolean addNewLine = false;
         for (int i = 0; i < bodyElements.size(); i++) {
             Object o = bodyElements.get(i);
-            if (o instanceof XWPFParagraph) {
-                appendParagraph((XWPFParagraph) o, text);
+            if (o instanceof XWPFParagraph paragraph) {
+                appendParagraph(paragraph, text);
                 addNewLine = true;
-            } else if (o instanceof XWPFTable) {
-                appendTable((XWPFTable) o, text);
+            } else if (o instanceof XWPFTable table) {
+                appendTable(table, text);
                 addNewLine = true;
-            } else if (o instanceof XWPFSDT) {
-                text.append(((XWPFSDT) o).getContent().getText());
+            } else if (o instanceof XWPFSDT sdt) {
+                text.append(sdt.getContent().getText());
                 addNewLine = true;
             } else if (o instanceof XWPFRun) {
                 text.append(o);
@@ -149,10 +149,10 @@ public class XWPFSDTContent implements ISDTContent {
             List<ICell> cells = row.getTableICells();
             for (int i = 0; i < cells.size(); i++) {
                 ICell cell = cells.get(i);
-                if (cell instanceof XWPFTableCell) {
-                    text.append(((XWPFTableCell) cell).getTextRecursively());
-                } else if (cell instanceof XWPFSDTCell) {
-                    text.append(((XWPFSDTCell) cell).getContent().getText());
+                if (cell instanceof XWPFTableCell tableCell) {
+                    text.append(tableCell.getTextRecursively());
+                } else if (cell instanceof XWPFSDTCell sdtCell) {
+                    text.append(sdtCell.getContent().getText());
                 }
                 if (i < cells.size() - 1) {
                     text.append("\t");

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTableCell.java
@@ -278,10 +278,10 @@ public class XWPFTableCell implements IBody, ICell {
         while (!(o instanceof CTP) && (cursor.toPrevSibling())) {
             o = cursor.getObject();
         }
-        if ((!(o instanceof CTP)) || o == p) {
+        if ((!(o instanceof CTP ctp)) || o == p) {
             paragraphs.add(0, newP);
         } else {
-            int pos = paragraphs.indexOf(getParagraph((CTP) o)) + 1;
+            int pos = paragraphs.indexOf(getParagraph(ctp)) + 1;
             paragraphs.add(pos, newP);
         }
         int i = 0;
@@ -315,10 +315,10 @@ public class XWPFTableCell implements IBody, ICell {
             while (!(o instanceof CTTbl) && (cursor.toPrevSibling())) {
                 o = cursor.getObject();
             }
-            if (!(o instanceof CTTbl)) {
+            if (!(o instanceof CTTbl tbl)) {
                 tables.add(0, newT);
             } else {
-                int pos = tables.indexOf(getTable((CTTbl) o)) + 1;
+                int pos = tables.indexOf(getTable(tbl)) + 1;
                 tables.add(pos, newT);
             }
             int i = 0;
@@ -533,8 +533,8 @@ public class XWPFTableCell implements IBody, ICell {
     public XWPFDocument getXWPFDocument() {
         if (xwpfDocument != null) {
             return xwpfDocument;
-        } else if (part instanceof XWPFTableCell) {
-            return getCellDocument((XWPFTableCell) part, 0);
+        } else if (part instanceof XWPFTableCell tableCell) {
+            return getCellDocument(tableCell, 0);
         } else if (part != null) {
             return part.getXWPFDocument();
         }


### PR DESCRIPTION
Mechanical, behavior-preserving modernization of poi-ooxml now that the build targets Java 17:

- pattern-matching `instanceof` in place of instanceof-then-cast (~150 sites across xslf, xwpf, xssf, xddf, xdgf, openxml4j, ooxml and poifs.crypt.dsig)
- arrow-form `switch` statements / switch expressions where cases had no fall-through or shared state (e.g. `SXSSFCell` accessors, `XSLFSheet.mapSchemeColor`, `XWPFRun`)
- `Stream.toList()` instead of `collect(Collectors.toList())` where the resulting list is never mutated (XDDF geometry/text, `ZipPackage`, `TSPTimeStampService`, `XSLFFontInfo`)

Deliberately left alone: switches with fall-through or shared `default` labels, instanceof checks where the subsequent cast targets a different variable/type, and `Collectors.toList()` results returned from public methods where callers might rely on mutability.

No public API signatures changed. `compileJava`/`compileTestJava` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)