### PR TITLE
Use more Java 17 idioms in poi-scratchpad

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/extractor/ole2/OLE2ScratchpadExtractorFactory.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/extractor/ole2/OLE2ScratchpadExtractorFactory.java
@@ -179,9 +179,9 @@ public class OLE2ScratchpadExtractorFactory implements ExtractorProvider {
             //} else if(ext instanceof PowerPointExtractor) {
             // Tricky, not stored directly in poifs
             // TODO
-        } else if (ext instanceof OutlookTextExtractor) {
+        } else if (ext instanceof OutlookTextExtractor outlookExtractor) {
             // Stored in the Attachment blocks
-            MAPIMessage msg = ((OutlookTextExtractor)ext).getMAPIMessage();
+            MAPIMessage msg = outlookExtractor.getMAPIMessage();
             for (AttachmentChunks attachment : msg.getAttachmentFiles()) {
                 if (attachment.getAttachData() != null) {
                     byte[] data = attachment.getAttachData().getValue();

--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusBrush.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusBrush.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
@@ -667,7 +666,7 @@ public class HemfPlusBrush {
             if (positions == null) {
                 setter.accept(null);
             } else {
-                setter.accept(IntStream.range(0, positions.length).boxed().map(sup).collect(Collectors.toList()));
+                setter.accept(IntStream.range(0, positions.length).boxed().map(sup).toList());
             }
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusPath.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/record/emfplus/HemfPlusPath.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.poi.common.usermodel.GenericRecord;
@@ -231,7 +230,7 @@ public class HemfPlusPath {
         private List<GenericRecord> getGenericPoints() {
             return IntStream.range(0, pathPoints.length).
                 mapToObj(this::getGenericPoint).
-                collect(Collectors.toList());
+                toList();
         }
 
         private GenericRecord getGenericPoint(final int idx) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/usermodel/HemfEmbeddedIterator.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/usermodel/HemfEmbeddedIterator.java
@@ -97,8 +97,8 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
             iter = iterStack.peek();
             while (iter.hasNext()) {
                 Object obj = iter.next();
-                if (obj instanceof EmfComment) {
-                    HemfComment.EmfCommentData cd = ((EmfComment)obj).getCommentData();
+                if (obj instanceof EmfComment comment) {
+                    HemfComment.EmfCommentData cd = comment.getCommentData();
                     if (
                         cd instanceof EmfCommentDataWMF ||
                         cd instanceof EmfCommentDataGeneric
@@ -107,16 +107,16 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
                         return true;
                     }
 
-                    if (cd instanceof EmfCommentDataMultiformats) {
-                        Iterator<?> iter2 = ((EmfCommentDataMultiformats)cd).getFormats().iterator();
+                    if (cd instanceof EmfCommentDataMultiformats mf) {
+                        Iterator<?> iter2 = mf.getFormats().iterator();
                         if (iter2.hasNext()) {
                             iterStack.push(iter2);
                             continue;
                         }
                     }
 
-                    if (cd instanceof EmfCommentDataPlus) {
-                        Iterator<?> iter2 = ((EmfCommentDataPlus)cd).getRecords().iterator();
+                    if (cd instanceof EmfCommentDataPlus cdp) {
+                        Iterator<?> iter2 = cdp.getRecords().iterator();
                         if (iter2.hasNext()) {
                             iter = iter2;
                             iterStack.push(iter2);
@@ -130,13 +130,13 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
                     return true;
                 }
 
-                if (obj instanceof EmfPlusObject && ((EmfPlusObject)obj).getObjectType() == EmfPlusObjectType.IMAGE) {
+                if (obj instanceof EmfPlusObject epo && epo.getObjectType() == EmfPlusObjectType.IMAGE) {
                     current = obj;
                     return true;
                 }
 
-                if (obj instanceof HwmfFill.WmfStretchDib) {
-                    HwmfBitmapDib bitmap = ((HwmfFill.WmfStretchDib) obj).getBitmap();
+                if (obj instanceof HwmfFill.WmfStretchDib dib) {
+                    HwmfBitmapDib bitmap = dib.getBitmap();
                     if (bitmap.isValid()) {
                         current = obj;
                         return true;
@@ -172,11 +172,10 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
     }
 
     private HwmfEmbedded checkEmfCommentDataWMF() {
-        if (!(current instanceof EmfComment && ((EmfComment)current).getCommentData() instanceof EmfCommentDataWMF)) {
+        if (!(current instanceof EmfComment comment && comment.getCommentData() instanceof EmfCommentDataWMF wmf)) {
             return null;
         }
 
-        EmfCommentDataWMF wmf = (EmfCommentDataWMF)((EmfComment)current).getCommentData();
         HwmfEmbedded emb = new HwmfEmbedded();
         emb.setEmbeddedType(HwmfEmbeddedType.WMF);
         emb.setData(wmf.getWMFData());
@@ -185,10 +184,9 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
     }
 
     private HwmfEmbedded checkEmfCommentDataGeneric() {
-        if (!(current instanceof EmfComment && ((EmfComment)current).getCommentData() instanceof EmfCommentDataGeneric)) {
+        if (!(current instanceof EmfComment comment && comment.getCommentData() instanceof EmfCommentDataGeneric cdg)) {
             return null;
         }
-        EmfCommentDataGeneric cdg = (EmfCommentDataGeneric)((EmfComment)current).getCommentData();
         HwmfEmbedded emb = new HwmfEmbedded();
         emb.setEmbeddedType(HwmfEmbeddedType.UNKNOWN);
         emb.setData(cdg.getPrivateData());
@@ -197,10 +195,9 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
     }
 
     private HwmfEmbedded checkEmfCommentDataFormat() {
-        if (!(current instanceof EmfCommentDataFormat)) {
+        if (!(current instanceof EmfCommentDataFormat cdf)) {
             return null;
         }
-        EmfCommentDataFormat cdf = (EmfCommentDataFormat)current;
         HwmfEmbedded emb = new HwmfEmbedded();
         boolean isEmf = (cdf.getSignature() == HemfComment.EmfFormatSignature.ENHMETA_SIGNATURE);
         emb.setEmbeddedType(isEmf ? HwmfEmbeddedType.EMF : HwmfEmbeddedType.EPS);
@@ -210,22 +207,21 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
     }
 
     private HwmfEmbedded checkWmfStretchDib() {
-        if (!(current instanceof HwmfFill.WmfStretchDib)) {
+        if (!(current instanceof HwmfFill.WmfStretchDib dib)) {
             return null;
         }
         HwmfEmbedded emb = new HwmfEmbedded();
-        emb.setData(((HwmfFill.WmfStretchDib) current).getBitmap().getBMPData());
+        emb.setData(dib.getBitmap().getBMPData());
         emb.setEmbeddedType(HwmfEmbeddedType.BMP);
         current = null;
         return emb;
     }
 
     private HwmfEmbedded checkEmfPlusObject() {
-        if (!(current instanceof EmfPlusObject)) {
+        if (!(current instanceof EmfPlusObject epo)) {
             return null;
         }
 
-        EmfPlusObject epo = (EmfPlusObject)current;
         assert(epo.getObjectType() == EmfPlusObjectType.IMAGE);
         EmfPlusImage img = epo.getObjectData();
         assert(img.getImageDataType() != null);
@@ -237,7 +233,7 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
 
         final HwmfEmbeddedType et;
         switch (img.getImageDataType()) {
-            case BITMAP:
+            case BITMAP -> {
                 if (img.getBitmapType() == EmfPlusBitmapDataType.COMPRESSED) {
                     et = switch (FileMagic.valueOf(emb.getRawData())) {
                         case JPEG -> HwmfEmbeddedType.JPEG;
@@ -250,18 +246,16 @@ public class HemfEmbeddedIterator implements Iterator<HwmfEmbedded> {
                     et = HwmfEmbeddedType.PNG;
                     compressGDIBitmap(img, emb, et);
                 }
-                break;
-            case METAFILE:
+            }
+            case METAFILE -> {
                 assert(img.getMetafileType() != null);
                 et = switch (img.getMetafileType()) {
                     case Wmf, WmfPlaceable -> HwmfEmbeddedType.WMF;
                     case Emf, EmfPlusDual, EmfPlusOnly -> HwmfEmbeddedType.EMF;
                     default -> HwmfEmbeddedType.UNKNOWN;
                 };
-                break;
-            default:
-                et = HwmfEmbeddedType.UNKNOWN;
-                break;
+            }
+            default -> et = HwmfEmbeddedType.UNKNOWN;
         }
         emb.setEmbeddedType(et);
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hemf/usermodel/HemfPicture.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hemf/usermodel/HemfPicture.java
@@ -107,10 +107,10 @@ public class HemfPicture implements Iterable<HemfRecord>, GenericRecord {
         List<HemfRecord> r = getRecords();
         if (r.isEmpty()) {
             throw new RecordFormatException("No records could be parsed - your .emf file is invalid");
-        } else if (!(r.get(0) instanceof HemfHeader)) {
+        } else if (!(r.get(0) instanceof HemfHeader hemfHeader)) {
             throw new RecordFormatException("Could not convert object of type " + r.get(0).getClass() + " + - your .emf file is invalid");
         } else {
-            return (HemfHeader)r.get(0);
+            return hemfHeader;
         }
     }
 
@@ -121,8 +121,8 @@ public class HemfPicture implements Iterable<HemfRecord>, GenericRecord {
             isParsed = true;
             HemfHeader[] header = new HemfHeader[1];
             new HemfRecordIterator(stream).forEachRemaining(r -> {
-                if (r instanceof HemfHeader) {
-                    header[0] = (HemfHeader) r;
+                if (r instanceof HemfHeader hemfHeader) {
+                    header[0] = hemfHeader;
                 }
                 r.setHeader(header[0]);
                 if (r instanceof HwmfCharsetAware charsetAware) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/MAPIDateAttribute.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/MAPIDateAttribute.java
@@ -76,8 +76,8 @@ public final class MAPIDateAttribute extends MAPIAttribute {
       if(attr == null) {
          return null;
       }
-      if(attr instanceof MAPIDateAttribute) {
-         return ((MAPIDateAttribute)attr).getDate();
+      if(attr instanceof MAPIDateAttribute dateAttribute) {
+         return dateAttribute.getDate();
       }
 
       LOG.atWarn().log("Warning, non date property found: {}", attr);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/MAPIStringAttribute.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/MAPIStringAttribute.java
@@ -70,11 +70,11 @@ public final class MAPIStringAttribute extends MAPIAttribute {
       if(attr == null) {
          return null;
       }
-      if(attr instanceof MAPIStringAttribute) {
-         return ((MAPIStringAttribute)attr).getDataString();
+      if(attr instanceof MAPIStringAttribute stringAttr) {
+         return stringAttr.getDataString();
       }
-      if(attr instanceof MAPIRtfAttribute) {
-         return ((MAPIRtfAttribute)attr).getDataString();
+      if(attr instanceof MAPIRtfAttribute rtfAttr) {
+         return rtfAttr.getDataString();
       }
 
       LOG.atWarn().log("Warning, non string property found: {}", attr);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/TNEFDateAttribute.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/TNEFDateAttribute.java
@@ -91,8 +91,8 @@ public final class TNEFDateAttribute extends TNEFAttribute {
       if(attr == null) {
          return null;
       }
-      if(attr instanceof TNEFDateAttribute) {
-         return ((TNEFDateAttribute)attr).getDate();
+      if(attr instanceof TNEFDateAttribute dateAttribute) {
+         return dateAttribute.getDate();
       }
 
       LOG.atWarn().log("Warning, non date property found: {}", attr);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/TNEFStringAttribute.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hmef/attribute/TNEFStringAttribute.java
@@ -74,8 +74,8 @@ public final class TNEFStringAttribute extends TNEFAttribute {
       if(attr == null) {
          return null;
       }
-      if(attr instanceof TNEFStringAttribute) {
-         return ((TNEFStringAttribute)attr).getString();
+      if(attr instanceof TNEFStringAttribute stringAttribute) {
+         return stringAttribute.getString();
       }
 
       LOG.atWarn().log("Warning, non string property found: {}", attr);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hmef/dev/HMEFDumper.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hmef/dev/HMEFDumper.java
@@ -133,11 +133,11 @@ public final class HMEFDumper {
          // Print the contents
          String indent = "  ";
 
-         if(attr instanceof TNEFStringAttribute) {
-            System.out.println(indent + indent + indent + ((TNEFStringAttribute)attr).getString());
+         if(attr instanceof TNEFStringAttribute stringAttr) {
+            System.out.println(indent + indent + indent + stringAttr.getString());
          }
-         if(attr instanceof TNEFDateAttribute) {
-            System.out.println(indent + indent + indent + ((TNEFDateAttribute)attr).getDate());
+         if(attr instanceof TNEFDateAttribute dateAttr) {
+            System.out.println(indent + indent + indent + dateAttr.getDate());
          }
 
          System.out.println(indent + "Data of length " + attr.getData().length);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hmef/extractor/HMEFContentsExtractor.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hmef/extractor/HMEFContentsExtractor.java
@@ -97,9 +97,9 @@ public final class HMEFContentsExtractor {
         }
 
         try (OutputStream fout = Files.newOutputStream(dest.toPath())) {
-            if (body instanceof MAPIStringAttribute) {
+            if (body instanceof MAPIStringAttribute stringAttribute) {
                 // Save in a predictable encoding, not raw bytes
-                String text = ((MAPIStringAttribute) body).getDataString();
+                String text = stringAttribute.getDataString();
                 fout.write(text.getBytes(StringUtil.UTF8));
             } else {
                 // Save the raw bytes, should be raw RTF

--- a/poi-scratchpad/src/main/java/org/apache/poi/hpbf/extractor/PublisherTextExtractor.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hpbf/extractor/PublisherTextExtractor.java
@@ -68,8 +68,7 @@ public final class PublisherTextExtractor implements POIOLE2TextExtractor {
         // Get the text from the Quill Contents
         QCBit[] bits = doc.getQuillContents().getBits();
         for (QCBit bit1 : bits) {
-            if (bit1 instanceof QCTextBit) {
-                QCTextBit t = (QCTextBit) bit1;
+            if (bit1 instanceof QCTextBit t) {
                 text.append(t.getText().replace('\r', '\n'));
             }
         }
@@ -81,8 +80,7 @@ public final class PublisherTextExtractor implements POIOLE2TextExtractor {
         //  how to tie that together.
         if(hyperlinksByDefault) {
             for (QCBit bit : bits) {
-                if (bit instanceof Type12) {
-                    Type12 hyperlinks = (Type12) bit;
+                if (bit instanceof Type12 hyperlinks) {
                     for (int j = 0; j < hyperlinks.getNumberOfHyperlinks(); j++) {
                         text.append("<");
                         text.append(hyperlinks.getHyperlink(j));

--- a/poi-scratchpad/src/main/java/org/apache/poi/hpbf/model/HPBFPart.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hpbf/model/HPBFPart.java
@@ -59,10 +59,10 @@ public abstract class HPBFPart {
         for(int i=0; i<path.length-1; i++) {
             try {
                 Entry entry = dir.getEntry(path[i]);
-                if (!(entry instanceof DirectoryNode)) {
+                if (!(entry instanceof DirectoryNode node)) {
                     throw new IllegalArgumentException("Had unexpected type of entry for path: " + path[i] + ": " + entry);
                 }
-                dir = (DirectoryNode) entry;
+                dir = node;
             } catch (FileNotFoundException e) {
                 throw new IllegalArgumentException("File invalid - failed to find directory entry '"
                         + path[i] + "': " + e);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/PPDrawingTextListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/PPDrawingTextListing.java
@@ -47,11 +47,10 @@ public final class PPDrawingTextListing {
                 Record[] children = records[i].getChildRecords();
                 if (children != null && children.length != 0) {
                     for (int j = 0; j < children.length; j++) {
-                        if (children[j] instanceof PPDrawing) {
+                        if (children[j] instanceof PPDrawing ppd) {
                             System.out.println("Found PPDrawing at " + j + " in top level record " + i + " (" + records[i].getRecordType() + ")");
 
                             // Look for EscherTextboxWrapper's
-                            PPDrawing ppd = (PPDrawing) children[j];
                             EscherTextboxWrapper[] wrappers = ppd.getTextboxWrappers();
                             System.out.println("  Has " + wrappers.length + " textbox wrappers within");
 
@@ -64,12 +63,10 @@ public final class PPDrawingTextListing {
                                 Record[] pptatoms = tbw.getChildRecords();
                                 for (Record pptatom : pptatoms) {
                                     String text = null;
-                                    if (pptatom instanceof TextBytesAtom) {
-                                        TextBytesAtom tba = (TextBytesAtom) pptatom;
+                                    if (pptatom instanceof TextBytesAtom tba) {
                                         text = tba.getText();
                                     }
-                                    if (pptatom instanceof TextCharsAtom) {
-                                        TextCharsAtom tca = (TextCharsAtom) pptatom;
+                                    if (pptatom instanceof TextCharsAtom tca) {
                                         text = tca.getText();
                                     }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SLWTListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SLWTListing.java
@@ -42,8 +42,7 @@ public final class SLWTListing {
         // Find the documents, and then their SLWT
         Record[] records = ss.getRecords();
         for(int i=0; i<records.length; i++) {
-            if(records[i] instanceof Document) {
-                Document doc = (Document)records[i];
+            if(records[i] instanceof Document doc) {
                 SlideListWithText[] slwts = doc.getSlideListWithTexts();
 
                 System.out.println("Document at " + i + " had " + slwts.length + " SlideListWithTexts");

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SLWTTextListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SLWTTextListing.java
@@ -48,14 +48,13 @@ public final class SLWTTextListing {
                 Record docRecord = records[i];
                 Record[] docChildren = docRecord.getChildRecords();
                 for(int j=0; j<docChildren.length; j++) {
-                    if(docChildren[j] instanceof SlideListWithText) {
+                    if(docChildren[j] instanceof SlideListWithText slwt) {
                         System.out.println("Found SLWT at pos " + j + " in the Document at " + i);
                         System.out.println("  Has " + docChildren[j].getChildRecords().length + " children");
 
                         // Grab the SlideAtomSet's, which contain
                         //  a SlidePersistAtom and then a bunch of text
                         //  + related records
-                        SlideListWithText slwt = (SlideListWithText)docChildren[j];
                         SlideListWithText.SlideAtomsSet[] thisSets = slwt.getSlideAtomsSets();
                         System.out.println("  Has " + thisSets.length + " AtomSets in it");
 
@@ -69,12 +68,10 @@ public final class SLWTTextListing {
                             Record[] slwtc = thisSets[k].getSlideRecords();
                             for (Record record : slwtc) {
                                 String text = null;
-                                if (record instanceof TextBytesAtom) {
-                                    TextBytesAtom tba = (TextBytesAtom) record;
+                                if (record instanceof TextBytesAtom tba) {
                                     text = tba.getText();
                                 }
-                                if (record instanceof TextCharsAtom) {
-                                    TextCharsAtom tca = (TextCharsAtom) record;
+                                if (record instanceof TextCharsAtom tca) {
                                     text = tca.getText();
                                 }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SlideAndNotesAtomListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SlideAndNotesAtomListing.java
@@ -49,16 +49,14 @@ public final class SlideAndNotesAtomListing {
             Record r = records[i];
 
             // When we find them, print out their IDs
-            if(r instanceof Slide) {
-                Slide s = (Slide)r;
+            if(r instanceof Slide s) {
                 SlideAtom sa = s.getSlideAtom();
                 System.out.println("Found Slide at " + i);
                 System.out.println("  Slide's master ID is " + sa.getMasterID());
                 System.out.println("  Slide's notes ID is  " + sa.getNotesID());
                 System.out.println();
             }
-            if(r instanceof Notes) {
-                Notes n = (Notes)r;
+            if(r instanceof Notes n) {
                 NotesAtom na = n.getNotesAtom();
                 System.out.println("Found Notes at " + i);
                 System.out.println("  Notes ID is " + na.getSlideID());

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SlideIdListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SlideIdListing.java
@@ -62,8 +62,8 @@ public final class SlideIdListing {
             // Grab any records that interest us
             Document document = null;
             for (Record latestRecord : latestRecords) {
-                if (latestRecord instanceof Document) {
-                    document = (Document) latestRecord;
+                if (latestRecord instanceof Document doc) {
+                    document = doc;
                 }
             }
 
@@ -76,8 +76,7 @@ public final class SlideIdListing {
             for (SlideListWithText slwt : slwts) {
                 Record[] cr = slwt.getChildRecords();
                 for (org.apache.poi.hslf.record.Record record : cr) {
-                    if (record instanceof SlidePersistAtom) {
-                        SlidePersistAtom spa = (SlidePersistAtom) record;
+                    if (record instanceof SlidePersistAtom spa) {
                         System.out.println("SlidePersistAtom knows about slide:");
                         System.out.println("\t" + spa.getRefID());
                         System.out.println("\t" + spa.getSlideIdentifier());
@@ -89,8 +88,7 @@ public final class SlideIdListing {
 
             // Look for latest core records that are slides or notes
             for (int i = 0; i < latestRecords.length; i++) {
-                if (latestRecords[i] instanceof Slide) {
-                    Slide s = (Slide) latestRecords[i];
+                if (latestRecords[i] instanceof Slide s) {
                     SlideAtom sa = s.getSlideAtom();
                     System.out.println("Found the latest version of a slide record:");
                     System.out.println("\tCore ID is " + s.getSheetId());
@@ -102,8 +100,7 @@ public final class SlideIdListing {
             }
             System.out.println();
             for (int i = 0; i < latestRecords.length; i++) {
-                if (latestRecords[i] instanceof Notes) {
-                    Notes n = (Notes) latestRecords[i];
+                if (latestRecords[i] instanceof Notes n) {
                     NotesAtom na = n.getNotesAtom();
                     System.out.println("Found the latest version of a notes record:");
                     System.out.println("\tCore ID is " + n.getSheetId());

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SlideShowRecordDumper.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/SlideShowRecordDumper.java
@@ -165,10 +165,10 @@ public final class SlideShowRecordDumper {
     }
 
     public void printEscherRecord(EscherRecord er, int indent) {
-        if (er instanceof EscherContainerRecord) {
-            printEscherContainerRecord( (EscherContainerRecord)er, indent );
-        } else if (er instanceof EscherTextboxRecord) {
-            printEscherTextBox( (EscherTextboxRecord)er, indent );
+        if (er instanceof EscherContainerRecord ecr) {
+            printEscherContainerRecord( ecr, indent );
+        } else if (er instanceof EscherTextboxRecord etr) {
+            printEscherTextBox( etr, indent );
         } else {
             ps.print( tabs.substring(0, indent) );
             ps.println(er);
@@ -182,19 +182,18 @@ public final class SlideShowRecordDumper {
         EscherTextboxWrapper etw = new EscherTextboxWrapper(tbRecord);
         Record prevChild = null;
         for (Record child : etw.getChildRecords()) {
-            if (child instanceof StyleTextPropAtom) {
+            if (child instanceof StyleTextPropAtom tsp) {
                 // need preceding Text[Chars|Bytes]Atom to initialize the data structure
                 String text;
-                if (prevChild instanceof TextCharsAtom) {
-                    text = ((TextCharsAtom)prevChild).getText();
-                } else if (prevChild instanceof TextBytesAtom) {
-                    text = ((TextBytesAtom)prevChild).getText();
+                if (prevChild instanceof TextCharsAtom tca) {
+                    text = tca.getText();
+                } else if (prevChild instanceof TextBytesAtom tba) {
+                    text = tba.getText();
                 } else {
                     ps.println(ind+"Error! Couldn't find preceding TextAtom for style");
                     continue;
                 }
 
-                StyleTextPropAtom tsp = (StyleTextPropAtom)child;
                 tsp.setParentTextSize(text.length());
             }
             ps.println(ind+ child);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/TextStyleListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/TextStyleListing.java
@@ -103,8 +103,7 @@ public final class TextStyleListing {
             System.out.println("          = " + tp.getValue());
             System.out.println("          @ " + tp.getMask());
 
-            if(tp instanceof BitMaskTextProp) {
-                BitMaskTextProp bmtp = (BitMaskTextProp)tp;
+            if(tp instanceof BitMaskTextProp bmtp) {
                 String[] subPropNames = bmtp.getSubPropNames();
                 boolean[] subPropMatches = bmtp.getSubPropMatches();
                 for(int j=0; j<subPropNames.length; j++) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/UserEditAndPersistListing.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/UserEditAndPersistListing.java
@@ -89,8 +89,7 @@ public final class UserEditAndPersistListing {
             pos = 0;
             // Now look for UserEditAtoms
             for (org.apache.poi.hslf.record.Record r : ss.getRecords()) {
-                if (r instanceof UserEditAtom) {
-                    UserEditAtom uea = (UserEditAtom) r;
+                if (r instanceof UserEditAtom uea) {
                     System.out.println("Found UserEditAtom at " + pos + " (" + Integer.toHexString(pos) + ")");
                     System.out.println("  lastUserEditAtomOffset = " + uea.getLastUserEditAtomOffset());
                     System.out.println("  persistPointersOffset  = " + uea.getPersistPointersOffset());

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/ActiveXShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/ActiveXShape.java
@@ -134,8 +134,7 @@ public final class ActiveXShape extends HSLFPictureShape {
         }
 
         for (Record ch : lst.getChildRecords()) {
-            if(ch instanceof ExControl){
-                ExControl c = (ExControl)ch;
+            if(ch instanceof ExControl c){
                 if(c.getExOleObjAtom().getObjID() == idx){
                     return c;
                 }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/HeadersFooters.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/HeadersFooters.java
@@ -65,9 +65,9 @@ public final class HeadersFooters {
 
         if (hdd == null) {
             for (Record ch : doc.getChildRecords()) {
-                if (ch instanceof HeadersFootersContainer
-                    && ((HeadersFootersContainer) ch).getOptions() == headerFooterType) {
-                    hdd = (HeadersFootersContainer) ch;
+                if (ch instanceof HeadersFootersContainer hfc
+                    && hfc.getOptions() == headerFooterType) {
+                    hdd = hfc;
                     break;
                 }
             }
@@ -275,7 +275,7 @@ public final class HeadersFooters {
         boolean visible;
         if(_ppt2007){
             HSLFSimpleShape ss = _sheet.getPlaceholder(placeholderId);
-            visible = ss instanceof HSLFTextShape && ((HSLFTextShape)ss).getText() != null;
+            visible = ss instanceof HSLFTextShape textShape && textShape.getText() != null;
         } else {
             visible = _container.getHeadersFootersAtom().getFlag(flag);
         }
@@ -286,7 +286,7 @@ public final class HeadersFooters {
         String text;
         if (_ppt2007) {
             HSLFSimpleShape ss = _sheet.getPlaceholder(ph);
-            text = (ss instanceof HSLFTextShape) ? ((HSLFTextShape)ss).getText() : null;
+            text = (ss instanceof HSLFTextShape textShape) ? textShape.getText() : null;
 
             // default text in master placeholders is not visible
             if("*".equals(text)) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/MovieShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/MovieShape.java
@@ -161,8 +161,7 @@ public final class MovieShape extends HSLFPictureShape {
 
         Record[]  r = lst.getChildRecords();
         for (Record record : r) {
-            if (record instanceof ExMCIMovie) {
-                ExMCIMovie mci = (ExMCIMovie) record;
+            if (record instanceof ExMCIMovie mci) {
                 ExVideoContainer exVideo = mci.getExVideo();
                 int objectId = exVideo.getExMediaAtom().getObjectId();
                 if (objectId == idx) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/textproperties/HSLFTabStop.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/textproperties/HSLFTabStop.java
@@ -100,10 +100,9 @@ public class HSLFTabStop implements TabStop, Duplicatable, GenericRecord {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof HSLFTabStop)) {
+        if (!(obj instanceof HSLFTabStop other)) {
             return false;
         }
-        HSLFTabStop other = (HSLFTabStop) obj;
         if (position != other.position) {
             return false;
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/textproperties/HSLFTabStopPropCollection.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/textproperties/HSLFTabStopPropCollection.java
@@ -122,10 +122,9 @@ public class HSLFTabStopPropCollection extends TextProp {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof HSLFTabStopPropCollection)) {
+        if (!(obj instanceof HSLFTabStopPropCollection other)) {
             return false;
         }
-        HSLFTabStopPropCollection other = (HSLFTabStopPropCollection) obj;
         if (!super.equals(other)) {
             return false;
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/textproperties/TextPropCollection.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/model/textproperties/TextPropCollection.java
@@ -236,8 +236,8 @@ public class TextPropCollection implements GenericRecord, Duplicatable {
                 // Bingo, data contains this property
                 TextProp prop = tp.copy();
                 int val = 0;
-                if (prop instanceof HSLFTabStopPropCollection) {
-                    ((HSLFTabStopPropCollection)prop).parseProperty(data, dataOffset+bytesPassed);
+                if (prop instanceof HSLFTabStopPropCollection tspc) {
+                    tspc.parseProperty(data, dataOffset+bytesPassed);
                 } else if (prop.getSize() == 2) {
                     val = LittleEndian.getShort(data,dataOffset+bytesPassed);
                 } else if(prop.getSize() == 4) {
@@ -248,8 +248,8 @@ public class TextPropCollection implements GenericRecord, Duplicatable {
                     continue;
                 }
 
-                if (prop instanceof BitMaskTextProp) {
-                    ((BitMaskTextProp)prop).setValueWithMask(val, containsField);
+                if (prop instanceof BitMaskTextProp bmtp) {
+                    bmtp.setValueWithMask(val, containsField);
                 } else if (!(prop instanceof HSLFTabStopPropCollection)) {
                     prop.setValue(val);
                 }
@@ -317,8 +317,8 @@ public class TextPropCollection implements GenericRecord, Duplicatable {
                 Record.writeLittleEndian((short)val,o);
             } else if (textProp.getSize() == 4) {
                 Record.writeLittleEndian(val,o);
-            } else if (textProp instanceof HSLFTabStopPropCollection) {
-                ((HSLFTabStopPropCollection)textProp).writeProperty(o);
+            } else if (textProp instanceof HSLFTabStopPropCollection tspc) {
+                tspc.writeProperty(o);
             }
         }
     }
@@ -364,8 +364,7 @@ public class TextPropCollection implements GenericRecord, Duplicatable {
             out.append("    ");
             out.append(p.toString());
             out.append("\n");
-            if (p instanceof BitMaskTextProp) {
-                BitMaskTextProp bm = (BitMaskTextProp)p;
+            if (p instanceof BitMaskTextProp bm) {
                 int i = 0;
                 for (String s : bm.getSubPropNames()) {
                     if (bm.getSubPropMatches()[i]) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/AnimationInfo.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/AnimationInfo.java
@@ -55,8 +55,8 @@ public final class AnimationInfo extends RecordContainer {
 
         // First child should be the ExMediaAtom
         final Record child = _children[0];
-        if(child instanceof AnimationInfoAtom) {
-            animationAtom = (AnimationInfoAtom) child;
+        if(child instanceof AnimationInfoAtom infoAtom) {
+            animationAtom = infoAtom;
         } else {
             LOG.atError().log("First child record wasn't a AnimationInfoAtom, was of type {}", box(child.getRecordType()));
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Comment2000.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Comment2000.java
@@ -125,8 +125,8 @@ public final class Comment2000 extends RecordContainer {
                     case 2: authorInitialsRecord = cs; break;
                     default: break;
                 }
-            } else if (r instanceof Comment2000Atom){
-                commentAtom = (Comment2000Atom)r;
+            } else if (r instanceof Comment2000Atom atom){
+                commentAtom = atom;
             } else {
                 LOG.atWarn().log("Unexpected record with type={} in Comment2000: {}", box(r.getRecordType()),r.getClass().getName());
             }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Document.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Document.java
@@ -131,10 +131,10 @@ public final class Document extends PositionDependentRecordContainer
         _children = Record.findChildRecords(source,start+8,len-8);
 
         // Our first one should be a document atom
-        if(! (_children[0] instanceof DocumentAtom)) {
+        if(! (_children[0] instanceof DocumentAtom docAtom)) {
             throw new IllegalStateException("The first child of a Document must be a DocumentAtom");
         }
-        documentAtom = (DocumentAtom)_children[0];
+        documentAtom = docAtom;
 
         // Find how many SlideListWithTexts we have
         // Also, grab the Environment and PPDrawing records
@@ -144,14 +144,14 @@ public final class Document extends PositionDependentRecordContainer
             if(_children[i] instanceof SlideListWithText) {
                 slwtcount++;
             }
-            if(_children[i] instanceof Environment) {
-                environment = (Environment)_children[i];
+            if(_children[i] instanceof Environment env) {
+                environment = env;
             }
-            if(_children[i] instanceof PPDrawingGroup) {
-                ppDrawing = (PPDrawingGroup)_children[i];
+            if(_children[i] instanceof PPDrawingGroup group) {
+                ppDrawing = group;
             }
-            if(_children[i] instanceof ExObjList) {
-                exObjList = (ExObjList)_children[i];
+            if(_children[i] instanceof ExObjList list) {
+                exObjList = list;
             }
         }
 
@@ -169,8 +169,8 @@ public final class Document extends PositionDependentRecordContainer
         slwts = new SlideListWithText[slwtcount];
         slwtcount = 0;
         for(int i=1; i<_children.length; i++) {
-            if(_children[i] instanceof SlideListWithText) {
-                slwts[slwtcount] = (SlideListWithText)_children[i];
+            if(_children[i] instanceof SlideListWithText slwt) {
+                slwts[slwtcount] = slwt;
                 slwtcount++;
             }
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/DocumentEncryptionAtom.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/DocumentEncryptionAtom.java
@@ -121,15 +121,15 @@ public final class DocumentEncryptionAtom extends PositionDependentRecordAtom {
         bos.writeInt(ei.getEncryptionFlags());
 
         final EncryptionHeader header = ei.getHeader();
-        if (!(header instanceof CryptoAPIEncryptionHeader)) {
+        if (!(header instanceof CryptoAPIEncryptionHeader capiHeader)) {
             throw new IllegalStateException("Had unexpected type of header: " + header.getClass());
         }
-        ((CryptoAPIEncryptionHeader) header).write(bos);
+        capiHeader.write(bos);
         final EncryptionVerifier verifier = ei.getVerifier();
-        if (!(verifier instanceof CryptoAPIEncryptionVerifier)) {
+        if (!(verifier instanceof CryptoAPIEncryptionVerifier capiVerifier)) {
             throw new IllegalStateException("Had unexpected type of verifier: " + verifier.getClass());
         }
-        ((CryptoAPIEncryptionVerifier) verifier).write(bos);
+        capiVerifier.write(bos);
 
         // Header
         LittleEndian.putInt(_header, 4, bos.getWriteIndex());

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Environment.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Environment.java
@@ -53,10 +53,10 @@ public final class Environment extends PositionDependentRecordContainer
 
         // Find our FontCollection record
         for (Record child : _children) {
-            if (child instanceof FontCollection) {
-                fontCollection = (FontCollection) child;
-            } else if (child instanceof TxMasterStyleAtom) {
-                txmaster = (TxMasterStyleAtom) child;
+            if (child instanceof FontCollection fc) {
+                fontCollection = fc;
+            } else if (child instanceof TxMasterStyleAtom atom) {
+                txmaster = atom;
             }
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/EscherTextboxWrapper.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/EscherTextboxWrapper.java
@@ -56,7 +56,7 @@ public final class EscherTextboxWrapper extends RecordContainer {
         byte[] data = _escherRecord.getData();
         _children = Record.findChildRecords(data,0,data.length);
         for (org.apache.poi.hslf.record.Record r : this._children) {
-            if (r instanceof StyleTextPropAtom) { this.styleTextPropAtom = (StyleTextPropAtom) r; }
+            if (r instanceof StyleTextPropAtom stpa) { this.styleTextPropAtom = stpa; }
         }
     }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExEmbed.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExEmbed.java
@@ -104,29 +104,28 @@ public class ExEmbed extends RecordContainer {
 
         // First child should be the ExHyperlinkAtom
         Record child = _children[0];
-        if(child instanceof ExEmbedAtom) {
-            embedAtom = (ExEmbedAtom) child;
+        if(child instanceof ExEmbedAtom atom) {
+            embedAtom = atom;
         } else {
             LOG.atError().log("First child record wasn't a ExEmbedAtom, was of type {}", box(child.getRecordType()));
         }
 
         // Second child should be the ExOleObjAtom
         child = _children[1];
-        if (child instanceof ExOleObjAtom) {
-            oleObjAtom = (ExOleObjAtom) child;
+        if (child instanceof ExOleObjAtom atom) {
+            oleObjAtom = atom;
         } else {
             LOG.atError().log("Second child record wasn't a ExOleObjAtom, was of type {}", box(child.getRecordType()));
         }
 
         for (int i = 2; i < _children.length; i++) {
-            if (_children[i] instanceof CString){
-                final CString cs = (CString)_children[i];
+            if (_children[i] instanceof CString cs){
                 final int opts = cs.getOptions() >> 4;
                 switch(opts){
-                    case 0x1: menuName = cs; break;
-                    case 0x2: progId = cs; break;
-                    case 0x3: clipboardName = cs; break;
-                    default: break;
+                    case 0x1 -> menuName = cs;
+                    case 0x2 -> progId = cs;
+                    case 0x3 -> clipboardName = cs;
+                    default -> { }
                 }
             }
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExHyperlink.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExHyperlink.java
@@ -116,17 +116,17 @@ public class ExHyperlink extends RecordContainer {
 
         // First child should be the ExHyperlinkAtom
         Record child = _children[0];
-        if(child instanceof ExHyperlinkAtom) {
-            linkAtom = (ExHyperlinkAtom) child;
+        if(child instanceof ExHyperlinkAtom hyperlinkAtom) {
+            linkAtom = hyperlinkAtom;
         } else {
             LOG.atError().log("First child record wasn't a ExHyperlinkAtom, was of type {}", box(child.getRecordType()));
         }
 
         for (int i = 1; i < _children.length; i++) {
             child = _children[i];
-            if (child instanceof CString){
-                if ( linkDetailsA == null) linkDetailsA = (CString) child;
-                else linkDetailsB = (CString) child;
+            if (child instanceof CString cs){
+                if ( linkDetailsA == null) linkDetailsA = cs;
+                else linkDetailsB = cs;
             } else {
                 LOG.atError().log("Record after ExHyperlinkAtom wasn't a CString, was of type {}", box(child.getRecordType()));
             }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExMCIMovie.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExMCIMovie.java
@@ -69,8 +69,8 @@ public class ExMCIMovie extends RecordContainer { // TODO - instantiable supercl
 
         // First child should be the ExVideoContainer
         final Record child = _children[0];
-        if (child instanceof ExVideoContainer) {
-            exVideo = (ExVideoContainer) child;
+        if (child instanceof ExVideoContainer videoContainer) {
+            exVideo = videoContainer;
         } else {
             LOG.atError().log("First child record wasn't a ExVideoContainer, was of type {}", box(child.getRecordType()));
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExObjList.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExObjList.java
@@ -44,8 +44,8 @@ public class ExObjList extends RecordContainer {
     public ExHyperlink[] getExHyperlinks() {
         ArrayList<ExHyperlink> links = new ArrayList<>();
         for (Record child : _children) {
-            if (child instanceof ExHyperlink) {
-                links.add((ExHyperlink) child);
+            if (child instanceof ExHyperlink link) {
+                links.add(link);
             }
         }
 
@@ -71,8 +71,8 @@ public class ExObjList extends RecordContainer {
      */
     private void findInterestingChildren() {
         // First child should be the atom
-        if(_children[0] instanceof ExObjListAtom) {
-            exObjListAtom = (ExObjListAtom)_children[0];
+        if(_children[0] instanceof ExObjListAtom atom) {
+            exObjListAtom = atom;
         } else {
             throw new IllegalStateException("First child record wasn't a ExObjListAtom, was of type " + _children[0].getRecordType());
         }
@@ -115,8 +115,7 @@ public class ExObjList extends RecordContainer {
      */
     public ExHyperlink get(int id){
         for (Record child : _children) {
-            if (child instanceof ExHyperlink) {
-                ExHyperlink rec = (ExHyperlink) child;
+            if (child instanceof ExHyperlink rec) {
                 if (rec.getExHyperlinkAtom() != null &&
                         rec.getExHyperlinkAtom().getNumber() == id) {
                     return rec;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExVideoContainer.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/ExVideoContainer.java
@@ -57,14 +57,14 @@ public final class ExVideoContainer extends RecordContainer {
 
         // First child should be the ExMediaAtom
         Record child = _children[0];
-        if(child instanceof ExMediaAtom) {
-            mediaAtom = (ExMediaAtom) child;
+        if(child instanceof ExMediaAtom atom) {
+            mediaAtom = atom;
         } else {
             LOG.atError().log("First child record wasn't a ExMediaAtom, was of type {}", box(child.getRecordType()));
         }
         child = _children[1];
-        if(child instanceof CString) {
-            pathAtom = (CString) child;
+        if(child instanceof CString cs) {
+            pathAtom = cs;
         } else {
             LOG.atError().log("Second child record wasn't a CString, was of type {}", box(child.getRecordType()));
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/FontCollection.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/FontCollection.java
@@ -52,11 +52,10 @@ public final class FontCollection extends RecordContainer {
         _children = Record.findChildRecords(source,start+8,len-8);
 
         for (org.apache.poi.hslf.record.Record r : _children){
-            if(r instanceof FontEntityAtom) {
-                HSLFFontInfo fi = new HSLFFontInfo((FontEntityAtom) r);
+            if(r instanceof FontEntityAtom fea) {
+                HSLFFontInfo fi = new HSLFFontInfo(fea);
                 fonts.put(fi.getIndex(), fi);
-            } else if (r instanceof FontEmbeddedData) {
-                FontEmbeddedData fed = (FontEmbeddedData)r;
+            } else if (r instanceof FontEmbeddedData fed) {
                 FontHeader fontHeader = fed.getFontHeader();
                 HSLFFontInfo fi = addFont(fontHeader);
                 fi.addFacet(fed);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/HeadersFootersContainer.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/HeadersFootersContainer.java
@@ -73,24 +73,15 @@ public final class HeadersFootersContainer extends RecordContainer {
      */
     private void findInterestingChildren() {
         for (Record child : _children) {
-            if (child instanceof HeadersFootersAtom) {
-                hdAtom = (HeadersFootersAtom) child;
-            } else if (child instanceof CString) {
-                CString cs = (CString) child;
+            if (child instanceof HeadersFootersAtom atom) {
+                hdAtom = atom;
+            } else if (child instanceof CString cs) {
                 int opts = cs.getOptions() >> 4;
                 switch (opts) {
-                    case USERDATEATOM:
-                        csDate = cs;
-                        break;
-                    case HEADERATOM:
-                        csHeader = cs;
-                        break;
-                    case FOOTERATOM:
-                        csFooter = cs;
-                        break;
-                    default:
-                        LOG.atWarn().log("Unexpected CString.Options in HeadersFootersContainer: {}", box(opts));
-                        break;
+                    case USERDATEATOM -> csDate = cs;
+                    case HEADERATOM -> csHeader = cs;
+                    case FOOTERATOM -> csFooter = cs;
+                    default -> LOG.atWarn().log("Unexpected CString.Options in HeadersFootersContainer: {}", box(opts));
                 }
             } else {
                 LOG.atWarn().log("Unexpected record in HeadersFootersContainer: {}", child);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/InteractiveInfo.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/InteractiveInfo.java
@@ -58,12 +58,12 @@ public class InteractiveInfo extends RecordContainer {
      */
     private void findInterestingChildren() {
         // First child should be the InteractiveInfoAtom
-        if (_children == null || _children.length == 0 || !(_children[0] instanceof InteractiveInfoAtom)) {
+        if (_children == null || _children.length == 0 || !(_children[0] instanceof InteractiveInfoAtom atom)) {
             LOG.atWarn().log("First child record wasn't a InteractiveInfoAtom - leaving this atom in an invalid state...");
             return;
         }
 
-        infoAtom = (InteractiveInfoAtom)_children[0];
+        infoAtom = atom;
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/MainMaster.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/MainMaster.java
@@ -65,18 +65,18 @@ public final class MainMaster extends SheetContainer {
         ArrayList<ColorSchemeAtom> clr = new ArrayList<>();
         // Find the interesting ones in there
         for (Record child : _children) {
-            if (child instanceof SlideAtom) {
-                slideAtom = (SlideAtom) child;
-            } else if (child instanceof PPDrawing) {
-                ppDrawing = (PPDrawing) child;
-            } else if (child instanceof TxMasterStyleAtom) {
-                tx.add((TxMasterStyleAtom) child);
-            } else if (child instanceof ColorSchemeAtom) {
-                clr.add((ColorSchemeAtom) child);
+            if (child instanceof SlideAtom atom) {
+                slideAtom = atom;
+            } else if (child instanceof PPDrawing drawing) {
+                ppDrawing = drawing;
+            } else if (child instanceof TxMasterStyleAtom atom) {
+                tx.add(atom);
+            } else if (child instanceof ColorSchemeAtom atom) {
+                clr.add(atom);
             }
 
-            if (ppDrawing != null && child instanceof ColorSchemeAtom) {
-                _colorScheme = (ColorSchemeAtom) child;
+            if (ppDrawing != null && child instanceof ColorSchemeAtom csa) {
+                _colorScheme = csa;
             }
 
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Notes.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Notes.java
@@ -59,14 +59,14 @@ public final class Notes extends SheetContainer
 
         // Find the interesting ones in there
         for (Record child : _children) {
-            if (child instanceof NotesAtom) {
-                notesAtom = (NotesAtom) child;
+            if (child instanceof NotesAtom atom) {
+                notesAtom = atom;
             }
-            if (child instanceof PPDrawing) {
-                ppDrawing = (PPDrawing) child;
+            if (child instanceof PPDrawing drawing) {
+                ppDrawing = drawing;
             }
-            if (ppDrawing != null && child instanceof ColorSchemeAtom) {
-                _colorScheme = (ColorSchemeAtom) child;
+            if (ppDrawing != null && child instanceof ColorSchemeAtom csa) {
+                _colorScheme = csa;
             }
         }
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Record.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Record.java
@@ -198,8 +198,7 @@ public abstract class Record implements GenericRecord
         // Handling for special kinds of records follow
 
         // If it's a position aware record, tell it where it is
-        if(toReturn instanceof PositionDependentRecord) {
-            PositionDependentRecord pdr = (PositionDependentRecord)toReturn;
+        if(toReturn instanceof PositionDependentRecord pdr) {
             pdr.setLastOnDiskOffset(start);
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/RecordContainer.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/RecordContainer.java
@@ -260,12 +260,12 @@ public abstract class RecordContainer extends Record
         // Loop over child records, looking for interesting ones
         for (org.apache.poi.hslf.record.Record record : br.getChildRecords()) {
             // Tell parent aware records of their parent
-            if (record instanceof ParentAwareRecord) {
-                ((ParentAwareRecord) record).setParentRecord(br);
+            if (record instanceof ParentAwareRecord par) {
+                par.setParentRecord(br);
             }
             // Walk on down for the case of container records
-            if (record instanceof RecordContainer) {
-                handleParentAwareRecords((RecordContainer)record);
+            if (record instanceof RecordContainer rc) {
+                handleParentAwareRecords(rc);
             }
         }
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Slide.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Slide.java
@@ -62,14 +62,14 @@ public final class Slide extends SheetContainer
 
         // Find the interesting ones in there
         for (Record child : _children) {
-            if (child instanceof SlideAtom) {
-                slideAtom = (SlideAtom) child;
-            } else if (child instanceof PPDrawing) {
-                ppDrawing = (PPDrawing) child;
+            if (child instanceof SlideAtom atom) {
+                slideAtom = atom;
+            } else if (child instanceof PPDrawing drawing) {
+                ppDrawing = drawing;
             }
 
-            if (ppDrawing != null && child instanceof ColorSchemeAtom) {
-                _colorScheme = (ColorSchemeAtom) child;
+            if (ppDrawing != null && child instanceof ColorSchemeAtom csa) {
+                _colorScheme = csa;
             }
         }
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Sound.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/Sound.java
@@ -64,23 +64,23 @@ public final class Sound extends RecordContainer {
     private void findInterestingChildren() {
         // First child should be the ExHyperlinkAtom
         Record child = _children[0];
-        if(child instanceof CString) {
-            _name = (CString) child;
+        if(child instanceof CString cs) {
+            _name = cs;
         } else {
             LOG.atError().log("First child record wasn't a CString, was of type {}", box(child.getRecordType()));
         }
 
         // Second child should be the ExOleObjAtom
         child = _children[1];
-        if (child instanceof CString) {
-            _type = (CString) child;
+        if (child instanceof CString cs) {
+            _type = cs;
         } else {
             LOG.atError().log("Second child record wasn't a CString, was of type {}", box(child.getRecordType()));
         }
 
         for (int i = 2; i < _children.length; i++) {
-            if(_children[i] instanceof SoundData){
-                _data = (SoundData)_children[i];
+            if(_children[i] instanceof SoundData sd){
+                _data = sd;
                 break;
             }
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/TextSpecInfoRun.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/record/TextSpecInfoRun.java
@@ -211,17 +211,14 @@ public class TextSpecInfoRun implements GenericRecord {
                 continue;
             }
             boolean valid;
-            if (valO instanceof byte[]) {
-                byte[] bufB = (byte[]) valO;
+            if (valO instanceof byte[] bufB) {
                 valid = bufB.length > 0;
                 out.write(bufB);
-            } else if (valO instanceof Integer) {
-                int valI = ((Integer)valO);
+            } else if (valO instanceof Integer valI) {
                 valid = (valI != -1);
                 LittleEndian.putInt(buf, 0, valI);
                 out.write(buf);
-            } else if (valO instanceof Short) {
-                short valS = ((Short)valO);
+            } else if (valO instanceof Short valS) {
                 valid = (valS != -1);
                 LittleEndian.putShort(buf, 0, valS);
                 out.write(buf, 0, 2);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFFontInfo.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFFontInfo.java
@@ -109,8 +109,7 @@ public class HSLFFontInfo implements FontInfo {
         setCharset(fontInfo.getCharset());
         setFamily(fontInfo.getFamily());
         setPitch(fontInfo.getPitch());
-        if (fontInfo instanceof HSLFFontInfo) {
-            HSLFFontInfo hFontInfo = (HSLFFontInfo)fontInfo;
+        if (fontInfo instanceof HSLFFontInfo hFontInfo) {
             setRenderType(hFontInfo.getRenderType());
             setEmbedSubsetted(hFontInfo.isEmbedSubsetted());
             setFontSubstitutable(hFontInfo.isFontSubstitutable());

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFGroupShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFGroupShape.java
@@ -298,9 +298,8 @@ implements HSLFShapeContainer, GroupShape<HSLFShape,HSLFTextParagraph> {
                 continue;
             }
 
-            if(r instanceof EscherContainerRecord) {
+            if(r instanceof EscherContainerRecord container) {
                 // Create the Shape for it
-                EscherContainerRecord container = (EscherContainerRecord)r;
                 HSLFShape shape = HSLFShapeFactory.createShape(container, this);
                 shape.setSheet(getSheet());
                 shapeList.add( shape );
@@ -359,10 +358,10 @@ implements HSLFShapeContainer, GroupShape<HSLFShape,HSLFTextParagraph> {
 
     @Override
     public HSLFPictureShape createPicture(PictureData pictureData) {
-        if (!(pictureData instanceof HSLFPictureData)) {
+        if (!(pictureData instanceof HSLFPictureData hslfPictureData)) {
             throw new IllegalArgumentException("pictureData needs to be of type HSLFPictureData");
         }
-        HSLFPictureShape s = new HSLFPictureShape((HSLFPictureData)pictureData, this);
+        HSLFPictureShape s = new HSLFPictureShape(hslfPictureData, this);
         s.setAnchor(new Rectangle2D.Double(0, 0, 100, 100));
         addShape(s);
         return s;
@@ -381,10 +380,10 @@ implements HSLFShapeContainer, GroupShape<HSLFShape,HSLFTextParagraph> {
 
     @Override
     public HSLFObjectShape createOleShape(PictureData pictureData) {
-        if (!(pictureData instanceof HSLFPictureData)) {
+        if (!(pictureData instanceof HSLFPictureData hslfPictureData)) {
             throw new IllegalArgumentException("pictureData needs to be of type HSLFPictureData");
         }
-        HSLFObjectShape s = new HSLFObjectShape((HSLFPictureData)pictureData, this);
+        HSLFObjectShape s = new HSLFObjectShape(hslfPictureData, this);
         s.setAnchor(new Rectangle2D.Double(0, 0, 100, 100));
         addShape(s);
         return s;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFHyperlink.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFHyperlink.java
@@ -352,11 +352,10 @@ public final class HSLFHyperlink implements Hyperlink<HSLFShape,HSLFTextParagrap
         while (iter.hasNext()) {
             org.apache.poi.hslf.record.Record r = iter.next();
             // see if we have InteractiveInfo in the textrun's records
-            if (!(r instanceof InteractiveInfo)) {
+            if (!(r instanceof InteractiveInfo hldr)) {
                 continue;
             }
 
-            InteractiveInfo hldr = (InteractiveInfo)r;
             InteractiveInfoAtom info = hldr.getInteractiveInfoAtom();
             if (info == null) {
                 continue;
@@ -372,11 +371,11 @@ public final class HSLFHyperlink implements Hyperlink<HSLFShape,HSLFTextParagrap
 
             if (iter.hasNext()) {
                 r = iter.next();
-                if (!(r instanceof TxInteractiveInfoAtom)) {
+                if (!(r instanceof TxInteractiveInfoAtom txiia)) {
                     iter.previous();
                     continue;
                 }
-                link.setTextRunInfo((TxInteractiveInfoAtom)r);
+                link.setTextRunInfo(txiia);
             }
         }
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFObjectShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFObjectShape.java
@@ -183,8 +183,7 @@ public final class HSLFObjectShape extends HSLFPictureShape implements ObjectSha
 
             int id = getObjectID();
             for (Record ch : lst.getChildRecords()) {
-                if(ch instanceof ExEmbed){
-                    ExEmbed embd = (ExEmbed)ch;
+                if(ch instanceof ExEmbed embd){
                     if( embd.getExOleObjAtom().getObjID() == id) {
                         _exEmbed = embd;
                     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFShape.java
@@ -462,8 +462,8 @@ public abstract class HSLFShape implements Shape<HSLFShape,HSLFTextParagraph> {
                 break;
             }
             case SHADOW_COLOR: {
-                if (this instanceof HSLFSimpleShape) {
-                    return ((HSLFSimpleShape)this).getShadowColor();
+                if (this instanceof HSLFSimpleShape simpleShape) {
+                    return simpleShape.getShadowColor();
                 }
                 break;
             }
@@ -475,8 +475,8 @@ public abstract class HSLFShape implements Shape<HSLFShape,HSLFTextParagraph> {
                 return getColor(EscherPropertyTypes.FILL__FILLBACKCOLOR, EscherPropertyTypes.FILL__FILLOPACITY);
             }
             case LINE_BACKGROUND_COLOR: {
-                if (this instanceof HSLFSimpleShape) {
-                    return ((HSLFSimpleShape)this).getLineBackgroundColor();
+                if (this instanceof HSLFSimpleShape simpleShape) {
+                    return simpleShape.getLineBackgroundColor();
                 }
                 break;
             }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFShapeFactory.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFShapeFactory.java
@@ -64,10 +64,9 @@ public final class HSLFShapeFactory {
     public static HSLFGroupShape createShapeGroup(EscherContainerRecord spContainer, ShapeContainer<HSLFShape,HSLFTextParagraph> parent){
         boolean isTable = false;
         EscherRecord child = spContainer.getChild(0);
-        if (!(child instanceof EscherContainerRecord)) {
+        if (!(child instanceof EscherContainerRecord ecr)) {
             throw new RecordFormatException("Did not have a EscherContainerRecord: " + child);
         }
-        EscherContainerRecord ecr = (EscherContainerRecord) child;
         EscherRecord opt = HSLFShape.getEscherChild(ecr, EscherRecordTypes.USER_DEFINED);
 
         if (opt != null) {
@@ -75,8 +74,8 @@ public final class HSLFShapeFactory {
             List<EscherProperty> props = f.createProperties( opt.serialize(), 8, opt.getInstance() );
             for (EscherProperty ep : props) {
                 if (ep.getPropertyNumber() == EscherPropertyTypes.GROUPSHAPE__TABLEPROPERTIES.propNumber
-                    && ep instanceof EscherSimpleProperty
-                    && (((EscherSimpleProperty)ep).getPropertyValue() & 1) == 1) {
+                    && ep instanceof EscherSimpleProperty esp
+                    && (esp.getPropertyValue() & 1) == 1) {
                     isTable = true;
                     break;
                 }
@@ -117,7 +116,7 @@ public final class HSLFShapeFactory {
                 shape = createNonPrimitive(spContainer, parent);
                 break;
             default:
-                if (parent instanceof HSLFTable) {
+                if (parent instanceof HSLFTable table) {
                     EscherTextboxRecord etr = spContainer.getChildById(EscherTextboxRecord.RECORD_ID);
                     if (etr == null) {
                         LOG.atWarn().log("invalid ppt - add EscherTextboxRecord to cell");
@@ -126,7 +125,7 @@ public final class HSLFShapeFactory {
                         etr.setOptions((short)15);
                         spContainer.addChildRecord(etr);
                     }
-                    shape = new HSLFTableCell(spContainer, (HSLFTable)parent);
+                    shape = new HSLFTableCell(spContainer, table);
                 } else {
                     shape = new HSLFAutoShape(spContainer, parent);
                 }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFShapePlaceholderDetails.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFShapePlaceholderDetails.java
@@ -241,8 +241,8 @@ public class HSLFShapePlaceholderDetails extends HSLFPlaceholderDetails {
 
     private void updatePlaceholderAtom(final Placeholder placeholder, final boolean create) {
         localDateTime = null;
-        if (shape instanceof HSLFTextBox) {
-            EscherTextboxWrapper txtBox = ((HSLFTextBox)shape).getEscherTextboxWrapper();
+        if (shape instanceof HSLFTextBox textBox) {
+            EscherTextboxWrapper txtBox = textBox.getEscherTextboxWrapper();
             if (txtBox != null) {
                 localDateTime = (DateTimeMCAtom)txtBox.findFirstOfType(RecordTypes.DateTimeMCAtom.typeID);
             }
@@ -259,11 +259,11 @@ public class HSLFShapePlaceholderDetails extends HSLFPlaceholderDetails {
         }
 
         for (org.apache.poi.hslf.record.Record r : clientData.getHSLFChildRecords()) {
-            if (r instanceof OEPlaceholderAtom) {
-                oePlaceholderAtom = (OEPlaceholderAtom)r;
-            } else if (r instanceof RoundTripHFPlaceholder12) {
+            if (r instanceof OEPlaceholderAtom atom) {
+                oePlaceholderAtom = atom;
+            } else if (r instanceof RoundTripHFPlaceholder12 hfPlaceholder) {
                 //special case for files saved in Office 2007
-                roundTripHFPlaceholder12 = (RoundTripHFPlaceholder12)r;
+                roundTripHFPlaceholder12 = hfPlaceholder;
             }
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSimpleShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSimpleShape.java
@@ -592,12 +592,12 @@ public abstract class HSLFSimpleShape extends HSLFShape implements SimpleShape<H
         OEPlaceholderAtom oep = null;
         RoundTripHFPlaceholder12 rtp = null;
         for (org.apache.poi.hslf.record.Record r : clientData.getHSLFChildRecords()) {
-            if (r instanceof OEPlaceholderAtom) {
-                oep = (OEPlaceholderAtom) r;
+            if (r instanceof OEPlaceholderAtom atom) {
+                oep = atom;
                 break;
             }
-            if (r instanceof RoundTripHFPlaceholder12) {
-                rtp = (RoundTripHFPlaceholder12) r;
+            if (r instanceof RoundTripHFPlaceholder12 hfPlaceholder) {
+                rtp = hfPlaceholder;
                 break;
             }
         }
@@ -612,8 +612,7 @@ public abstract class HSLFSimpleShape extends HSLFShape implements SimpleShape<H
         final byte phId = getPlaceholderId(getSheet(), placeholder);
 
         switch (placeholder) {
-            case HEADER:
-            case FOOTER:
+            case HEADER, FOOTER -> {
                 if (rtp == null) {
                     rtp = new RoundTripHFPlaceholder12();
                     rtp.setPlaceholderId(phId);
@@ -622,15 +621,15 @@ public abstract class HSLFSimpleShape extends HSLFShape implements SimpleShape<H
                 if (oep != null) {
                     clientData.removeChild(OEPlaceholderAtom.class);
                 }
-                break;
-            default:
+            }
+            default -> {
                 if (rtp != null) {
                     clientData.removeChild(RoundTripHFPlaceholder12.class);
                 }
                 if (oep == null) {
                     oep = createOEPlaceholderAtom(clientData, phId);
                 }
-                break;
+            }
         }
     }
 
@@ -644,16 +643,16 @@ public abstract class HSLFSimpleShape extends HSLFShape implements SimpleShape<H
 
         // TODO: handle PaintStyle
         for (Object st : styles) {
-            if (st instanceof Number) {
-                setLineWidth(((Number)st).doubleValue());
-            } else if (st instanceof LineCap) {
-                setLineCap((LineCap)st);
-            } else if (st instanceof LineDash) {
-                setLineDash((LineDash)st);
-            } else if (st instanceof LineCompound) {
-                setLineCompound((LineCompound)st);
-            } else if (st instanceof Color) {
-                setLineColor((Color)st);
+            if (st instanceof Number number) {
+                setLineWidth(number.doubleValue());
+            } else if (st instanceof LineCap cap) {
+                setLineCap(cap);
+            } else if (st instanceof LineDash dash) {
+                setLineDash(dash);
+            } else if (st instanceof LineCompound compound) {
+                setLineCompound(compound);
+            } else if (st instanceof Color color) {
+                setLineColor(color);
             }
         }
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlide.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlide.java
@@ -166,18 +166,14 @@ public final class HSLFSlide extends HSLFSheet implements Slide<HSLFShape,HSLFTe
         dgg.setDrawingsSaved(dgg.getDrawingsSaved() + 1);
 
         for (EscherContainerRecord c : dgContainer.getChildContainers()) {
-            EscherSpRecord spr = null;
-            switch(EscherRecordTypes.forTypeID(c.getRecordId())){
-                case SPGR_CONTAINER:
+            EscherSpRecord spr = switch(EscherRecordTypes.forTypeID(c.getRecordId())){
+                case SPGR_CONTAINER -> {
                     EscherContainerRecord dc = (EscherContainerRecord)c.getChild(0);
-                    spr = dc.getChildById(EscherSpRecord.RECORD_ID);
-                    break;
-                case SP_CONTAINER:
-                    spr = c.getChildById(EscherSpRecord.RECORD_ID);
-                    break;
-                default:
-                    break;
-            }
+                    yield dc.getChildById(EscherSpRecord.RECORD_ID);
+                }
+                case SP_CONTAINER -> c.getChildById(EscherSpRecord.RECORD_ID);
+                default -> null;
+            };
             if(spr != null) {
                 spr.setShapeId(allocateShapeId());
             }
@@ -411,8 +407,8 @@ public final class HSLFSlide extends HSLFSheet implements Slide<HSLFShape,HSLFTe
 
         if (binaryTags != null) {
             for (final org.apache.poi.hslf.record.Record record : binaryTags.getChildRecords()) {
-                if (record instanceof Comment2000) {
-                    comments.add(new HSLFComment((Comment2000)record));
+                if (record instanceof Comment2000 comment) {
+                    comments.add(new HSLFComment(comment));
                 }
             }
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShow.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShow.java
@@ -148,8 +148,8 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
 
         // Handle Parent-aware Records
         for (Record record : _hslfSlideShow.getRecords()) {
-            if(record instanceof RecordContainer){
-                RecordContainer.handleParentAwareRecords((RecordContainer)record);
+            if(record instanceof RecordContainer container){
+                RecordContainer.handleParentAwareRecords(container);
             }
         }
 
@@ -255,8 +255,7 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
         // To start with, find the most recent in the byte offset domain
         Map<Integer,Integer> mostRecentByBytes = new HashMap<>();
         for (Record record : _hslfSlideShow.getRecords()) {
-            if (record instanceof PersistPtrHolder) {
-                PersistPtrHolder pph = (PersistPtrHolder) record;
+            if (record instanceof PersistPtrHolder pph) {
 
                 // If we've already seen any of the "slide" IDs for this
                 // PersistPtr, remove their old positions
@@ -293,11 +292,10 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
 
         // Now convert the byte offsets back into record offsets
         for (Record record : _hslfSlideShow.getRecords()) {
-            if (!(record instanceof PositionDependentRecord)) {
+            if (!(record instanceof PositionDependentRecord pdr)) {
                 continue;
             }
 
-            PositionDependentRecord pdr = (PositionDependentRecord) record;
             int recordAt = pdr.getLastOnDiskOffset();
 
             Integer thisID = mostRecentByBytesRev.get(recordAt);
@@ -310,8 +308,7 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
             int storeAt = _sheetIdToCoreRecordsLookup.get(thisID);
 
             // Tell it its Sheet ID, if it cares
-            if (pdr instanceof PositionDependentRecordContainer) {
-                PositionDependentRecordContainer pdrc = (PositionDependentRecordContainer) record;
+            if (pdr instanceof PositionDependentRecordContainer pdrc) {
                 pdrc.setSheetId(thisID);
             }
 
@@ -419,12 +416,12 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
         for (SlideAtomsSet sas : masterSLWT.getSlideAtomsSets()) {
             Record r = getCoreRecordForSAS(sas);
             int sheetNo = sas.getSlidePersistAtom().getSlideIdentifier();
-            if (r instanceof Slide) {
-                HSLFTitleMaster master = new HSLFTitleMaster((Slide)r, sheetNo);
+            if (r instanceof Slide slide) {
+                HSLFTitleMaster master = new HSLFTitleMaster(slide, sheetNo);
                 master.setSlideShow(this);
                 _titleMasters.add(master);
-            } else if (r instanceof MainMaster) {
-                HSLFSlideMaster master = new HSLFSlideMaster((MainMaster)r, sheetNo);
+            } else if (r instanceof MainMaster mainMaster) {
+                HSLFSlideMaster master = new HSLFSlideMaster(mainMaster, sheetNo);
                 master.setSlideShow(this);
                 _masters.add(master);
             }
@@ -455,12 +452,10 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
             }
 
             // Ensure it really is a notes record
-            if (!(r instanceof Notes)) {
+            if (!(r instanceof Notes notesRecord)) {
                 LOG.atError().log("{}, but that was actually a {}", loggerLoc, r);
                 continue;
             }
-
-            Notes notesRecord = (Notes) r;
 
             // Record the match between slide id and these notes
             int slideId = spa.getSlideIdentifier();
@@ -491,13 +486,12 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
             Record r = getCoreRecordForSAS(sas);
 
             // Ensure it really is a slide record
-            if (!(r instanceof Slide)) {
+            if (!(r instanceof Slide slide)) {
                 LOG.atError().log("A Slide SlideAtomSet at {} said its record was at refID {}, but that was actually a {}",
                         box(idx), box(spa.getRefID()), r);
                 continue;
             }
 
-            Slide slide = (Slide)r;
             if (slide.getSlideAtom() == null) {
                 LOG.atError().log("SlideAtomSet at {} at refID {} is null", box(idx), box(spa.getRefID()));
                 continue;
@@ -554,10 +548,9 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
 
     private void writeDirtyParagraphs(HSLFShapeContainer container) {
         for (HSLFShape sh : container.getShapes()) {
-            if (sh instanceof HSLFShapeContainer) {
-                writeDirtyParagraphs((HSLFShapeContainer)sh);
-            } else if (sh instanceof HSLFTextShape) {
-                HSLFTextShape hts = (HSLFTextShape)sh;
+            if (sh instanceof HSLFShapeContainer shapeContainer) {
+                writeDirtyParagraphs(shapeContainer);
+            } else if (sh instanceof HSLFTextShape hts) {
                 boolean isDirty = false;
                 for (HSLFTextParagraph p : hts.getTextParagraphs()) {
                     isDirty |= p.isDirty();
@@ -1021,17 +1014,11 @@ public final class HSLFSlideShow extends POIDocument implements SlideShow<HSLFSh
      * @return 0-based index of the movie
      */
     public int addMovie(String path, int type) {
-        ExMCIMovie mci;
-        switch (type) {
-            case MovieShape.MOVIE_MPEG:
-                mci = new ExMCIMovie();
-                break;
-            case MovieShape.MOVIE_AVI:
-                mci = new ExAviMovie();
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported Movie: " + type);
-        }
+        ExMCIMovie mci = switch (type) {
+            case MovieShape.MOVIE_MPEG -> new ExMCIMovie();
+            case MovieShape.MOVIE_AVI -> new ExAviMovie();
+            default -> throw new IllegalArgumentException("Unsupported Movie: " + type);
+        };
 
         ExVideoContainer exVideo = mci.getExVideo();
         exVideo.getExMediaAtom().setMask(0xE80000);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowEncrypted.java
@@ -101,10 +101,9 @@ public class HSLFSlideShowEncrypted implements Closeable {
         UserEditAtom userEditAtomWithEncryption = null;
         for (Map.Entry<Integer, Record> me : recordMap.descendingMap().entrySet()) {
             org.apache.poi.hslf.record.Record r = me.getValue();
-            if (!(r instanceof UserEditAtom)) {
+            if (!(r instanceof UserEditAtom uea)) {
                 continue;
             }
-            UserEditAtom uea = (UserEditAtom)r;
             if (uea.getEncryptSessionPersistIdRef() != -1) {
                 userEditAtomWithEncryption = uea;
                 break;
@@ -117,10 +116,9 @@ public class HSLFSlideShowEncrypted implements Closeable {
         }
 
         org.apache.poi.hslf.record.Record r = recordMap.get(userEditAtomWithEncryption.getPersistPointersOffset());
-        if (!(r instanceof PersistPtrHolder)) {
+        if (!(r instanceof PersistPtrHolder ptr)) {
             throw new RecordFormatException("Encountered an unexpected record-type: " + r);
         }
-        PersistPtrHolder ptr = (PersistPtrHolder)r;
 
         Integer encOffset = ptr.getSlideLocationsLookup().get(userEditAtomWithEncryption.getEncryptSessionPersistIdRef());
         if (encOffset == null) {
@@ -136,10 +134,10 @@ public class HSLFSlideShowEncrypted implements Closeable {
             recordMap.put(encOffset, r);
         }
 
-        if (!(r instanceof DocumentEncryptionAtom)) {
+        if (!(r instanceof DocumentEncryptionAtom atom)) {
             throw new EncryptedPowerPointFileException("Did not have a DocumentEncryptionAtom: " + r);
         }
-        this.dea = (DocumentEncryptionAtom)r;
+        this.dea = atom;
 
         final String pass = password == null ? Biff8EncryptionKey.getCurrentUserPassword() : password;
         EncryptionInfo ei = getEncryptionInfo();
@@ -461,16 +459,16 @@ public class HSLFSlideShowEncrypted implements Closeable {
             if (!(r instanceof PositionDependentRecord pdr)) {
                 throw new AssertionError("Expected PositionDependentRecord");
             }
-            if (pdr instanceof UserEditAtom) {
-                uea = (UserEditAtom)pdr;
+            if (pdr instanceof UserEditAtom atom) {
+                uea = atom;
                 continue;
             }
 
-            if (pdr instanceof PersistPtrHolder) {
+            if (pdr instanceof PersistPtrHolder holder) {
                 if (pph != null) {
                     duplicatedCount++;
                 }
-                pph = (PersistPtrHolder)pdr;
+                pph = holder;
                 for (Map.Entry<Integer,Integer> me : pph.getSlideLocationsLookup().entrySet()) {
                     Integer oldOffset = slideLocations.put(me.getKey(), me.getValue());
                     if (oldOffset != null) {
@@ -515,15 +513,15 @@ public class HSLFSlideShowEncrypted implements Closeable {
         UserEditAtom uea = null;
         List<org.apache.poi.hslf.record.Record> recordList = new ArrayList<>();
         for (org.apache.poi.hslf.record.Record r : records) {
-            if (r instanceof DocumentEncryptionAtom) {
-                deaOffset = ((DocumentEncryptionAtom)r).getLastOnDiskOffset();
+            if (r instanceof DocumentEncryptionAtom dea) {
+                deaOffset = dea.getLastOnDiskOffset();
                 continue;
-            } else if (r instanceof UserEditAtom) {
-                uea = (UserEditAtom)r;
+            } else if (r instanceof UserEditAtom atom) {
+                uea = atom;
                 deaSlideId = uea.getEncryptSessionPersistIdRef();
                 uea.setEncryptSessionPersistIdRef(-1);
-            } else if (r instanceof PersistPtrHolder) {
-                ptr = (PersistPtrHolder)r;
+            } else if (r instanceof PersistPtrHolder holder) {
+                ptr = holder;
             }
             recordList.add(r);
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
@@ -377,8 +377,8 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
                 entry.setValue(record);
             }
 
-            if (record instanceof PersistRecord) {
-                ((PersistRecord) record).setPersistId(persistId);
+            if (record instanceof PersistRecord persistRecord) {
+                persistRecord.setPersistId(persistId);
             }
         }
 
@@ -389,10 +389,9 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
     private void initRecordOffsets(byte[] docstream, int usrOffset, NavigableMap<Integer, Record> recordMap, Map<Integer, Integer> offset2id) {
         while (usrOffset != 0) {
             Record builtRecord = Record.buildRecordAtOffset(docstream, usrOffset);
-            if (!(builtRecord instanceof UserEditAtom)) {
+            if (!(builtRecord instanceof UserEditAtom usr)) {
                 throw new CorruptPowerPointFileException("Did not have a user edit atom: " + builtRecord);
             }
-            UserEditAtom usr = (UserEditAtom) builtRecord;
 
             recordMap.put(usrOffset, usr);
 
@@ -401,10 +400,9 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
             if (record == null) {
                 throw new CorruptPowerPointFileException("Powerpoint document is missing a PersistPtrHolder at " + psrOffset);
             }
-            if (!(record instanceof PersistPtrHolder)) {
+            if (!(record instanceof PersistPtrHolder ptr)) {
                 throw new CorruptPowerPointFileException("Record is not a PersistPtrHolder: " + record + " at " + psrOffset);
             }
-            PersistPtrHolder ptr = (PersistPtrHolder) record;
             recordMap.put(psrOffset, ptr);
 
             for (Map.Entry<Integer, Integer> entry : ptr.getSlideLocationsLookup().entrySet()) {
@@ -437,8 +435,8 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
 
     public DocumentEncryptionAtom getDocumentEncryptionAtom() {
         for (Record r : _records) {
-            if (r instanceof DocumentEncryptionAtom) {
-                return (DocumentEncryptionAtom) r;
+            if (r instanceof DocumentEncryptionAtom dea) {
+                return dea;
             }
         }
         return null;
@@ -477,10 +475,9 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         }
 
         final Entry en = getDirectory().getEntryCaseInsensitive("Pictures");
-        if (!(en instanceof DocumentEntry)) {
+        if (!(en instanceof DocumentEntry entry)) {
             throw new IllegalArgumentException("Had unexpected type of entry for name: Pictures: " + en.getClass());
         }
-        DocumentEntry entry = (DocumentEntry) en;
         EscherContainerRecord blipStore = getBlipStore();
         byte[] pictstream;
         try (DocumentInputStream is = getDirectory().createDocumentInputStream(entry)) {
@@ -584,10 +581,9 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         //  records share an offset.
         Map<Integer, List<EscherBSERecord>> unmatchedRecords = new HashMap<>();
         for (EscherRecord child : blipStore) {
-            if (!(child instanceof EscherBSERecord)) {
+            if (!(child instanceof EscherBSERecord record)) {
                 throw new CorruptPowerPointFileException("Did not have a EscherBSERecord: " + child);
             }
-            EscherBSERecord record = (EscherBSERecord) child;
             unmatchedRecords.computeIfAbsent(record.getOffset(), k -> new ArrayList<>()).add(record);
         }
 
@@ -700,10 +696,9 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         CountingOS cos = new CountingOS();
         for (Record record : _records) {
             // all top level records are position dependent
-            if (!(record instanceof PositionDependentRecord)) {
+            if (!(record instanceof PositionDependentRecord pdr)) {
                 throw new CorruptPowerPointFileException("Record is not a position dependent record: " + record);
             }
-            PositionDependentRecord pdr = (PositionDependentRecord) record;
             int oldPos = pdr.getLastOnDiskOffset();
             int newPos = cos.size();
             pdr.setLastOnDiskOffset(newPos);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSoundData.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSoundData.java
@@ -79,8 +79,8 @@ public final class HSLFSoundData {
                 RecordContainer col = (RecordContainer) value;
                 org.apache.poi.hslf.record.Record[] sr = col.getChildRecords();
                 for (org.apache.poi.hslf.record.Record record : sr) {
-                    if (record instanceof Sound) {
-                        lst.add(new HSLFSoundData((Sound) record));
+                    if (record instanceof Sound sound) {
+                        lst.add(new HSLFSoundData(sound));
                     }
                 }
             }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTable.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTable.java
@@ -177,8 +177,8 @@ implements HSLFShapeContainer, TableShape<HSLFShape,HSLFTextParagraph> {
     private void cellListToArray() {
         List<HSLFTableCell> htc = new ArrayList<>();
         for (HSLFShape h : getShapes()) {
-            if (h instanceof HSLFTableCell) {
-                htc.add((HSLFTableCell)h);
+            if (h instanceof HSLFTableCell cell) {
+                htc.add(cell);
             }
         }
 
@@ -255,8 +255,8 @@ implements HSLFShapeContainer, TableShape<HSLFShape,HSLFTextParagraph> {
     private void fitLinesToCells() {
         List<LineRect> lines = new ArrayList<>();
         for (HSLFShape h : getShapes()) {
-            if (h instanceof HSLFLine) {
-                lines.add(new LineRect((HSLFLine)h));
+            if (h instanceof HSLFLine line) {
+                lines.add(new LineRect(line));
             }
         }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextParagraph.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextParagraph.java
@@ -28,7 +28,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.logging.PoiLogManager;
@@ -540,10 +539,9 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
 
             @Override
             public void setBulletFontColor(PaintStyle color) {
-                if (!(color instanceof SolidPaint)) {
+                if (!(color instanceof SolidPaint sp)) {
                     throw new IllegalArgumentException("HSLF only supports SolidPaint");
                 }
-                SolidPaint sp = (SolidPaint)color;
                 Color col = DrawPaint.applyColorTransform(sp.getSolidColor());
                 HSLFTextParagraph.this.setBulletColor(col);
             }
@@ -773,7 +771,7 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
             tabStops = textRuler.getTabStops();
         }
 
-        return tabStops.stream().map(HSLFTabStopDecorator::new).collect(Collectors.toList());
+        return tabStops.stream().map(HSLFTabStopDecorator::new).toList();
     }
 
     @Override
@@ -873,8 +871,8 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
         final HSLFSheet sheet = getSheet();
         final int txtype = getRunType();
         final HSLFMasterSheet master;
-        if (sheet instanceof HSLFMasterSheet) {
-            master = (HSLFMasterSheet)sheet;
+        if (sheet instanceof HSLFMasterSheet masterSheet) {
+            master = masterSheet;
         } else {
             master = sheet.getMasterSheet();
             if (master == null) {
@@ -918,8 +916,8 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
         final boolean isChar = props.getTextPropType() == TextPropType.character;
 
         final TextPropCollection pc;
-        if (_sheet instanceof HSLFMasterSheet) {
-            pc = ((HSLFMasterSheet)_sheet).getPropCollection(getRunType(), getIndentLevel(), "*", isChar);
+        if (_sheet instanceof HSLFMasterSheet masterSheet) {
+            pc = masterSheet.getPropCollection(getRunType(), getIndentLevel(), "*", isChar);
             if (pc == null) {
                 throw new HSLFException("Master text property collection can't be determined.");
             }
@@ -1131,8 +1129,8 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
         // If TextSpecInfoAtom is present, we must update the text size in it,
         // otherwise the ppt will be corrupted
         for (Record r : paragraphs.get(0).getRecords()) {
-            if (r instanceof TextSpecInfoAtom) {
-                ((TextSpecInfoAtom) r).setParentSize(rawText.length() + 1);
+            if (r instanceof TextSpecInfoAtom tsia) {
+                tsia.setParentSize(rawText.length() + 1);
                 break;
             }
         }
@@ -1412,9 +1410,9 @@ public final class HSLFTextParagraph implements TextParagraph<HSLFShape,HSLFText
                 // if we haven't found the wrapper in the sheet runs, create a new paragraph list from its record
                 List<List<HSLFTextParagraph>> rvl = findTextParagraphs(wrapper.getChildRecords());
                 switch (rvl.size()) {
-                case 0: break; // nothing found
-                case 1: rv = rvl.get(0); break; // normal case
-                default:
+                case 0 -> { } // nothing found
+                case 1 -> rv = rvl.get(0); // normal case
+                default ->
                     throw new HSLFException("TextBox contains more than one list of paragraphs.");
                 }
             }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextRun.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFTextRun.java
@@ -412,11 +412,10 @@ public final class HSLFTextRun implements TextRun {
 
     @Override
     public void setFontColor(PaintStyle color) {
-        if (!(color instanceof SolidPaint)) {
+        if (!(color instanceof SolidPaint sp)) {
             throw new IllegalArgumentException("HSLF only supports solid paint");
         }
         // In PowerPont RGB bytes are swapped, as BGR
-        SolidPaint sp = (SolidPaint)color;
         Color c = DrawPaint.applyColorTransform(sp.getSolidColor());
         int rgb = new Color(c.getBlue(), c.getGreen(), c.getRed(), 254).getRGB();
         setFontColor(rgb);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/MAPIMessage.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/MAPIMessage.java
@@ -176,17 +176,17 @@ public class MAPIMessage extends POIReadOnlyDocument {
         ArrayList<RecipientChunks> recipients = new ArrayList<>();
         for (ChunkGroup group : chunkGroups) {
             // Should only ever be one of each of these
-            if (group instanceof Chunks) {
-                mainChunks = (Chunks) group;
-            } else if (group instanceof NameIdChunks) {
-                nameIdChunks = (NameIdChunks) group;
-            } else if (group instanceof RecipientChunks) {
-                recipients.add((RecipientChunks) group);
+            if (group instanceof Chunks chunks) {
+                mainChunks = chunks;
+            } else if (group instanceof NameIdChunks idChunks) {
+                nameIdChunks = idChunks;
+            } else if (group instanceof RecipientChunks rc) {
+                recipients.add(rc);
             }
 
             // Can be multiple of these - add to list(s)
-            if (group instanceof AttachmentChunks) {
-                attachments.add((AttachmentChunks) group);
+            if (group instanceof AttachmentChunks ac) {
+                attachments.add(ac);
             }
         }
         attachmentChunks = attachments.toArray(new AttachmentChunks[0]);

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/AttachmentChunks.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/AttachmentChunks.java
@@ -233,10 +233,10 @@ public class AttachmentChunks implements ChunkGroup {
 
         try {
             if (chunkId == ATTACH_DATA.id) {
-                if (chunk instanceof ByteChunk) {
-                    attachData = (ByteChunk) chunk;
-                } else if (chunk instanceof DirectoryChunk) {
-                    attachmentDirectory = (DirectoryChunk) chunk;
+                if (chunk instanceof ByteChunk byteChunk) {
+                    attachData = byteChunk;
+                } else if (chunk instanceof DirectoryChunk directoryChunk) {
+                    attachmentDirectory = directoryChunk;
                 } else {
                     LOG.atError().log("Unexpected data chunk of type {}", chunk.getEntryName());
                 }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/Chunks.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/Chunks.java
@@ -235,16 +235,16 @@ public final class Chunks implements ChunkGroupWithProperties {
             } else if (prop == MAPIProperty.BODY) {
                 textBodyChunk = (StringChunk) chunk;
             } else if (prop == MAPIProperty.BODY_HTML) {
-                if (chunk instanceof StringChunk) {
-                    htmlBodyChunkString = (StringChunk) chunk;
+                if (chunk instanceof StringChunk stringChunk) {
+                    htmlBodyChunkString = stringChunk;
                 }
-                if (chunk instanceof ByteChunk) {
-                    htmlBodyChunkBinary = (ByteChunk) chunk;
+                if (chunk instanceof ByteChunk byteChunk) {
+                    htmlBodyChunkBinary = byteChunk;
                 }
             } else if (prop == MAPIProperty.RTF_COMPRESSED) {
                 rtfBodyChunk = (ByteChunk) chunk;
-            } else if (chunk instanceof MessagePropertiesChunk) {
-                messageProperties = (MessagePropertiesChunk) chunk;
+            } else if (chunk instanceof MessagePropertiesChunk propertiesChunk) {
+                messageProperties = propertiesChunk;
             }
 
             // And add to the main list

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/PropertiesChunk.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/PropertiesChunk.java
@@ -183,8 +183,7 @@ public abstract class PropertiesChunk extends Chunk {
 
         // Loop over our values, looking for chunk based ones
         for (PropertyValue val : properties.values()) {
-            if (val instanceof ChunkBasedPropertyValue) {
-                ChunkBasedPropertyValue cVal = (ChunkBasedPropertyValue) val;
+            if (val instanceof ChunkBasedPropertyValue cVal) {
                 Chunk chunk = chunks.get(cVal.getProperty().id);
                 // System.err.println(cVal.getProperty() + " = " + cVal + " -> "
                 // + HexDump.toHex(cVal.data));

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/RecipientChunks.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/datatypes/RecipientChunks.java
@@ -226,8 +226,8 @@ public final class RecipientChunks implements ChunkGroupWithProperties {
                 recipientSMTPChunk = (StringChunk) chunk;
             } else if (chunk.getChunkId() == DELIVERY_TYPE.id) {
                 deliveryTypeChunk = (StringChunk) chunk;
-            } else if (chunk instanceof PropertiesChunk) {
-                recipientProperties = (PropertiesChunk) chunk;
+            } else if (chunk instanceof PropertiesChunk propertiesChunk) {
+                recipientProperties = propertiesChunk;
             }
         } catch (ClassCastException e) {
             throw new IllegalArgumentException("ChunkId and type of chunk did not match, had id " +

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/dev/HSMFDump.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/dev/HSMFDump.java
@@ -48,8 +48,7 @@ public class HSMFDump {
          for(Chunk chunk : chunks.getChunks()) {
             MAPIProperty attr = MAPIProperty.get(chunk.getChunkId());
             
-            if (chunk instanceof PropertiesChunk) {
-               PropertiesChunk props = (PropertiesChunk)chunk;
+            if (chunk instanceof PropertiesChunk props) {
                out.println(
                      "   Properties - " + props.getProperties().size() + ":"
                );

--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/parsers/POIFSChunkParser.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/parsers/POIFSChunkParser.java
@@ -73,8 +73,7 @@ public final class POIFSChunkParser {
         // Note - we don't handle children of children yet, as
         //  there doesn't seem to be any use of that in Outlook
         for (Entry entry : node) {
-            if (entry instanceof DirectoryNode) {
-                DirectoryNode dir = (DirectoryNode) entry;
+            if (entry instanceof DirectoryNode dir) {
                 ChunkGroup group = null;
 
                 // Do we know what to do with it?
@@ -145,8 +144,8 @@ public final class POIFSChunkParser {
             return;
         }
 
-        if (entry instanceof DocumentNode) {
-            try (DocumentInputStream inp = new DocumentInputStream((DocumentNode) entry)) {
+        if (entry instanceof DocumentNode docNode) {
+            try (DocumentInputStream inp = new DocumentInputStream(docNode)) {
                 chunk.readValue(inp);
             } catch (IOException e) {
                 LOG.atError().withThrowable(e).log("Error reading from part {}", entry.getName());
@@ -216,8 +215,8 @@ public final class POIFSChunkParser {
             return new MessageSubmissionChunk(namePrefix, chunkId, type);
         } else if (type == Types.BINARY && chunkId == MAPIProperty.ATTACH_DATA.id) {
             ByteChunkDeferred bcd = new ByteChunkDeferred(namePrefix, chunkId, type);
-            if (entry instanceof DocumentNode) {
-                bcd.readValue((DocumentNode) entry);
+            if (entry instanceof DocumentNode docNode) {
+                bcd.readValue(docNode);
             }
             return bcd;
         } else {
@@ -226,8 +225,8 @@ public final class POIFSChunkParser {
             if (isMultiValue[0]) {
                 return readMultiValue(namePrefix, ids, chunkId, entry, type, multiChunks);
             } else {
-                if (type == Types.DIRECTORY && entry instanceof DirectoryNode) {
-                    return new DirectoryChunk((DirectoryNode) entry, namePrefix, chunkId, type);
+                if (type == Types.DIRECTORY && entry instanceof DirectoryNode dirNode) {
+                    return new DirectoryChunk(dirNode, namePrefix, chunkId, type);
                 } else if (type == Types.BINARY) {
                     return new ByteChunk(namePrefix, chunkId, type);
                 } else if (type == Types.ASCII_STRING || type == Types.UNICODE_STRING) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwmf/usermodel/HwmfEmbeddedIterator.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwmf/usermodel/HwmfEmbeddedIterator.java
@@ -63,8 +63,8 @@ public class HwmfEmbeddedIterator implements Iterator<HwmfEmbedded> {
                     current = obj;
                     return true;
                 }
-                if (obj instanceof HwmfEscape && ((HwmfEscape)obj).getEscapeFunction() == EscapeFunction.META_ESCAPE_ENHANCED_METAFILE) {
-                    WmfEscapeEMF emfData = ((HwmfEscape)obj).getEscapeData();
+                if (obj instanceof HwmfEscape esc && esc.getEscapeFunction() == EscapeFunction.META_ESCAPE_ENHANCED_METAFILE) {
+                    WmfEscapeEMF emfData = esc.getEscapeData();
                     if (emfData.isValid()) {
                         current = obj;
                         return true;
@@ -91,11 +91,10 @@ public class HwmfEmbeddedIterator implements Iterator<HwmfEmbedded> {
     }
 
     private HwmfEmbedded checkHwmfImageRecord() {
-        if (!(current instanceof HwmfImageRecord)) {
+        if (!(current instanceof HwmfImageRecord hir)) {
             return null;
         }
 
-        HwmfImageRecord hir = (HwmfImageRecord)current;
         current = null;
 
         HwmfEmbedded emb = new HwmfEmbedded();

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwmf/usermodel/HwmfPicture.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwmf/usermodel/HwmfPicture.java
@@ -136,8 +136,8 @@ public class HwmfPicture implements Iterable<HwmfRecord>, GenericRecord {
                     }
                 }
 
-                if (wr instanceof HwmfCharsetAware) {
-                    ((HwmfCharsetAware)wr).setCharsetProvider(this::getDefaultCharset);
+                if (wr instanceof HwmfCharsetAware charsetAware) {
+                    charsetAware.setCharsetProvider(this::getDefaultCharset);
                 }
             }
         }
@@ -220,10 +220,10 @@ public class HwmfPicture implements Iterable<HwmfRecord>, GenericRecord {
         WmfSetWindowOrg wOrg = null;
         WmfSetWindowExt wExt = null;
         for (HwmfRecord r : getRecords()) {
-            if (r instanceof WmfSetWindowOrg) {
-                wOrg = (WmfSetWindowOrg)r;
-            } else if (r instanceof WmfSetWindowExt) {
-                wExt = (WmfSetWindowExt)r;
+            if (r instanceof WmfSetWindowOrg org) {
+                wOrg = org;
+            } else if (r instanceof WmfSetWindowExt ext) {
+                wExt = ext;
             }
             if (wOrg != null && wExt != null) {
                 return new Rectangle2D.Double(wOrg.getX(), wOrg.getY(), wExt.getSize().getWidth(), wExt.getSize().getHeight());

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/HWPFDocumentCore.java
@@ -238,10 +238,10 @@ public abstract class HWPFDocumentCore extends POIDocument {
         DirectoryEntry objectPoolEntry = null;
         if (directory.hasEntryCaseInsensitive(STREAM_OBJECT_POOL)) {
             final Entry entry = directory.getEntryCaseInsensitive(STREAM_OBJECT_POOL);
-            if (!(entry instanceof DirectoryEntry)) {
+            if (!(entry instanceof DirectoryEntry directoryEntry)) {
                 throw new IllegalArgumentException("Had unexpected type of entry for name: " + STREAM_OBJECT_POOL + ": " + entry.getClass());
             }
-            objectPoolEntry = (DirectoryEntry) entry;
+            objectPoolEntry = directoryEntry;
         }
         _objectPool = new ObjectPoolImpl(objectPoolEntry);
     }
@@ -420,10 +420,9 @@ public abstract class HWPFDocumentCore extends POIDocument {
     protected byte[] getDocumentEntryBytes(String name, int encryptionOffset, final int len) throws IOException {
         DirectoryNode dir = getDirectory();
         final Entry entry = dir.getEntryCaseInsensitive(name);
-        if (!(entry instanceof DocumentEntry)) {
+        if (!(entry instanceof DocumentEntry documentProps)) {
             throw new IllegalArgumentException("Had unexpected type of entry for name: " + name + ": " + entry);
         }
-        DocumentEntry documentProps = (DocumentEntry) entry;
         int streamSize = documentProps.getSize();
         boolean isEncrypted = (encryptionOffset > -1 && getEncryptionInfo() != null);
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/AbstractWordConverter.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/AbstractWordConverter.java
@@ -313,7 +313,7 @@ public abstract class AbstractWordConverter {
                     continue;
                 }
 
-                Field aliveField = ((HWPFDocument) wordDocument).getFields()
+                Field aliveField = doc.getFields()
                     .getFieldByStartOffset(FieldsDocumentPart.MAIN,
                         characterRun.getStartOffset());
                 if (aliveField != null) {
@@ -429,10 +429,9 @@ public abstract class AbstractWordConverter {
                 throw new AssertionError();
             }
 
-            if (wordDocument instanceof HWPFDocument
-                && ((HWPFDocument) wordDocument).getPicturesTable()
+            if (wordDocument instanceof HWPFDocument newFormat
+                && newFormat.getPicturesTable()
                 .hasPicture(characterRun)) {
-                HWPFDocument newFormat = (HWPFDocument) wordDocument;
                 Picture picture = newFormat.getPicturesTable().extractPicture(
                     characterRun, true);
 
@@ -452,39 +451,35 @@ public abstract class AbstractWordConverter {
 
             if (characterRun.isSpecialCharacter()) {
                 if (text.charAt(0) == SPECCHAR_AUTONUMBERED_FOOTNOTE_REFERENCE
-                    && (wordDocument instanceof HWPFDocument)) {
-                    HWPFDocument doc = (HWPFDocument) wordDocument;
+                    && (wordDocument instanceof HWPFDocument doc)) {
                     processNoteAnchor(doc, characterRun, block);
                     continue;
                 }
                 if (text.charAt(0) == SPECCHAR_DRAWN_OBJECT
-                    && (wordDocument instanceof HWPFDocument)) {
-                    HWPFDocument doc = (HWPFDocument) wordDocument;
+                    && (wordDocument instanceof HWPFDocument doc)) {
                     processDrawnObject(doc, characterRun, block);
                     continue;
                 }
                 if (characterRun.isOle2()
-                    && (wordDocument instanceof HWPFDocument)) {
-                    HWPFDocument doc = (HWPFDocument) wordDocument;
+                    && (wordDocument instanceof HWPFDocument doc)) {
                     processOle2(doc, characterRun, block);
                     continue;
                 }
                 if (characterRun.isSymbol()
-                    && (wordDocument instanceof HWPFDocument)) {
-                    HWPFDocument doc = (HWPFDocument) wordDocument;
+                    && (wordDocument instanceof HWPFDocument doc)) {
                     processSymbol(doc, characterRun, block);
                     continue;
                 }
             }
 
             if (text.charAt(0) == FIELD_BEGIN_MARK) {
-                if (wordDocument instanceof HWPFDocument) {
-                    Field aliveField = ((HWPFDocument) wordDocument)
+                if (wordDocument instanceof HWPFDocument doc) {
+                    Field aliveField = doc
                         .getFields().getFieldByStartOffset(
                             FieldsDocumentPart.MAIN,
                             characterRun.getStartOffset());
                     if (aliveField != null) {
-                        processField(((HWPFDocument) wordDocument), range,
+                        processField(doc, range,
                             currentTableLevel, aliveField, block);
 
                         int continueAfter = aliveField.getFieldEndOffset();

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/AbstractWordUtils.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/AbstractWordUtils.java
@@ -153,8 +153,8 @@ public class AbstractWordUtils {
         childNodes = parentElement.getChildNodes();
         for ( int i = 0; i < childNodes.getLength() - 1; i++ ) {
             Node child = childNodes.item( i );
-            if ( child instanceof Element ) {
-                compactChildNodesR( (Element) child, childTagName );
+            if ( child instanceof Element element ) {
+                compactChildNodesR( element, childTagName );
             }
         }
     }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/WordToFoConverter.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/WordToFoConverter.java
@@ -382,9 +382,8 @@ public class WordToFoConverter extends AbstractWordConverter
         if ( childNodes.getLength() > 0 )
         {
             Node lastChild = childNodes.item( childNodes.getLength() - 1 );
-            if ( lastChild instanceof Element )
+            if ( lastChild instanceof Element lastElement )
             {
-                Element lastElement = (Element) lastChild;
                 if ( !lastElement.hasAttribute( "break-after" ) )
                 {
                     block = lastElement;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/WordToTextConverter.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/converter/WordToTextConverter.java
@@ -324,9 +324,8 @@ public class WordToTextConverter extends AbstractWordConverter {
     protected boolean processOle2( HWPFDocument wordDocument, Element block,
             Entry entry ) throws Exception
     {
-        if ( !( entry instanceof DirectoryNode ) )
+        if ( !( entry instanceof DirectoryNode directoryNode ) )
             return false;
-        DirectoryNode directoryNode = (DirectoryNode) entry;
 
         /*
          * even if there is no ExtractorFactory in classpath, still support
@@ -334,7 +333,7 @@ public class WordToTextConverter extends AbstractWordConverter {
          */
         if ( directoryNode.hasEntryCaseInsensitive( "WordDocument" ) )
         {
-            String text = WordToTextConverter.getText( (DirectoryNode) entry );
+            String text = WordToTextConverter.getText( directoryNode );
             block.appendChild( textDocumentFacade
                     .createText( UNICODECHAR_ZERO_WIDTH_SPACE + text
                             + UNICODECHAR_ZERO_WIDTH_SPACE ) );

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/dev/HWPFLister.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/dev/HWPFLister.java
@@ -293,12 +293,11 @@ public final class HWPFLister {
     }
 
     private void dumpBookmarks() {
-        if ( !( _doc instanceof HWPFDocument ) ) {
+        if ( !( _doc instanceof HWPFDocument document ) ) {
             System.out.println( "Word 95 not supported so far" );
             return;
         }
 
-        HWPFDocument document = (HWPFDocument) _doc;
         Bookmarks bookmarks = document.getBookmarks();
         for ( int b = 0; b < bookmarks.getBookmarksCount(); b++ ) {
             Bookmark bookmark = bookmarks.getBookmark( b );
@@ -342,12 +341,12 @@ public final class HWPFLister {
     }
 
     private void dumpDop() {
-        if ( !( _doc instanceof HWPFDocument ) ) {
+        if ( !( _doc instanceof HWPFDocument document ) ) {
             System.out.println( "Word 95 not supported so far" );
             return;
         }
 
-        System.out.println( ( (HWPFDocument) _doc ).getDocProperties() );
+        System.out.println( document.getDocProperties() );
     }
 
     private void dumpEscher() {
@@ -366,12 +365,10 @@ public final class HWPFLister {
     }
 
     private void dumpFields() {
-        if ( !( _doc instanceof HWPFDocument ) ) {
+        if ( !( _doc instanceof HWPFDocument document ) ) {
             System.out.println( "Word 95 not supported so far" );
             return;
         }
-
-        HWPFDocument document = (HWPFDocument) _doc;
 
         for ( FieldsDocumentPart part : FieldsDocumentPart.values() ) {
             System.out.println( "=== Document part: " + part + " ===" );
@@ -401,19 +398,17 @@ public final class HWPFLister {
     }
 
     private String dumpFileSystem( Entry entry ) {
-        if ( entry instanceof DirectoryEntry )
-            return dumpFileSystem( (DirectoryEntry) entry );
+        if ( entry instanceof DirectoryEntry directory )
+            return dumpFileSystem( directory );
 
         return entry.getName();
     }
 
     private void dumpOfficeDrawings() {
-        if ( !( _doc instanceof HWPFDocument ) ) {
+        if ( !( _doc instanceof HWPFDocument document ) ) {
             System.out.println( "Word 95 not supported so far" );
             return;
         }
-
-        HWPFDocument document = (HWPFDocument) _doc;
 
         if ( document.getOfficeDrawingsHeaders() != null ) {
             System.out.println( "=== Document part: HEADER ===" );
@@ -433,10 +428,8 @@ public final class HWPFLister {
     }
 
     public void dumpPapx( boolean withProperties, boolean withSprms ) {
-        if ( _doc instanceof HWPFDocument ) {
+        if ( _doc instanceof HWPFDocument doc ) {
             System.out.println( "binary PAP pages " );
-
-            HWPFDocument doc = (HWPFDocument) _doc;
 
             byte[] mainStream = _doc.getMainStream();
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/Ffn.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/Ffn.java
@@ -173,8 +173,7 @@ public final class Ffn {
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof Ffn)) return false;
-        Ffn o = (Ffn) other;
+        if (!(other instanceof Ffn o)) return false;
 
         return (
                 o._cbFfnM1 == this._cbFfnM1

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/FontTable.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/FontTable.java
@@ -137,8 +137,7 @@ public final class FontTable
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof FontTable)) return false;
-        FontTable o = (FontTable)other;
+        if (!(other instanceof FontTable o)) return false;
 
         if (o._stringCount != this._stringCount
                 || o._extraDataSz != this._extraDataSz

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/ListFormatOverrideLevel.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/ListFormatOverrideLevel.java
@@ -47,8 +47,7 @@ public final class ListFormatOverrideLevel
 
     public boolean equals( Object obj )
     {
-        if (!(obj instanceof ListFormatOverrideLevel)) return false;
-        ListFormatOverrideLevel lfolvl = (ListFormatOverrideLevel) obj;
+        if (!(obj instanceof ListFormatOverrideLevel lfolvl)) return false;
         boolean lvlEquality = false;
         if ( _lvl != null )
         {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/ListLevel.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/ListLevel.java
@@ -120,9 +120,8 @@ public final class ListLevel
     @Override
     public boolean equals( Object obj )
     {
-        if (!(obj instanceof ListLevel)) return false;
+        if (!(obj instanceof ListLevel lvl)) return false;
 
-        ListLevel lvl = (ListLevel) obj;
         return lvl._lvlf.equals( this._lvlf )
                 && Arrays.equals( lvl._grpprlChpx, _grpprlChpx )
                 && Arrays.equals( lvl._grpprlPapx, _grpprlPapx )

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/ParagraphHeight.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/ParagraphHeight.java
@@ -82,8 +82,7 @@ public final class ParagraphHeight implements Duplicatable {
 
   public boolean equals(Object o)
   {
-    if (!(o instanceof ParagraphHeight)) return false;
-    ParagraphHeight ph = (ParagraphHeight)o;
+    if (!(o instanceof ParagraphHeight ph)) return false;
 
     return infoField == ph.infoField && reserved == ph.reserved &&
            dxaCol == ph.dxaCol && dymLineOrHeight == ph.dymLineOrHeight;

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/PicturesTable.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/PicturesTable.java
@@ -159,8 +159,7 @@ public final class PicturesTable {
      */
     private void searchForPictures(List<EscherRecord> escherRecords, List<Picture> pictures) {
         for (EscherRecord escherRecord : escherRecords) {
-            if (escherRecord instanceof EscherBSERecord) {
-                EscherBSERecord bse = (EscherBSERecord) escherRecord;
+            if (escherRecord instanceof EscherBSERecord bse) {
                 EscherBlipRecord blip = bse.getBlipRecord();
                 if (blip != null) {
                     pictures.add(new Picture(blip));
@@ -172,10 +171,10 @@ public final class PicturesTable {
                         EscherRecord record = recordFactory.createRecord(
                             _mainStream, bse.getOffset());
 
-                        if (record instanceof EscherBlipRecord) {
+                        if (record instanceof EscherBlipRecord blipRecord) {
                             record.fillFields(_mainStream, bse.getOffset(),
                                 recordFactory);
-                            blip = (EscherBlipRecord) record;
+                            blip = blipRecord;
                             pictures.add(new Picture(blip));
                         }
                     } catch (Exception exc) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/SEPX.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/SEPX.java
@@ -74,8 +74,7 @@ public final class SEPX extends PropertyNode<SEPX> {
     @Override
     public boolean equals( Object o )
     {
-        if (!(o instanceof SEPX)) return false;
-        SEPX sepx = (SEPX) o;
+        if (!(o instanceof SEPX sepx)) return false;
         if ( super.equals( o ) )
         {
             return sepx._sed.equals( _sed );

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/SavedByEntry.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/SavedByEntry.java
@@ -56,8 +56,7 @@ public final class SavedByEntry
   public boolean equals(Object other)
   {
     if (other == this) return true;
-    if (!(other instanceof SavedByEntry)) return false;
-    SavedByEntry that = (SavedByEntry) other;
+    if (!(other instanceof SavedByEntry that)) return false;
     return that.userName.equals(userName) &&
            that.saveLocation.equals(saveLocation);
   }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/SectionDescriptor.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/SectionDescriptor.java
@@ -86,8 +86,7 @@ public final class SectionDescriptor implements Duplicatable {
   @Override
   public boolean equals(Object o)
   {
-    if (!(o instanceof SectionDescriptor)) return false;
-    SectionDescriptor sed = (SectionDescriptor)o;
+    if (!(o instanceof SectionDescriptor sed)) return false;
     return sed.fn == fn && sed.fnMpr == fnMpr;
   }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/StyleDescription.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/StyleDescription.java
@@ -218,9 +218,8 @@ public final class StyleDescription {
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (!(obj instanceof StyleDescription))
+        if (!(obj instanceof StyleDescription other))
             return false;
-        StyleDescription other = (StyleDescription) obj;
         if (!Objects.equals(_name, other._name)) {
             return false;
         }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/StyleSheet.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/StyleSheet.java
@@ -174,8 +174,7 @@ public final class StyleSheet {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof StyleSheet)) return false;
-        StyleSheet ss = (StyleSheet) o;
+        if (!(o instanceof StyleSheet ss)) return false;
 
         if (!ss._stshif.equals(this._stshif)
                 || ss._cbStshi != this._cbStshi

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/TextPiece.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/TextPiece.java
@@ -186,8 +186,7 @@ public class TextPiece extends PropertyNode<TextPiece> {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TextPiece)) return false;
-        TextPiece tp = (TextPiece) o;
+        if (!(o instanceof TextPiece tp)) return false;
         assert (_buf != null && tp._buf != null && _pd != null && tp._pd != null);
 
         return (

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/TextPieceTable.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/TextPieceTable.java
@@ -169,8 +169,7 @@ public class TextPieceTable implements CharIndexTranslator {
     }
 
     public boolean equals(Object o) {
-        if (!(o instanceof TextPieceTable)) return false;
-        TextPieceTable tpt = (TextPieceTable) o;
+        if (!(o instanceof TextPieceTable tpt)) return false;
 
         int size = tpt._textPieces.size();
         if (size == _textPieces.size()) {

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/UPX.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/model/UPX.java
@@ -43,8 +43,7 @@ public final class UPX
   @Override
   public boolean equals(Object o)
   {
-    if (!(o instanceof UPX)) return false;
-    UPX upx = (UPX)o;
+    if (!(o instanceof UPX upx)) return false;
     return Arrays.equals(_upx, upx._upx);
   }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/sprm/SprmBuffer.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/sprm/SprmBuffer.java
@@ -124,8 +124,7 @@ public final class SprmBuffer implements Duplicatable {
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof SprmBuffer)) return false;
-        SprmBuffer sprmBuf = (SprmBuffer) obj;
+        if (!(obj instanceof SprmBuffer sprmBuf)) return false;
         return (Arrays.equals(_buf, sprmBuf._buf));
     }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/BorderCode.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/BorderCode.java
@@ -76,8 +76,7 @@ public final class BorderCode implements Duplicatable {
   @Override
   public boolean equals(Object o)
   {
-    if (!(o instanceof BorderCode)) return false;
-    BorderCode brc = (BorderCode)o;
+    if (!(o instanceof BorderCode brc)) return false;
     return _info == brc._info && _info2 == brc._info2;
   }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/CharacterRun.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/CharacterRun.java
@@ -458,8 +458,8 @@ public final class CharacterRun extends Range implements Duplicatable, org.apach
 
   public String getFontName()
   {
-    if (_doc instanceof HWPFOldDocument) {
-      return ((HWPFOldDocument) _doc).getOldFontTable().getMainFont(_props.getFtcAscii());
+    if (_doc instanceof HWPFOldDocument oldDocument) {
+      return oldDocument.getOldFontTable().getMainFont(_props.getFtcAscii());
     }
 
     if (_doc.getFontTable() == null)
@@ -650,13 +650,13 @@ public final class CharacterRun extends Range implements Duplicatable, org.apach
 
     public String[] getDropDownListValues()
     {
-        if ( getDocument() instanceof HWPFDocument )
+        if ( getDocument() instanceof HWPFDocument document )
         {
             char c = _text.charAt( _start );
             if ( c == 0x01 )
             {
                 NilPICFAndBinData data = new NilPICFAndBinData(
-                        ( (HWPFDocument) getDocument() ).getDataStream(),
+                        document.getDataStream(),
                         getPicOffset() );
                 FFData ffData = new FFData( data.getBinData(), 0 );
 
@@ -668,13 +668,13 @@ public final class CharacterRun extends Range implements Duplicatable, org.apach
 
     public Integer getDropDownListDefaultItemIndex()
     {
-        if ( getDocument() instanceof HWPFDocument )
+        if ( getDocument() instanceof HWPFDocument document )
         {
             char c = _text.charAt( _start );
             if ( c == 0x01 )
             {
                 NilPICFAndBinData data = new NilPICFAndBinData(
-                        ( (HWPFDocument) getDocument() ).getDataStream(),
+                        document.getDataStream(),
                         getPicOffset() );
                 FFData ffData = new FFData( data.getBinData(), 0 );
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/DateAndTime.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/DateAndTime.java
@@ -69,8 +69,7 @@ public final class DateAndTime implements Duplicatable {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof DateAndTime)) return false;
-        DateAndTime dttm = (DateAndTime) o;
+        if (!(o instanceof DateAndTime dttm)) return false;
         return _info == dttm._info && _info2 == dttm._info2;
     }
 

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/LineSpacingDescriptor.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/LineSpacingDescriptor.java
@@ -75,8 +75,7 @@ public final class LineSpacingDescriptor implements Duplicatable {
   @Override
   public boolean equals(Object o)
   {
-    if (!(o instanceof LineSpacingDescriptor)) return false;
-    LineSpacingDescriptor lspd = (LineSpacingDescriptor)o;
+    if (!(o instanceof LineSpacingDescriptor lspd)) return false;
 
     return _dyaLine == lspd._dyaLine && _fMultiLinespace == lspd._fMultiLinespace;
   }

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/OfficeDrawingsImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/OfficeDrawingsImpl.java
@@ -61,15 +61,13 @@ public class OfficeDrawingsImpl implements OfficeDrawings
 
         EscherRecord imageRecord = bContainer.getChild( bitmapIndex - 1 );
 
-        if ( imageRecord instanceof EscherBlipRecord )
+        if ( imageRecord instanceof EscherBlipRecord blipRecord )
         {
-            return (EscherBlipRecord) imageRecord;
+            return blipRecord;
         }
 
-        if ( imageRecord instanceof EscherBSERecord )
+        if ( imageRecord instanceof EscherBSERecord bseRecord )
         {
-            EscherBSERecord bseRecord = (EscherBSERecord) imageRecord;
-
             EscherBlipRecord blip = bseRecord.getBlipRecord();
             if ( blip != null )
             {
@@ -86,11 +84,11 @@ public class OfficeDrawingsImpl implements OfficeDrawings
                 EscherRecord record = recordFactory.createRecord( _mainStream,
                         bseRecord.getOffset() );
 
-                if ( record instanceof EscherBlipRecord )
+                if ( record instanceof EscherBlipRecord blipRecord )
                 {
                     record.fillFields( _mainStream, bseRecord.getOffset(),
                             recordFactory );
-                    return (EscherBlipRecord) record;
+                    return blipRecord;
                 }
             }
         }
@@ -123,23 +121,16 @@ public class OfficeDrawingsImpl implements OfficeDrawings
             {
                 int value = getTertiaryPropertyValue(EscherPropertyTypes.GROUPSHAPE__POSH );
 
-                switch ( value )
+                return switch ( value )
                 {
-                case 0:
-                    return HorizontalPositioning.ABSOLUTE;
-                case 1:
-                    return HorizontalPositioning.LEFT;
-                case 2:
-                    return HorizontalPositioning.CENTER;
-                case 3:
-                    return HorizontalPositioning.RIGHT;
-                case 4:
-                    return HorizontalPositioning.INSIDE;
-                case 5:
-                    return HorizontalPositioning.OUTSIDE;
-                }
-
-                return HorizontalPositioning.ABSOLUTE;
+                case 0 -> HorizontalPositioning.ABSOLUTE;
+                case 1 -> HorizontalPositioning.LEFT;
+                case 2 -> HorizontalPositioning.CENTER;
+                case 3 -> HorizontalPositioning.RIGHT;
+                case 4 -> HorizontalPositioning.INSIDE;
+                case 5 -> HorizontalPositioning.OUTSIDE;
+                default -> HorizontalPositioning.ABSOLUTE;
+                };
             }
 
             @Override
@@ -147,19 +138,14 @@ public class OfficeDrawingsImpl implements OfficeDrawings
             {
                 int value = getTertiaryPropertyValue( EscherPropertyTypes.GROUPSHAPE__POSRELH );
 
-                switch ( value )
+                return switch ( value )
                 {
-                case 1:
-                    return HorizontalRelativeElement.MARGIN;
-                case 2:
-                    return HorizontalRelativeElement.PAGE;
-                case 3:
-                    return HorizontalRelativeElement.TEXT;
-                case 4:
-                    return HorizontalRelativeElement.CHAR;
-                }
-
-                return HorizontalRelativeElement.TEXT;
+                case 1 -> HorizontalRelativeElement.MARGIN;
+                case 2 -> HorizontalRelativeElement.PAGE;
+                case 3 -> HorizontalRelativeElement.TEXT;
+                case 4 -> HorizontalRelativeElement.CHAR;
+                default -> HorizontalRelativeElement.TEXT;
+                };
             }
 
             @Override
@@ -244,23 +230,16 @@ public class OfficeDrawingsImpl implements OfficeDrawings
             {
                 int value = getTertiaryPropertyValue( EscherPropertyTypes.GROUPSHAPE__POSV );
 
-                switch ( value )
+                return switch ( value )
                 {
-                case 0:
-                    return VerticalPositioning.ABSOLUTE;
-                case 1:
-                    return VerticalPositioning.TOP;
-                case 2:
-                    return VerticalPositioning.CENTER;
-                case 3:
-                    return VerticalPositioning.BOTTOM;
-                case 4:
-                    return VerticalPositioning.INSIDE;
-                case 5:
-                    return VerticalPositioning.OUTSIDE;
-                }
-
-                return VerticalPositioning.ABSOLUTE;
+                case 0 -> VerticalPositioning.ABSOLUTE;
+                case 1 -> VerticalPositioning.TOP;
+                case 2 -> VerticalPositioning.CENTER;
+                case 3 -> VerticalPositioning.BOTTOM;
+                case 4 -> VerticalPositioning.INSIDE;
+                case 5 -> VerticalPositioning.OUTSIDE;
+                default -> VerticalPositioning.ABSOLUTE;
+                };
             }
 
             @Override
@@ -268,19 +247,14 @@ public class OfficeDrawingsImpl implements OfficeDrawings
             {
                 int value = getTertiaryPropertyValue( EscherPropertyTypes.GROUPSHAPE__POSV );
 
-                switch ( value )
+                return switch ( value )
                 {
-                case 1:
-                    return VerticalRelativeElement.MARGIN;
-                case 2:
-                    return VerticalRelativeElement.PAGE;
-                case 3:
-                    return VerticalRelativeElement.TEXT;
-                case 4:
-                    return VerticalRelativeElement.LINE;
-                }
-
-                return VerticalRelativeElement.TEXT;
+                case 1 -> VerticalRelativeElement.MARGIN;
+                case 2 -> VerticalRelativeElement.PAGE;
+                case 3 -> VerticalRelativeElement.TEXT;
+                case 4 -> VerticalRelativeElement.LINE;
+                default -> VerticalRelativeElement.TEXT;
+                };
             }
 
             @Override

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/Picture.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/Picture.java
@@ -273,15 +273,11 @@ public final class Picture {
         // trying to extract width and height from pictures content:
         switch ( pictureType )
         {
-        case JPEG:
-            fillJPGWidthHeight();
-            break;
-        case PNG:
-            fillPNGWidthHeight();
-            break;
-        default:
+        case JPEG -> fillJPGWidthHeight();
+        case PNG -> fillPNGWidthHeight();
+        default -> {
             // unsupported;
-            break;
+        }
         }
     }
 
@@ -387,8 +383,7 @@ public final class Picture {
             EscherOptRecord optRecord = shape.getChildById(EscherRecordTypes.OPT.typeID);
             if (optRecord != null) {
                 EscherProperty property = optRecord.lookup(propType);
-                if (property instanceof EscherSimpleProperty) {
-                    EscherSimpleProperty simpleProperty = (EscherSimpleProperty) property;
+                if (property instanceof EscherSimpleProperty simpleProperty) {
                     return Units.fixedPointToDouble(simpleProperty.getPropertyValue());
                 }
             }
@@ -453,14 +448,14 @@ public final class Picture {
         }
 
         EscherRecord escherRecord = _blipRecords.get( 0 );
-        if ( escherRecord instanceof EscherBlipRecord )
+        if ( escherRecord instanceof EscherBlipRecord blipRecord )
         {
-            return ( (EscherBlipRecord) escherRecord ).getPicturedata();
+            return blipRecord.getPicturedata();
         }
 
-        if ( escherRecord instanceof EscherBSERecord )
+        if ( escherRecord instanceof EscherBSERecord bseRecord )
         {
-            EscherBlipRecord blip = ( (EscherBSERecord) escherRecord ).getBlipRecord();
+            EscherBlipRecord blip = bseRecord.getBlipRecord();
             if (blip != null) {
                 return blip.getPicturedata();
 
@@ -516,8 +511,7 @@ public final class Picture {
     public String getDescription()
     {
        for(EscherRecord escherRecord : _picfAndOfficeArtData.getShape()){
-          if(escherRecord instanceof EscherOptRecord){
-             EscherOptRecord escherOptRecord = (EscherOptRecord) escherRecord;
+          if(escherRecord instanceof EscherOptRecord escherOptRecord){
              for(EscherProperty property : escherOptRecord.getEscherProperties()){
                 if (EscherPropertyTypes.GROUPSHAPE__DESCRIPTION.propNumber == property.getPropertyNumber()){
                    byte[] complexData = ((EscherComplexProperty)property).getComplexData();
@@ -561,56 +555,36 @@ public final class Picture {
         }
 
         EscherRecord escherRecord = _blipRecords.get( 0 );
-        if (escherRecord instanceof EscherBSERecord) {
-            EscherBSERecord bseRecord = (EscherBSERecord) escherRecord;
-            switch ( bseRecord.getBlipTypeWin32() ) {
-                case 0x00:
-                    return PictureType.UNKNOWN;
-                case 0x01:
-                    return PictureType.UNKNOWN;
-                case 0x02:
-                    return PictureType.EMF;
-                case 0x03:
-                    return PictureType.WMF;
-                case 0x04:
-                    return PictureType.PICT;
-                case 0x05:
-                    return PictureType.JPEG;
-                case 0x06:
-                    return PictureType.PNG;
-                case 0x07:
-                    return PictureType.BMP;
-                case 0x11:
-                    return PictureType.TIFF;
-                case 0x12:
-                    return PictureType.JPEG;
-                default:
-                    return PictureType.UNKNOWN;
-            }
+        if (escherRecord instanceof EscherBSERecord bseRecord) {
+            return switch ( bseRecord.getBlipTypeWin32() ) {
+                case 0x00 -> PictureType.UNKNOWN;
+                case 0x01 -> PictureType.UNKNOWN;
+                case 0x02 -> PictureType.EMF;
+                case 0x03 -> PictureType.WMF;
+                case 0x04 -> PictureType.PICT;
+                case 0x05 -> PictureType.JPEG;
+                case 0x06 -> PictureType.PNG;
+                case 0x07 -> PictureType.BMP;
+                case 0x11 -> PictureType.TIFF;
+                case 0x12 -> PictureType.JPEG;
+                default -> PictureType.UNKNOWN;
+            };
         }
 
         Enum<?> recordType = escherRecord.getGenericRecordType();
         if (!(recordType instanceof EscherRecordTypes escherRecordType)) {
             throw new AssertionError("Expected EscherRecordTypes");
         }
-        switch (escherRecordType) {
-            case BLIP_EMF:
-                return PictureType.EMF;
-            case BLIP_WMF:
-                return PictureType.WMF;
-            case BLIP_PICT:
-                return PictureType.PICT;
-            case BLIP_JPEG:
-                return PictureType.JPEG;
-            case BLIP_PNG:
-                return PictureType.PNG;
-            case BLIP_DIB:
-                return PictureType.BMP;
-            case BLIP_TIFF:
-                return PictureType.TIFF;
-            default:
-                return PictureType.UNKNOWN;
-        }
+        return switch (escherRecordType) {
+            case BLIP_EMF -> PictureType.EMF;
+            case BLIP_WMF -> PictureType.WMF;
+            case BLIP_PICT -> PictureType.PICT;
+            case BLIP_JPEG -> PictureType.JPEG;
+            case BLIP_PNG -> PictureType.PNG;
+            case BLIP_DIB -> PictureType.BMP;
+            case BLIP_TIFF -> PictureType.TIFF;
+            default -> PictureType.UNKNOWN;
+        };
     }
 
     /**

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/Range.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/Range.java
@@ -17,7 +17,6 @@
 
 package org.apache.poi.hwpf.usermodel;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.logging.log4j.util.Unbox.box;
 
 import java.util.List;
@@ -197,15 +196,15 @@ public class Range {
         _end = other._end;
         _doc = other._doc;
         _sectionRangeFound = other._sectionRangeFound;
-        _sections = (other._sections == null) ? null : other._sections.stream().map(SEPX::copy).collect(toList());
+        _sections = (other._sections == null) ? null : other._sections.stream().map(SEPX::copy).toList();
         _sectionStart = other._sectionStart;
         _sectionEnd = other._sectionEnd;
         _parRangeFound = other._parRangeFound;
-        _paragraphs = (other._paragraphs == null) ? null : other._paragraphs.stream().map(PAPX::copy).collect(toList());
+        _paragraphs = (other._paragraphs == null) ? null : other._paragraphs.stream().map(PAPX::copy).toList();
         _parStart = other._parStart;
         _parEnd = other._parEnd;
         _charRangeFound = other._charRangeFound;
-        _characters = (other._characters == null) ? null : other._characters.stream().map(CHPX::copy).collect(toList());
+        _characters = (other._characters == null) ? null : other._characters.stream().map(CHPX::copy).toList();
         _charStart = other._charStart;
         _charEnd = other._charEnd;
         _text = (other._text == null) ? null : new StringBuilder(other._text);
@@ -334,9 +333,9 @@ public class Range {
         _doc.getCharacterTable().adjustForInsert( _charStart, text.length() );
         _doc.getParagraphTable().adjustForInsert( _parStart, text.length() );
         _doc.getSectionTable().adjustForInsert( _sectionStart, text.length() );
-        if ( _doc instanceof HWPFDocument )
+        if ( _doc instanceof HWPFDocument document )
         {
-            ( (BookmarksImpl) ( (HWPFDocument) _doc ).getBookmarks() )
+            ( (BookmarksImpl) document.getBookmarks() )
                     .afterInsert( _start, text.length() );
         }
         adjustForInsert( text.length() );
@@ -365,9 +364,9 @@ public class Range {
         _doc.getCharacterTable().adjustForInsert( _charEnd - 1, text.length() );
         _doc.getParagraphTable().adjustForInsert( _parEnd - 1, text.length() );
         _doc.getSectionTable().adjustForInsert( _sectionEnd - 1, text.length() );
-        if ( _doc instanceof HWPFDocument )
+        if ( _doc instanceof HWPFDocument document )
         {
-            ( (BookmarksImpl) ( (HWPFDocument) _doc ).getBookmarks() )
+            ( (BookmarksImpl) document.getBookmarks() )
                     .afterInsert( _end, text.length() );
         }
         adjustForInsert( text.length() );
@@ -566,9 +565,9 @@ public class Range {
             // + " -> " + sepx.getEnd());
         }
 
-        if ( _doc instanceof HWPFDocument )
+        if ( _doc instanceof HWPFDocument document )
         {
-            ( (BookmarksImpl) ( (HWPFDocument) _doc ).getBookmarks() )
+            ( (BookmarksImpl) document.getBookmarks() )
                     .afterDelete( _start, ( _end - _start ) );
         }
 
@@ -718,9 +717,9 @@ public class Range {
         }
 
         short istd;
-        if ( this instanceof Paragraph )
+        if ( this instanceof Paragraph paragraph )
         {
-            istd = ((Paragraph) this)._istd;
+            istd = paragraph._istd;
         }
         else
         {


### PR DESCRIPTION
Follow-up to #1237, same treatment for poi-scratchpad. Mechanical, behavior-preserving modernization now that the build targets Java 17:

- pattern-matching `instanceof` in place of instanceof-then-cast (~230 sites across hslf, hwpf, hsmf, hmef, hemf, hwmf, hpbf and the ole2 extractor factory)
- arrow-form `switch` statements / switch expressions where cases had no fall-through or shared state (e.g. `HSLFSlideShow.addMovie`, `HSLFSlide.onCreate`, `Picture.suggestPictureType`, `OfficeDrawingsImpl` positioning getters)
- `Stream.toList()` instead of `collect(Collectors.toList())` where the resulting list is never mutated (`Range` copy constructor, `HSLFTextParagraph.getTabStops`, HemfPlus records)

Deliberately left alone: switches with fall-through or shared `default` labels, casts guarded by record-type IDs rather than instanceof (including ones relying on a deliberate `catch (ClassCastException)` in hsmf), casts to a different variable/type than the instanceof check, and `Collectors.toList()` results that are mutated afterwards (`HSLFSlideShowImpl`).

No public API signatures changed. `compileJava`/`compileTestJava` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)