### PR TITLE
Use more Java 17 idioms in the poi core module

### DIFF
--- a/poi/src/main/java/org/apache/poi/ddf/EscherArrayProperty.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherArrayProperty.java
@@ -23,7 +23,6 @@ import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.apache.poi.util.GenericRecordUtil;
@@ -261,7 +260,7 @@ public final class EscherArrayProperty extends EscherComplexProperty implements 
             "numElements", this::getNumberOfElementsInArray,
             "numElementsInMemory", this::getNumberOfElementsInMemory,
             "sizeOfElements", this::getSizeOfElements,
-            "elements", () -> StreamSupport.stream(spliterator(), false).collect(Collectors.toList())
+            "elements", () -> StreamSupport.stream(spliterator(), false).toList()
         );
     }
 }

--- a/poi/src/main/java/org/apache/poi/ddf/EscherBSERecord.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherBSERecord.java
@@ -112,12 +112,12 @@ public final class EscherBSERecord extends EscherRecord {
         int bytesRead = 0;
         if (bytesRemaining > 0) {
             EscherRecord record = recordFactory.createRecord(data, pos + 36);
-            if (!(record instanceof EscherBlipRecord)) {
+            if (!(record instanceof EscherBlipRecord blip)) {
                 throw new IllegalArgumentException("Did not have a EscherBlipRecord: " + record);
             }
 
             // Some older escher formats skip this last record
-            field_12_blipRecord = (EscherBlipRecord) record;
+            field_12_blipRecord = blip;
             bytesRead = field_12_blipRecord.fillFields( data, pos + 36, recordFactory );
         }
         pos += 36 + bytesRead;

--- a/poi/src/main/java/org/apache/poi/ddf/EscherComplexProperty.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherComplexProperty.java
@@ -191,11 +191,9 @@ public class EscherComplexProperty extends EscherProperty {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof EscherComplexProperty)) {
+        if (!(o instanceof EscherComplexProperty escherComplexProperty)) {
             return false;
         }
-
-        EscherComplexProperty escherComplexProperty = (EscherComplexProperty) o;
 
         // not equal if size differs
         if (complexSize != escherComplexProperty.complexSize) {

--- a/poi/src/main/java/org/apache/poi/ddf/EscherContainerRecord.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherContainerRecord.java
@@ -232,8 +232,8 @@ public final class EscherContainerRecord extends EscherRecord implements Iterabl
     public List<EscherContainerRecord> getChildContainers() {
         List<EscherContainerRecord> containers = new ArrayList<>();
         for (EscherRecord r : this) {
-            if(r instanceof EscherContainerRecord) {
-                containers.add((EscherContainerRecord) r);
+            if(r instanceof EscherContainerRecord c) {
+                containers.add(c);
             }
         }
         return containers;
@@ -305,8 +305,7 @@ public final class EscherContainerRecord extends EscherRecord implements Iterabl
      */
     public void getRecordsById(short recordId, List<EscherRecord> out){
         for (EscherRecord r : this) {
-            if(r instanceof EscherContainerRecord) {
-                EscherContainerRecord c = (EscherContainerRecord)r;
+            if(r instanceof EscherContainerRecord c) {
                 c.getRecordsById(recordId, out );
             } else if (r.getRecordId() == recordId){
                 out.add(r);

--- a/poi/src/main/java/org/apache/poi/ddf/EscherPropertyFactory.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherPropertyFactory.java
@@ -48,27 +48,20 @@ public final class EscherPropertyFactory {
 
             EscherPropertyTypes propertyType = EscherPropertyTypes.forPropertyID(propId);
 
-            final BiFunction<Short,Integer,EscherProperty> con;
-            switch (propertyType.holder) {
-                case BOOLEAN:
-                    con = EscherBoolProperty::new;
-                    break;
-                case RGB:
-                    con = EscherRGBProperty::new;
-                    break;
-                case SHAPE_PATH:
-                    con = EscherShapePathProperty::new;
-                    break;
-                default:
+            final BiFunction<Short,Integer,EscherProperty> con = switch (propertyType.holder) {
+                case BOOLEAN -> EscherBoolProperty::new;
+                case RGB -> EscherRGBProperty::new;
+                case SHAPE_PATH -> EscherShapePathProperty::new;
+                default -> {
                     if ( isComplex ) {
-                        con = (propertyType.holder == EscherPropertyTypesHolder.ARRAY)
+                        yield (propertyType.holder == EscherPropertyTypesHolder.ARRAY)
                             ? EscherArrayProperty::new
                             : EscherComplexProperty::new;
                     } else {
-                        con = EscherSimpleProperty::new;
+                        yield EscherSimpleProperty::new;
                     }
-                    break;
-            }
+                }
+            };
 
             results.add( con.apply(propId,propData) );
             pos += 6;
@@ -76,11 +69,9 @@ public final class EscherPropertyFactory {
 
         // Get complex data
         for (EscherProperty p : results) {
-            if (p instanceof EscherArrayProperty) {
-                EscherArrayProperty eap = (EscherArrayProperty)p;
+            if (p instanceof EscherArrayProperty eap) {
                 pos += eap.setArrayData(data, pos);
-            } else if (p instanceof EscherComplexProperty) {
-                EscherComplexProperty ecp = (EscherComplexProperty)p;
+            } else if (p instanceof EscherComplexProperty ecp) {
                 int cdLen = ecp.getComplexSize();
                 int leftover = data.length - pos;
                 if (leftover < cdLen) {

--- a/poi/src/main/java/org/apache/poi/ddf/EscherSimpleProperty.java
+++ b/poi/src/main/java/org/apache/poi/ddf/EscherSimpleProperty.java
@@ -121,11 +121,9 @@ public class EscherSimpleProperty extends EscherProperty {
         if ( this == o ) {
             return true;
         }
-        if ( !( o instanceof EscherSimpleProperty ) ) {
+        if ( !( o instanceof EscherSimpleProperty escherSimpleProperty ) ) {
             return false;
         }
-
-        final EscherSimpleProperty escherSimpleProperty = (EscherSimpleProperty) o;
 
         if ( propertyValue != escherSimpleProperty.propertyValue ) {
             return false;

--- a/poi/src/main/java/org/apache/poi/ddf/UnknownEscherRecord.java
+++ b/poi/src/main/java/org/apache/poi/ddf/UnknownEscherRecord.java
@@ -95,8 +95,8 @@ public final class UnknownEscherRecord extends EscherRecord {
                 EscherRecord child = recordFactory.createRecord( data, offset );
                 final int childBytesWritten;
 
-                if (child instanceof EscherContainerRecord) {
-                    childBytesWritten = ((EscherContainerRecord)child).fillFields(data, offset, recordFactory, nesting + 1);
+                if (child instanceof EscherContainerRecord ecr) {
+                    childBytesWritten = ecr.fillFields(data, offset, recordFactory, nesting + 1);
                 } else {
                     childBytesWritten = child.fillFields(data, offset, recordFactory, nesting + 1);
                 }

--- a/poi/src/main/java/org/apache/poi/hpsf/ClassID.java
+++ b/poi/src/main/java/org/apache/poi/hpsf/ClassID.java
@@ -213,7 +213,7 @@ public class ClassID implements Duplicatable, GenericRecord {
      */
     @Override
     public boolean equals(final Object o) {
-        return (o instanceof ClassID) && Arrays.equals(bytes, ((ClassID)o).bytes);
+        return (o instanceof ClassID other) && Arrays.equals(bytes, other.bytes);
     }
 
     /**

--- a/poi/src/main/java/org/apache/poi/hpsf/Property.java
+++ b/poi/src/main/java/org/apache/poi/hpsf/Property.java
@@ -298,10 +298,9 @@ public class Property {
      */
     @Override
     public boolean equals(final Object o) {
-        if (!(o instanceof Property)) {
+        if (!(o instanceof Property p)) {
             return false;
         }
-        final Property p = (Property) o;
         final Object pValue = p.getValue();
         final long pId = p.getID();
         if (id != pId || (id != 0 && !typesAreEqual(type, p.getType()))) {
@@ -322,9 +321,9 @@ public class Property {
             return false;
         }
 
-        if (value instanceof byte[]) {
+        if (value instanceof byte[] thisVal) {
             // compare without padding bytes
-            byte[] thisVal = (byte[]) value, otherVal = (byte[]) pValue;
+            byte[] otherVal = (byte[]) pValue;
             int len = unpaddedLength(thisVal);
             if (len != unpaddedLength(otherVal)) {
                 return false;
@@ -396,8 +395,8 @@ public class Property {
         b.append(") ");
         final Object value = getValue();
         b.append(", value: ");
-        if (value instanceof String) {
-            b.append((String)value);
+        if (value instanceof String str) {
+            b.append(str);
             b.append("\n");
             UnsynchronizedByteArrayOutputStream bos = UnsynchronizedByteArrayOutputStream.builder().get();
             try {
@@ -411,15 +410,13 @@ public class Property {
                 final String hex = HexDump.dump(bos.toByteArray(), -2L*LittleEndianConsts.INT_SIZE, 2*LittleEndianConsts.INT_SIZE);
                 b.append(hex);
             }
-        } else if (value instanceof byte[]) {
+        } else if (value instanceof byte[] bytes) {
             b.append("\n");
-            byte[] bytes = (byte[])value;
             if(bytes.length > 0) {
                 String hex = HexDump.dump(bytes, 0L, 0);
                 b.append(hex);
             }
-        } else if (value instanceof Date) {
-            Date d = (Date)value;
+        } else if (value instanceof Date d) {
             long filetime = Filetime.dateToFileTime(d);
             if (Filetime.isUndefined(d)) {
                 b.append("<undefined>");
@@ -469,10 +466,12 @@ public class Property {
     private String decodeValueFromID() {
         try {
             switch((int)getID()) {
-                case PropertyIDMap.PID_CODEPAGE:
+                case PropertyIDMap.PID_CODEPAGE -> {
                     return CodePageUtil.codepageToEncoding(((Number)value).intValue());
-                case PropertyIDMap.PID_LOCALE:
+                }
+                case PropertyIDMap.PID_LOCALE -> {
                     return LocaleUtil.getLocaleFromLCID(((Number)value).intValue());
+                }
             }
         } catch (Exception e) {
             LOG.atWarn().log("Can't decode id {}", box(getID()));

--- a/poi/src/main/java/org/apache/poi/hpsf/PropertySet.java
+++ b/poi/src/main/java/org/apache/poi/hpsf/PropertySet.java
@@ -627,31 +627,27 @@ public class PropertySet {
         if (propertyValue == null) {
             return null;
         }
-        if (propertyValue instanceof String) {
-            return (String)propertyValue;
+        if (propertyValue instanceof String str) {
+            return str;
         }
 
         // Do our best with some edge cases
-        if (propertyValue instanceof byte[]) {
-            byte[] b = (byte[])propertyValue;
-            switch (b.length) {
-                case 0:
-                    return "";
-                case 1:
-                    return Byte.toString(b[0]);
-                case 2:
-                    return Integer.toString( LittleEndian.getUShort(b) );
-                case 4:
-                    return Long.toString( LittleEndian.getUInt(b) );
-                default:
+        if (propertyValue instanceof byte[] b) {
+            return switch (b.length) {
+                case 0 -> "";
+                case 1 -> Byte.toString(b[0]);
+                case 2 -> Integer.toString( LittleEndian.getUShort(b) );
+                case 4 -> Long.toString( LittleEndian.getUInt(b) );
+                default -> {
                     // Maybe it's a string? who knows!
                     try {
-                        return CodePageUtil.getStringFromCodePage(b, Property.DEFAULT_CODEPAGE);
+                        yield CodePageUtil.getStringFromCodePage(b, Property.DEFAULT_CODEPAGE);
                     } catch (UnsupportedEncodingException e) {
                         // doesn't happen ...
-                        return "";
+                        yield "";
                     }
-            }
+                }
+            };
         }
         return propertyValue.toString();
     }
@@ -799,10 +795,9 @@ public class PropertySet {
      */
     @Override
     public boolean equals(final Object o) {
-        if (!(o instanceof PropertySet)) {
+        if (!(o instanceof PropertySet ps)) {
             return false;
         }
-        final PropertySet ps = (PropertySet) o;
         int byteOrder1 = ps.getByteOrder();
         int byteOrder2 = getByteOrder();
         ClassID classID1 = ps.getClassID();

--- a/poi/src/main/java/org/apache/poi/hpsf/Section.java
+++ b/poi/src/main/java/org/apache/poi/hpsf/Section.java
@@ -658,10 +658,9 @@ public class Section {
      */
     @Override
     public boolean equals(final Object o) {
-        if (!(o instanceof Section)) {
+        if (!(o instanceof Section s)) {
             return false;
         }
-        final Section s = (Section) o;
         if (!s.getFormatID().equals(getFormatID())) {
             return false;
         }

--- a/poi/src/main/java/org/apache/poi/hpsf/VariantSupport.java
+++ b/poi/src/main/java/org/apache/poi/hpsf/VariantSupport.java
@@ -188,36 +188,41 @@ public class VariantSupport extends Variant {
              * other types as byte arrays. In future major versions it shall be
              * changed -- sergey
              */
-            case Variant.VT_EMPTY:
-            case Variant.VT_I1:
-            case Variant.VT_UI1:
-            case Variant.VT_UI2:
-            case Variant.VT_I4:
-            case Variant.VT_UI4:
-            case Variant.VT_I8:
-            case Variant.VT_UI8:
-            case Variant.VT_R4:
-            case Variant.VT_R8:
+            case Variant.VT_EMPTY,
+                 Variant.VT_I1,
+                 Variant.VT_UI1,
+                 Variant.VT_UI2,
+                 Variant.VT_I4,
+                 Variant.VT_UI4,
+                 Variant.VT_I8,
+                 Variant.VT_UI8,
+                 Variant.VT_R4,
+                 Variant.VT_R8 -> {
                 return typedPropertyValue.getValue();
+            }
 
             /*
              * also for backward-compatibility with prev. versions of POI
              * --sergey
              */
-            case Variant.VT_I2:
+            case Variant.VT_I2 -> {
                 return ( (Short) typedPropertyValue.getValue() ).intValue();
+            }
 
-            case Variant.VT_FILETIME:
+            case Variant.VT_FILETIME -> {
                 Filetime filetime = (Filetime) typedPropertyValue.getValue();
                 return filetime.getJavaValue();
+            }
 
-            case Variant.VT_LPSTR:
+            case Variant.VT_LPSTR -> {
                 CodePageString cpString = (CodePageString) typedPropertyValue.getValue();
                 return cpString.getJavaValue( codepage );
+            }
 
-            case Variant.VT_LPWSTR:
+            case Variant.VT_LPWSTR -> {
                 UnicodeString uniString = (UnicodeString) typedPropertyValue.getValue();
                 return uniString.toJavaString();
+            }
 
             // if(l1 < 0) {
             /*
@@ -237,25 +242,28 @@ public class VariantSupport extends Variant {
             // System.arraycopy(src, o1, v, 0, v.length);
             // value = v;
             // break;
-            case Variant.VT_CF:
+            case Variant.VT_CF -> {
                 ClipboardData clipboardData = (ClipboardData) typedPropertyValue.getValue();
                 return clipboardData.toByteArray();
+            }
 
-            case Variant.VT_BOOL:
+            case Variant.VT_BOOL -> {
                 VariantBool bool = (VariantBool) typedPropertyValue.getValue();
                 return bool.getValue();
+            }
 
             /*
              * it is not very good, but what can do without breaking current
              * API? --sergey
              */
-            default:
+            default -> {
                 final int unpadded = lei.getReadIndex()-offset;
                 lei.setReadIndex(offset);
                 final byte[] v = IOUtils.safelyAllocate(unpadded, CodePageString.getMaxRecordLength(),
                         "CodePageString.setMaxRecordLength()");
                 lei.readFully( v, 0, unpadded );
                 throw new ReadingNotSupportedException( type, v );
+            }
         }
     }
 
@@ -278,83 +286,81 @@ public class VariantSupport extends Variant {
     throws IOException, WritingNotSupportedException {
         int length = -1;
         switch ((int) type) {
-            case Variant.VT_BOOL: {
-                if (value instanceof Boolean) {
-                    int bb = ((Boolean)value) ? 0xff : 0x00;
+            case Variant.VT_BOOL -> {
+                if (value instanceof Boolean b) {
+                    int bb = b ? 0xff : 0x00;
                     out.write(bb);
                     out.write(bb);
                     length = 2;
                 }
-                break;
             }
 
-            case Variant.VT_LPSTR:
-                if (value instanceof String) {
+            case Variant.VT_LPSTR -> {
+                if (value instanceof String str) {
                     CodePageString codePageString = new CodePageString();
-                    codePageString.setJavaValue( (String)value, codepage );
+                    codePageString.setJavaValue( str, codepage );
                     length = codePageString.write( out );
                 }
-                break;
+            }
 
-            case Variant.VT_LPWSTR:
-                if (value instanceof String) {
+            case Variant.VT_LPWSTR -> {
+                if (value instanceof String str) {
                     UnicodeString uniString = new UnicodeString();
-                    uniString.setJavaValue((String)value);
+                    uniString.setJavaValue(str);
                     length = uniString.write(out);
                 }
-                break;
+            }
 
-            case Variant.VT_CF:
-                if (value instanceof byte[]) {
-                    final byte[] cf = (byte[]) value;
+            case Variant.VT_CF -> {
+                if (value instanceof byte[] cf) {
                     out.write(cf);
                     length = cf.length;
                 }
-                break;
+            }
 
-            case Variant.VT_EMPTY:
+            case Variant.VT_EMPTY -> {
                 LittleEndian.putUInt(Variant.VT_EMPTY, out);
                 length = LittleEndianConsts.INT_SIZE;
-                break;
+            }
 
-            case Variant.VT_I2:
-                if (value instanceof Number) {
-                    LittleEndian.putShort( out, ((Number)value).shortValue() );
+            case Variant.VT_I2 -> {
+                if (value instanceof Number n) {
+                    LittleEndian.putShort( out, n.shortValue() );
                     length = LittleEndianConsts.SHORT_SIZE;
                 }
-                break;
+            }
 
-            case Variant.VT_UI2:
-                if (value instanceof Number) {
-                    LittleEndian.putUShort( ((Number)value).intValue(), out );
+            case Variant.VT_UI2 -> {
+                if (value instanceof Number n) {
+                    LittleEndian.putUShort( n.intValue(), out );
                     length = LittleEndianConsts.SHORT_SIZE;
                 }
-                break;
+            }
 
-            case Variant.VT_I4:
-                if (value instanceof Number) {
-                    LittleEndian.putInt( ((Number)value).intValue(), out);
+            case Variant.VT_I4 -> {
+                if (value instanceof Number n) {
+                    LittleEndian.putInt( n.intValue(), out);
                     length = LittleEndianConsts.INT_SIZE;
                 }
-                break;
+            }
 
-            case Variant.VT_UI4:
-                if (value instanceof Number) {
-                    LittleEndian.putUInt( ((Number)value).longValue(), out);
+            case Variant.VT_UI4 -> {
+                if (value instanceof Number n) {
+                    LittleEndian.putUInt( n.longValue(), out);
                     length = LittleEndianConsts.INT_SIZE;
                 }
-                break;
+            }
 
-            case Variant.VT_I8:
-                if (value instanceof Number) {
-                    LittleEndian.putLong( ((Number)value).longValue(), out);
+            case Variant.VT_I8 -> {
+                if (value instanceof Number n) {
+                    LittleEndian.putLong( n.longValue(), out);
                     length = LittleEndianConsts.LONG_SIZE;
                 }
-                break;
+            }
 
-            case Variant.VT_UI8: {
-                if (value instanceof Number) {
-                    BigInteger bi = (value instanceof BigInteger) ? (BigInteger)value : BigInteger.valueOf(((Number)value).longValue());
+            case Variant.VT_UI8 -> {
+                if (value instanceof Number n) {
+                    BigInteger bi = (value instanceof BigInteger bigInt) ? bigInt : BigInteger.valueOf(n.longValue());
                     if (bi.bitLength() > 64) {
                         throw new WritingNotSupportedException(type, value);
                     }
@@ -371,39 +377,36 @@ public class VariantSupport extends Variant {
                     out.write(biBytesLE);
                     length = LittleEndianConsts.LONG_SIZE;
                 }
-                break;
             }
 
-            case Variant.VT_R4: {
-                if (value instanceof Number) {
-                    int floatBits = Float.floatToIntBits(((Number)value).floatValue());
+            case Variant.VT_R4 -> {
+                if (value instanceof Number n) {
+                    int floatBits = Float.floatToIntBits(n.floatValue());
                     LittleEndian.putInt(floatBits, out);
                     length = LittleEndianConsts.INT_SIZE;
                 }
-                break;
             }
 
-            case Variant.VT_R8:
-                if (value instanceof Number) {
-                    LittleEndian.putDouble( ((Number)value).doubleValue(), out);
+            case Variant.VT_R8 -> {
+                if (value instanceof Number n) {
+                    LittleEndian.putDouble( n.doubleValue(), out);
                     length = LittleEndianConsts.DOUBLE_SIZE;
                 }
-                break;
+            }
 
-            case Variant.VT_FILETIME:
-                Filetime filetimeValue = (value instanceof Date) ? new Filetime((Date)value) : new Filetime();
+            case Variant.VT_FILETIME -> {
+                Filetime filetimeValue = (value instanceof Date d) ? new Filetime(d) : new Filetime();
                 length = filetimeValue.write( out );
-                break;
+            }
 
-            default:
-                break;
+            default -> {
+            }
         }
 
         /* The variant type is not supported yet. However, if the value
          * is a byte array we can write it nevertheless. */
         if (length == -1) {
-            if (value instanceof byte[]) {
-                final byte[] b = (byte[]) value;
+            if (value instanceof byte[] b) {
                 out.write(b);
                 length = b.length;
                 writeUnsupportedTypeMessage(new WritingNotSupportedException(type, value));

--- a/poi/src/main/java/org/apache/poi/hssf/eventusermodel/EventWorkbookBuilder.java
+++ b/poi/src/main/java/org/apache/poi/hssf/eventusermodel/EventWorkbookBuilder.java
@@ -171,14 +171,14 @@ public class EventWorkbookBuilder {
          * @param record the record to be processed
          */
         public void processRecordInternally(org.apache.poi.hssf.record.Record record) {
-            if(record instanceof BoundSheetRecord) {
-                boundSheetRecords.add((BoundSheetRecord)record);
+            if(record instanceof BoundSheetRecord bsr) {
+                boundSheetRecords.add(bsr);
             }
-            else if(record instanceof ExternSheetRecord) {
-                externSheetRecords.add((ExternSheetRecord)record);
+            else if(record instanceof ExternSheetRecord esr) {
+                externSheetRecords.add(esr);
             }
-            else if(record instanceof SSTRecord) {
-                sstRecord = (SSTRecord)record;
+            else if(record instanceof SSTRecord sst) {
+                sstRecord = sst;
             }
         }
     }

--- a/poi/src/main/java/org/apache/poi/hssf/eventusermodel/FormatTrackingHSSFListener.java
+++ b/poi/src/main/java/org/apache/poi/hssf/eventusermodel/FormatTrackingHSSFListener.java
@@ -101,12 +101,10 @@ public class FormatTrackingHSSFListener implements HSSFListener {
      * @param record the record to be processed
      */
     public void processRecordInternally(Record record) {
-        if (record instanceof FormatRecord) {
-            FormatRecord fr = (FormatRecord) record;
+        if (record instanceof FormatRecord fr) {
             _customFormatRecords.put(Integer.valueOf(fr.getIndexCode()), fr);
         }
-        if (record instanceof ExtendedFormatRecord) {
-            ExtendedFormatRecord xr = (ExtendedFormatRecord) record;
+        if (record instanceof ExtendedFormatRecord xr) {
             _xfRecords.add(xr);
         }
     }
@@ -125,10 +123,10 @@ public class FormatTrackingHSSFListener implements HSSFListener {
      */
     public String formatNumberDateCell(CellValueRecordInterface cell) {
         double value;
-        if (cell instanceof NumberRecord) {
-            value = ((NumberRecord) cell).getValue();
-        } else if (cell instanceof FormulaRecord) {
-            value = ((FormulaRecord) cell).getValue();
+        if (cell instanceof NumberRecord nr) {
+            value = nr.getValue();
+        } else if (cell instanceof FormulaRecord fr) {
+            value = fr.getValue();
         } else {
             throw new IllegalArgumentException("Unsupported CellValue Record passed in " + cell);
         }

--- a/poi/src/main/java/org/apache/poi/hssf/eventusermodel/HSSFRequest.java
+++ b/poi/src/main/java/org/apache/poi/hssf/eventusermodel/HSSFRequest.java
@@ -94,8 +94,7 @@ public class HSSFRequest {
         if (listeners != null) {
 
             for (Object listenObj : listeners) {
-                if (listenObj instanceof AbortableHSSFListener) {
-                    AbortableHSSFListener listener = (AbortableHSSFListener) listenObj;
+                if (listenObj instanceof AbortableHSSFListener listener) {
                     userCode = listener.abortableProcessRecord(rec);
                     if (userCode != 0)
                         break;

--- a/poi/src/main/java/org/apache/poi/hssf/eventusermodel/MissingRecordAwareHSSFListener.java
+++ b/poi/src/main/java/org/apache/poi/hssf/eventusermodel/MissingRecordAwareHSSFListener.java
@@ -67,8 +67,7 @@ public final class MissingRecordAwareHSSFListener implements HSSFListener {
         int thisColumn;
         CellValueRecordInterface[] expandedRecords = null;
 
-        if (record instanceof CellValueRecordInterface) {
-            CellValueRecordInterface valueRec = (CellValueRecordInterface) record;
+        if (record instanceof CellValueRecordInterface valueRec) {
             thisRow = valueRec.getRow();
             thisColumn = valueRec.getColumn();
         } else {
@@ -83,15 +82,15 @@ public final class MissingRecordAwareHSSFListener implements HSSFListener {
             switch (record.getSid()) {
                 // the BOFRecord can represent either the beginning of a sheet or
                 // the workbook
-                case BOFRecord.sid:
+                case BOFRecord.sid -> {
                     BOFRecord bof = (BOFRecord) record;
-                    if (bof.getType() == BOFRecord.TYPE_WORKBOOK || 
+                    if (bof.getType() == BOFRecord.TYPE_WORKBOOK ||
                             bof.getType() == BOFRecord.TYPE_WORKSHEET) {
                         // Reset the row and column counts - new workbook / worksheet
                         resetCounts();
                     }
-                    break;
-                case RowRecord.sid:
+                }
+                case RowRecord.sid -> {
                     RowRecord rowrec = (RowRecord) record;
 
                     // If there's a jump in rows, fire off missing row records
@@ -105,34 +104,34 @@ public final class MissingRecordAwareHSSFListener implements HSSFListener {
                     // Record this as the last row we saw
                     lastRowRow = rowrec.getRowNumber();
                     lastCellColumn = -1;
-                    break;
-
-                case SharedFormulaRecord.sid:
+                }
+                case SharedFormulaRecord.sid -> {
                     // SharedFormulaRecord occurs after the first FormulaRecord of the cell range.
                     // There are probably (but not always) more cell records after this
                     // - so don't fire off the LastCellOfRowDummyRecord yet
                     childListener.processRecord(record);
                     return;
-                case MulBlankRecord.sid:
+                }
+                case MulBlankRecord.sid -> {
                     // These appear in the middle of the cell records, to
                     //  specify that the next bunch are empty but styled
                     // Expand this out into multiple blank cells
                     MulBlankRecord mbr = (MulBlankRecord)record;
                     expandedRecords = RecordFactory.convertBlankRecords(mbr);
-                    break;
-                case MulRKRecord.sid:
+                }
+                case MulRKRecord.sid -> {
                     // This is multiple consecutive number cells in one record
                     // Exand this out into multiple regular number cells
                     MulRKRecord mrk = (MulRKRecord)record;
                     expandedRecords = RecordFactory.convertRKRecords(mrk);
-                    break;
-                case NoteRecord.sid:
+                }
+                case NoteRecord.sid -> {
                     NoteRecord nrec = (NoteRecord) record;
                     thisRow = nrec.getRow();
                     thisColumn = nrec.getColumn();
-                    break;
-                default:
-                    break;
+                }
+                default -> {
+                }
             }
         }
 

--- a/poi/src/main/java/org/apache/poi/hssf/extractor/EventBasedExcelExtractor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/extractor/EventBasedExcelExtractor.java
@@ -200,11 +200,11 @@ public class EventBasedExcelExtractor implements POIOLE2TextExtractor, org.apach
             int thisRow = -1;
 
             switch (record.getSid()) {
-                case BoundSheetRecord.sid:
+                case BoundSheetRecord.sid -> {
                     BoundSheetRecord sr = (BoundSheetRecord) record;
                     sheetNames.add(sr.getSheetname());
-                    break;
-                case BOFRecord.sid:
+                }
+                case BOFRecord.sid -> {
                     BOFRecord bof = (BOFRecord) record;
                     if (bof.getType() == BOFRecord.TYPE_WORKSHEET) {
                         sheetNum++;
@@ -215,12 +215,10 @@ public class EventBasedExcelExtractor implements POIOLE2TextExtractor, org.apach
                             _text.append(sheetNames.get(sheetNum));
                         }
                     }
-                    break;
-                case SSTRecord.sid:
-                    sstRecord = (SSTRecord) record;
-                    break;
+                }
+                case SSTRecord.sid -> sstRecord = (SSTRecord) record;
 
-                case FormulaRecord.sid:
+                case FormulaRecord.sid -> {
                     FormulaRecord frec = (FormulaRecord) record;
                     thisRow = frec.getRow();
 
@@ -236,8 +234,8 @@ public class EventBasedExcelExtractor implements POIOLE2TextExtractor, org.apach
                             thisText = _ft.formatNumberDateCell(frec);
                         }
                     }
-                    break;
-                case StringRecord.sid:
+                }
+                case StringRecord.sid -> {
                     if (outputNextStringValue) {
                         // String for formula
                         StringRecord srec = (StringRecord) record;
@@ -245,32 +243,32 @@ public class EventBasedExcelExtractor implements POIOLE2TextExtractor, org.apach
                         thisRow = nextRow;
                         outputNextStringValue = false;
                     }
-                    break;
-                case LabelRecord.sid:
+                }
+                case LabelRecord.sid -> {
                     LabelRecord lrec = (LabelRecord) record;
                     thisRow = lrec.getRow();
                     thisText = lrec.getValue();
-                    break;
-                case LabelSSTRecord.sid:
+                }
+                case LabelSSTRecord.sid -> {
                     LabelSSTRecord lsrec = (LabelSSTRecord) record;
                     thisRow = lsrec.getRow();
                     if (sstRecord == null) {
                         throw new IllegalStateException("No SST record found");
                     }
                     thisText = sstRecord.getString(lsrec.getSSTIndex()).toString();
-                    break;
-                case NoteRecord.sid:
+                }
+                case NoteRecord.sid -> {
                     NoteRecord nrec = (NoteRecord) record;
                     thisRow = nrec.getRow();
                     // TODO: Find object to match nrec.getShapeId()
-                    break;
-                case NumberRecord.sid:
+                }
+                case NumberRecord.sid -> {
                     NumberRecord numrec = (NumberRecord) record;
                     thisRow = numrec.getRow();
                     thisText = _ft.formatNumberDateCell(numrec);
-                    break;
-                default:
-                    break;
+                }
+                default -> {
+                }
             }
 
             if (thisText != null) {
@@ -319,8 +317,8 @@ public class EventBasedExcelExtractor implements POIOLE2TextExtractor, org.apach
         // also ensure that an underlying DirectoryNode
         // is closed properly to avoid leaking file-handles
         DirectoryEntry root = getRoot();
-        if (root instanceof DirectoryNode) {
-            Closeable fs = ((DirectoryNode) root).getFileSystem();
+        if (root instanceof DirectoryNode node) {
+            Closeable fs = node.getFileSystem();
             if (isCloseFilesystem() && fs != null) {
                 fs.close();
             }

--- a/poi/src/main/java/org/apache/poi/hssf/extractor/OldExcelExtractor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/extractor/OldExcelExtractor.java
@@ -122,8 +122,8 @@ public class OldExcelExtractor implements POITextExtractor {
 
     @SuppressWarnings("java:S2093")
     private void open(InputStream biffStream) throws IOException {
-        BufferedInputStream bis = (biffStream instanceof BufferedInputStream)
-            ? (BufferedInputStream)biffStream
+        BufferedInputStream bis = (biffStream instanceof BufferedInputStream bufferedStream)
+            ? bufferedStream
             : new BufferedInputStream(biffStream, 8);
 
         if (FileMagic.valueOf(bis) == FileMagic.OLE2) {
@@ -151,17 +151,17 @@ public class OldExcelExtractor implements POITextExtractor {
         DocumentNode book;
         try {
             Entry entry = directory.getEntryCaseInsensitive(OLD_WORKBOOK_DIR_ENTRY_NAME);
-            if (!(entry instanceof DocumentNode)) {
+            if (!(entry instanceof DocumentNode node)) {
                 throw new IllegalArgumentException("Did not have an Excel 5/95 Book stream: " + entry);
             }
-            book = (DocumentNode) entry;
+            book = node;
         } catch (FileNotFoundException | IllegalArgumentException e) {
             // some files have "Workbook" instead
             Entry entry = directory.getEntryCaseInsensitive(WORKBOOK);
-            if (!(entry instanceof DocumentNode)) {
+            if (!(entry instanceof DocumentNode node)) {
                 throw new IllegalArgumentException("Did not have an Excel 5/95 Book stream: " + entry);
             }
-            book = (DocumentNode) entry;
+            book = node;
         }
 
         ris = new RecordInputStream(directory.createDocumentInputStream(book));
@@ -187,22 +187,13 @@ public class OldExcelExtractor implements POITextExtractor {
 
         // Work out what version we're dealing with
         int bofSid = ris.getSid();
-        switch (bofSid) {
-            case BOFRecord.biff2_sid:
-                biffVersion = 2;
-                break;
-            case BOFRecord.biff3_sid:
-                biffVersion = 3;
-                break;
-            case BOFRecord.biff4_sid:
-                biffVersion = 4;
-                break;
-            case BOFRecord.biff5_sid:
-                biffVersion = 5;
-                break;
-            default:
-                throw new IllegalArgumentException("File does not begin with a BOF, found sid of " + bofSid);
-        }
+        biffVersion = switch (bofSid) {
+            case BOFRecord.biff2_sid -> 2;
+            case BOFRecord.biff3_sid -> 3;
+            case BOFRecord.biff4_sid -> 4;
+            case BOFRecord.biff5_sid -> 5;
+            default -> throw new IllegalArgumentException("File does not begin with a BOF, found sid of " + bofSid);
+        };
 
         // Get the type
         BOFRecord bof = new BOFRecord(ris);
@@ -249,39 +240,35 @@ public class OldExcelExtractor implements POITextExtractor {
             ris.nextRecord();
 
             switch (sid) {
-                case  FILE_PASS_RECORD_SID:
+                case FILE_PASS_RECORD_SID ->
                     throw new EncryptedDocumentException("Encryption not supported for Old Excel files");
 
-                case OldSheetRecord.sid:
+                case OldSheetRecord.sid -> {
                     OldSheetRecord shr = new OldSheetRecord(ris);
                     shr.setCodePage(codepage);
                     text.append("Sheet: ");
                     text.append(shr.getSheetname());
                     text.append('\n');
-                    break;
+                }
 
-                case OldLabelRecord.biff2_sid:
-                case OldLabelRecord.biff345_sid:
+                case OldLabelRecord.biff2_sid, OldLabelRecord.biff345_sid -> {
                     OldLabelRecord lr = new OldLabelRecord(ris);
                     lr.setCodePage(codepage);
                     text.append(lr.getValue());
                     text.append('\n');
-                    break;
-                case OldStringRecord.biff2_sid:
-                case OldStringRecord.biff345_sid:
+                }
+                case OldStringRecord.biff2_sid, OldStringRecord.biff345_sid -> {
                     OldStringRecord sr = new OldStringRecord(ris);
                     sr.setCodePage(codepage);
                     text.append(sr.getString());
                     text.append('\n');
-                    break;
+                }
 
-                case NumberRecord.sid:
+                case NumberRecord.sid -> {
                     NumberRecord nr = new NumberRecord(ris);
                     handleNumericCell(text, nr.getValue());
-                    break;
-                case OldFormulaRecord.biff2_sid:
-                case OldFormulaRecord.biff3_sid:
-                case OldFormulaRecord.biff4_sid:
+                }
+                case OldFormulaRecord.biff2_sid, OldFormulaRecord.biff3_sid, OldFormulaRecord.biff4_sid -> {
                     // Biff 2 and 5+ share the same SID, due to a bug...
                     if (biffVersion == 5) {
                         FormulaRecord fr = new FormulaRecord(ris);
@@ -294,18 +281,15 @@ public class OldExcelExtractor implements POITextExtractor {
                             handleNumericCell(text, fr.getValue());
                         }
                     }
-                    break;
-                case RKRecord.sid:
+                }
+                case RKRecord.sid -> {
                     RKRecord rr = new RKRecord(ris);
                     handleNumericCell(text, rr.getRKNumber());
-                    break;
+                }
 
-                case CodepageRecord.sid:
-                    codepage = new CodepageRecord(ris);
-                    break;
+                case CodepageRecord.sid -> codepage = new CodepageRecord(ris);
 
-                default:
-                    ris.readFully(HSSFWorkbook.safelyAllocate(ris.remaining()));
+                default -> ris.readFully(HSSFWorkbook.safelyAllocate(ris.remaining()));
             }
         }
 

--- a/poi/src/main/java/org/apache/poi/hssf/model/ConvertAnchor.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/ConvertAnchor.java
@@ -31,10 +31,8 @@ public class ConvertAnchor
 {
     public static EscherRecord createAnchor( HSSFAnchor userAnchor )
     {
-        if (userAnchor instanceof HSSFClientAnchor)
+        if (userAnchor instanceof HSSFClientAnchor a)
         {
-            HSSFClientAnchor a = (HSSFClientAnchor) userAnchor;
-
             EscherClientAnchorRecord anchor = new EscherClientAnchorRecord();
             anchor.setRecordId( EscherClientAnchorRecord.RECORD_ID );
             anchor.setOptions( (short) 0x0000 );

--- a/poi/src/main/java/org/apache/poi/hssf/model/InternalSheet.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/InternalSheet.java
@@ -376,8 +376,8 @@ public final class InternalSheet {
     public InternalSheet cloneSheet() {
         List<Record> clonedRecords = new ArrayList<>(_records.size());
         for (RecordBase rb : _records) {
-            if (rb instanceof RecordAggregate) {
-                ((RecordAggregate) rb).visitContainedRecords(new RecordCloner(clonedRecords));
+            if (rb instanceof RecordAggregate agg) {
+                agg.visitContainedRecords(new RecordCloner(clonedRecords));
                 continue;
             }
             if (rb instanceof EscherAggregate) {
@@ -558,11 +558,10 @@ public final class InternalSheet {
         for (int k = 0; k < _records.size(); k++) {
             RecordBase recordBase = _records.get(k);
 
-            if (recordBase instanceof RecordAggregate) {
-                RecordAggregate agg = (RecordAggregate) recordBase;
+            if (recordBase instanceof RecordAggregate agg) {
                 agg.visitContainedRecords(ptv);
-            } else if (recordBase instanceof Record) {
-                ptv.visitRecord((Record) recordBase);
+            } else if (recordBase instanceof Record record) {
+                ptv.visitRecord(record);
             }
 
             // If the BOF record was just serialized then add the IndexRecord
@@ -1284,10 +1283,9 @@ public final class InternalSheet {
         int max = _records.size();
         for (int i=0; i< max; i++) {
             Object rb = _records.get(i);
-            if (!(rb instanceof Record)) {
+            if (!(rb instanceof Record record)) {
                 continue;
             }
-            Record record = (Record) rb;
             if (record.getSid() == sid) {
                 return i;
             }
@@ -1656,8 +1654,8 @@ public final class InternalSheet {
         List<NoteRecord> temp = new ArrayList<>();
         for(int i=_records.size()-1; i>=0; i--) {
             RecordBase rec = _records.get(i);
-            if (rec instanceof NoteRecord) {
-                temp.add((NoteRecord) rec);
+            if (rec instanceof NoteRecord note) {
+                temp.add(note);
             }
         }
         if (temp.size() < 1) {

--- a/poi/src/main/java/org/apache/poi/hssf/model/InternalWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/InternalWorkbook.java
@@ -468,10 +468,10 @@ public final class InternalWorkbook {
         }
 
         Record record = records.get((records.getFontpos() - (numfonts - 1)) + index);
-        if (!(record instanceof FontRecord)) {
+        if (!(record instanceof FontRecord fontRecord)) {
             throw new IllegalStateException("Did not have the expected record-type FontRecord: " + record.getClass());
         }
-        return ( FontRecord ) record;
+        return fontRecord;
     }
 
     /**
@@ -849,10 +849,10 @@ public final class InternalWorkbook {
         xfptr += index;
 
         Record record = records.get(xfptr);
-        if (!(record instanceof ExtendedFormatRecord)) {
+        if (!(record instanceof ExtendedFormatRecord xfr)) {
             throw new IllegalStateException("Did not have a ExtendedFormatRecord: " + record);
         }
-        return (ExtendedFormatRecord) record;
+        return xfr;
     }
 
     /**
@@ -912,8 +912,7 @@ public final class InternalWorkbook {
         //  the ExtendedFormat records
         for(int i=records.getXfpos(); i<records.size(); i++) {
             Record r = records.get(i);
-            if (r instanceof StyleRecord) {
-                StyleRecord sr = (StyleRecord)r;
+            if (r instanceof StyleRecord sr) {
                 if (sr.getXFIndex() == xfIndex) {
                     return sr;
                 }
@@ -934,8 +933,7 @@ public final class InternalWorkbook {
         //  the ExtendedFormat records
         for(int i=records.getXfpos(); i<records.size(); i++) {
             Record r = records.get(i);
-            if (r instanceof StyleRecord) {
-                StyleRecord sr = (StyleRecord)r;
+            if (r instanceof StyleRecord sr) {
                 if (sr.getXFIndex() == oldXf) {
                     sr.setXFIndex(newXf);
                 }
@@ -1043,8 +1041,8 @@ public final class InternalWorkbook {
         boolean wroteBoundSheets = false;
         for ( Record record : records.getRecords() ) {
             int len = 0;
-            if (record instanceof SSTRecord) {
-                lSST = (SSTRecord)record;
+            if (record instanceof SSTRecord sstRec) {
+                lSST = sstRec;
                 sstPos = pos;
             }
             if (record.getSid() == ExtSSTRecord.sid && lSST != null) {
@@ -1077,8 +1075,7 @@ public final class InternalWorkbook {
         // Can be a few short if new sheets were added
         if (records.getTabpos() > 0) {
             Record rec = records.get(records.getTabpos());
-            if (rec instanceof TabIdRecord) {
-                TabIdRecord tir = ( TabIdRecord ) rec;
+            if (rec instanceof TabIdRecord tir) {
                 if(tir.getTabIdSize() < boundsheets.size()) {
                     fixTabIdRecord();
                 }
@@ -1091,8 +1088,8 @@ public final class InternalWorkbook {
 
         SSTRecord lSST = null;
         for ( Record record : records.getRecords() ) {
-            if (record instanceof SSTRecord) {
-                lSST = (SSTRecord)record;
+            if (record instanceof SSTRecord sstRec) {
+                lSST = sstRec;
             }
 
             if (record.getSid() == ExtSSTRecord.sid && lSST != null) {
@@ -1823,8 +1820,8 @@ public final class InternalWorkbook {
         int palettePos = records.getPalettepos();
         if (palettePos != -1) {
             Record rec = records.get(palettePos);
-            if (rec instanceof PaletteRecord) {
-                palette = (PaletteRecord) rec;
+            if (rec instanceof PaletteRecord paletteRecord) {
+                palette = paletteRecord;
             } else {
                 throw new IllegalStateException("InternalError: Expected PaletteRecord but got a '"+rec+"'");
             }
@@ -1850,10 +1847,9 @@ public final class InternalWorkbook {
 
         // Need to find a DrawingGroupRecord that contains a EscherDggRecord
         for(Record r : records.getRecords() ) {
-            if (!(r instanceof DrawingGroupRecord)) {
+            if (!(r instanceof DrawingGroupRecord dg)) {
                 continue;
             }
-            DrawingGroupRecord dg = (DrawingGroupRecord)r;
             dg.decode();
             drawingManager = findDrawingManager(dg, escherBSERecords);
             if (drawingManager != null) {
@@ -1881,8 +1877,8 @@ public final class InternalWorkbook {
         EscherDggRecord dgg = null;
         EscherContainerRecord bStore = null;
         for(EscherRecord er : cr) {
-            if (er instanceof EscherDggRecord) {
-                dgg = (EscherDggRecord) er;
+            if (er instanceof EscherDggRecord dggRecord) {
+                dgg = dggRecord;
             } else if (er.getRecordId() == EscherContainerRecord.BSTORE_CONTAINER) {
                 bStore = (EscherContainerRecord) er;
             }
@@ -1895,8 +1891,8 @@ public final class InternalWorkbook {
         DrawingManager2 dm = new DrawingManager2(dgg);
         if(bStore != null){
             for (EscherRecord bs : bStore) {
-                if(bs instanceof EscherBSERecord) {
-                    escherBSERecords.add((EscherBSERecord)bs);
+                if(bs instanceof EscherBSERecord bse) {
+                    escherBSERecords.add(bse);
                 }
             }
         }
@@ -2143,13 +2139,13 @@ public final class InternalWorkbook {
 
         EscherDgRecord dg = null;
         for(EscherRecord er : escherContainer) {
-            if(er instanceof EscherDgRecord) {
-                dg = (EscherDgRecord)er;
+            if(er instanceof EscherDgRecord dgRecord) {
+                dg = dgRecord;
                 //update id of the drawing in the cloned sheet
                 dg.setOptions( (short) ( dgId << 4 ) );
-            } else if (er instanceof EscherContainerRecord){
+            } else if (er instanceof EscherContainerRecord container){
                 // iterate over shapes and re-generate shapeId
-                for(EscherRecord er2 : (EscherContainerRecord)er) {
+                for(EscherRecord er2 : container) {
                     for(EscherRecord shapeChildRecord : (EscherContainerRecord)er2) {
                         int recordId = shapeChildRecord.getRecordId();
                         if (recordId == EscherSpRecord.RECORD_ID){

--- a/poi/src/main/java/org/apache/poi/hssf/model/LinkTable.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/LinkTable.java
@@ -82,11 +82,11 @@ final class LinkTable {
             CRNRecord[] crns = new CRNRecord[nCRNs];
             for (int i = 0; i < crns.length; i++) {
                 Record record = rs.getNext();
-                if (!(record instanceof CRNRecord)) {
+                if (!(record instanceof CRNRecord crn)) {
                     throw new IllegalStateException("Record is not a CRNRecord: " +
                             (record == null ? "<null>" : record.getClass() + ": " + record) );
                 }
-                crns[i] = (CRNRecord) record;
+                crns[i] = crn;
             }
             _crns = crns;
         }
@@ -662,7 +662,7 @@ final class LinkTable {
         // find the posistion of the Add-In SupBookRecord in the workbook stream,
         // the created ExternalNameRecord will be appended to it
         for (org.apache.poi.hssf.record.Record record : _workbookRecordList.getRecords()) {
-            if (record instanceof SupBookRecord && ((SupBookRecord) record).isAddInFunctions()) {
+            if (record instanceof SupBookRecord sbr && sbr.isAddInFunctions()) {
                 break;
             }
             supLinkIndex++;

--- a/poi/src/main/java/org/apache/poi/hssf/model/RowBlocksReader.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/RowBlocksReader.java
@@ -69,10 +69,9 @@ public final class RowBlocksReader {
             switch (rec.getSid()) {
                 case MergeCellsRecord.sid:    dest = mergeCellRecords; break;
                 case SharedFormulaRecord.sid: dest = shFrmRecords;
-                    if (!(prevRec instanceof FormulaRecord)) {
+                    if (!(prevRec instanceof FormulaRecord fr)) {
                         throw new IllegalStateException("Shared formula record should follow a FormulaRecord, but had " + prevRec);
                     }
-                    FormulaRecord fr = (FormulaRecord)prevRec;
                     firstCellRefs.add(new CellReference(fr.getRow(), fr.getColumn()));
                     break;
                 case ArrayRecord.sid:         dest = arrayRecords;     break;

--- a/poi/src/main/java/org/apache/poi/hssf/record/AbstractEscherHolderRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/AbstractEscherHolderRecord.java
@@ -151,8 +151,8 @@ public abstract class AbstractEscherHolderRecord extends Record {
      */
     public EscherContainerRecord getEscherContainer() {
         for (EscherRecord er : escherRecords) {
-            if(er instanceof EscherContainerRecord) {
-                return (EscherContainerRecord)er;
+            if(er instanceof EscherContainerRecord container) {
+                return container;
             }
         }
         return null;

--- a/poi/src/main/java/org/apache/poi/hssf/record/EscherAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/EscherAggregate.java
@@ -532,8 +532,8 @@ public final class EscherAggregate extends AbstractEscherHolderRecord {
     private static short sid(RecordBase record) {
         // Aggregates don't have a sid
         // We could step into them, but for these needs we don't care
-        return (record instanceof org.apache.poi.hssf.record.Record)
-            ? ((org.apache.poi.hssf.record.Record)record).getSid()
+        return (record instanceof org.apache.poi.hssf.record.Record rec)
+            ? rec.getSid()
             : -1;
     }
 

--- a/poi/src/main/java/org/apache/poi/hssf/record/ExtendedFormatRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/ExtendedFormatRecord.java
@@ -1725,8 +1725,7 @@ public final class ExtendedFormatRecord extends StandardRecord {
             return true;
         if (obj == null)
             return false;
-        if (obj instanceof ExtendedFormatRecord) {
-            final ExtendedFormatRecord other = (ExtendedFormatRecord) obj;
+        if (obj instanceof ExtendedFormatRecord other) {
             return Arrays.equals(stateSummary(), other.stateSummary());
         }
         return false;

--- a/poi/src/main/java/org/apache/poi/hssf/record/FontRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/FontRecord.java
@@ -485,7 +485,7 @@ public final class FontRecord extends StandardRecord {
     }
 
     public boolean equals(Object o) {
-        return (o instanceof FontRecord) && sameProperties((FontRecord) o);
+        return (o instanceof FontRecord other) && sameProperties(other);
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/hssf/record/RecordFactory.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/RecordFactory.java
@@ -78,11 +78,11 @@ public final class RecordFactory {
             // Not needed by POI.  Regenerated from scratch by POI when spreadsheet is written
             return new Record[] { null, };
         }
-        if (record instanceof RKRecord) {
-            return new Record[] { convertToNumberRecord((RKRecord) record), };
+        if (record instanceof RKRecord rk) {
+            return new Record[] { convertToNumberRecord(rk), };
         }
-        if (record instanceof MulRKRecord) {
-            return convertRKRecords((MulRKRecord)record);
+        if (record instanceof MulRKRecord mrk) {
+            return convertRKRecords(mrk);
         }
         return new Record[] { record, };
     }

--- a/poi/src/main/java/org/apache/poi/hssf/record/RecordFactoryInputStream.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/RecordFactoryInputStream.java
@@ -80,8 +80,8 @@ public final class RecordFactoryInputStream {
                     }
                     
                     // If it's a FILEPASS, track it specifically
-                    if (rec instanceof FilePassRecord) {
-                        fpr = (FilePassRecord) rec;
+                    if (rec instanceof FilePassRecord filePass) {
+                        fpr = filePass;
                     }
 
                     // workbook not encrypted (typical case)
@@ -338,12 +338,12 @@ public final class RecordFactoryInputStream {
             return null;
         }
 
-        if (record instanceof RKRecord) {
-            return RecordFactory.convertToNumberRecord((RKRecord) record);
+        if (record instanceof RKRecord rk) {
+            return RecordFactory.convertToNumberRecord(rk);
         }
 
-        if (record instanceof MulRKRecord) {
-            Record[] records = RecordFactory.convertRKRecords((MulRKRecord) record);
+        if (record instanceof MulRKRecord mrk) {
+            Record[] records = RecordFactory.convertRKRecords(mrk);
 
             _unreadRecordBuffer = records;
             _unreadRecordIndex = 1;
@@ -351,8 +351,7 @@ public final class RecordFactoryInputStream {
         }
 
         if (record.getSid() == DrawingGroupRecord.sid
-                && _lastRecord instanceof DrawingGroupRecord) {
-            DrawingGroupRecord lastDGRecord = (DrawingGroupRecord) _lastRecord;
+                && _lastRecord instanceof DrawingGroupRecord lastDGRecord) {
             lastDGRecord.join((AbstractEscherHolderRecord) record);
             return null;
         }
@@ -370,8 +369,8 @@ public final class RecordFactoryInputStream {
                 }
                 return null;
             }
-            if (_lastRecord instanceof DrawingGroupRecord) {
-                ((DrawingGroupRecord) _lastRecord).processContinueRecord(contRec.getData());
+            if (_lastRecord instanceof DrawingGroupRecord dgRecord) {
+                dgRecord.processContinueRecord(contRec.getData());
                 return null;
             }
             if (_lastRecord instanceof DrawingRecord) {
@@ -391,8 +390,8 @@ public final class RecordFactoryInputStream {
             throw new RecordFormatException("Unhandled Continue Record followining " + _lastRecord.getClass());
         }
         _lastRecord = record;
-        if (record instanceof DrawingRecord) {
-            _lastDrawingRecord = (DrawingRecord) record;
+        if (record instanceof DrawingRecord drawingRecord) {
+            _lastDrawingRecord = drawingRecord;
         }
         return record;
     }

--- a/poi/src/main/java/org/apache/poi/hssf/record/RecordInputStream.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/RecordInputStream.java
@@ -125,9 +125,9 @@ public final class RecordInputStream implements LittleEndianInput {
 
     public RecordInputStream(InputStream in, EncryptionInfo key, int initialOffset) throws RecordFormatException {
         if (key == null) {
-            _dataInput = (in instanceof LittleEndianInput)
+            _dataInput = (in instanceof LittleEndianInput lei)
                 // accessing directly is an optimisation
-                ? (LittleEndianInput)in
+                ? lei
                 // less optimal, but should work OK just the same. Often occurs in junit tests.
                 : new LittleEndianInputStream(in);
             _bhi = new SimpleHeaderInput(_dataInput);
@@ -516,10 +516,10 @@ public final class RecordInputStream implements LittleEndianInput {
      */
     @Internal
     public void mark(int readlimit) {
-        if (!(_dataInput instanceof InputStream)) {
+        if (!(_dataInput instanceof InputStream stream)) {
             throw new IllegalStateException("Cannot use mark for dataInput of type " + _dataInput.getClass() + ", need an InputStream");
         }
-        ((InputStream)_dataInput).mark(readlimit);
+        stream.mark(readlimit);
         _markedDataOffset = _currentDataOffset;
     }
 
@@ -539,6 +539,6 @@ public final class RecordInputStream implements LittleEndianInput {
 
     @Internal
     public boolean isEncrypted() {
-        return _dataInput instanceof Biff8DecryptingStream && ((Biff8DecryptingStream)_dataInput).isCurrentRecordEncrypted();
+        return _dataInput instanceof Biff8DecryptingStream bds && bds.isCurrentRecordEncrypted();
     }
 }

--- a/poi/src/main/java/org/apache/poi/hssf/record/TextObjectRecord.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/TextObjectRecord.java
@@ -127,10 +127,10 @@ public final class TextObjectRecord extends ContinuableRecord {
                 throw new RecordFormatException("Read " + ptgs.length
                         + " tokens but expected exactly 1");
             }
-            if (!(ptgs[0] instanceof OperandPtg)) {
+            if (!(ptgs[0] instanceof OperandPtg operandPtg)) {
                 throw new IllegalArgumentException("Had unexpected type of ptg at index 0: " + ptgs[0].getClass());
             }
-            _linkRefPtg = (OperandPtg) ptgs[0];
+            _linkRefPtg = operandPtg;
             _unknownPostFormulaByte = in.remaining() > 0 ? in.readByte() : null;
         } else {
             _linkRefPtg = null;

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/CFRecordsAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/CFRecordsAggregate.java
@@ -126,10 +126,10 @@ public final class CFRecordsAggregate extends RecordAggregate implements Generic
         CFRuleBase[] rules = new CFRuleBase[nRules];
         for (int i = 0; i < rules.length; i++) {
             Record record = rs.getNext();
-            if (!(record instanceof CFRuleBase)) {
+            if (!(record instanceof CFRuleBase cfRule)) {
                 throw new IllegalArgumentException("Did not have a CFRuleBase: " + record);
             }
-            rules[i] = (CFRuleBase) record;
+            rules[i] = cfRule;
         }
 
         return new CFRecordsAggregate(header, rules);
@@ -263,8 +263,7 @@ public final class CFRecordsAggregate extends RecordAggregate implements Generic
             if (ptgs != null && shifter.adjustFormula(ptgs, currentExternSheetIx)) {
                 rule.setParsedExpression2(ptgs);
             }
-            if (rule instanceof CFRule12Record) {
-                CFRule12Record rule12 = (CFRule12Record)rule;
+            if (rule instanceof CFRule12Record rule12) {
                 ptgs = rule12.getParsedExpressionScale();
                 if (ptgs != null && shifter.adjustFormula(ptgs, currentExternSheetIx)) {
                     rule12.setParsedExpressionScale(ptgs);

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/ChartSubstreamRecordAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/ChartSubstreamRecordAggregate.java
@@ -70,8 +70,8 @@ public final class ChartSubstreamRecordAggregate extends RecordAggregate {
         }
         rv.visitRecord(_bofRec);
         for (RecordBase rb : _recs) {
-            if (rb instanceof RecordAggregate) {
-                ((RecordAggregate) rb).visitContainedRecords(rv);
+            if (rb instanceof RecordAggregate agg) {
+                agg.visitContainedRecords(rv);
             } else {
                 rv.visitRecord((org.apache.poi.hssf.record.Record) rb);
             }

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/CustomViewSettingsRecordAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/CustomViewSettingsRecordAggregate.java
@@ -77,8 +77,8 @@ public final class CustomViewSettingsRecordAggregate extends RecordAggregate {
         // need to copy list to avoid ConcurrentModificationException
         // as there are cases where the visitor modifies the list itself
         for (RecordBase rb : new ArrayList<>(_recs)) {
-            if (rb instanceof RecordAggregate) {
-                ((RecordAggregate) rb).visitContainedRecords(rv);
+            if (rb instanceof RecordAggregate agg) {
+                agg.visitContainedRecords(rv);
             } else {
                 rv.visitRecord((org.apache.poi.hssf.record.Record) rb);
             }

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/PageSettingsBlock.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/PageSettingsBlock.java
@@ -139,62 +139,60 @@ public final class PageSettingsBlock extends RecordAggregate {
 
     private boolean readARecord(RecordStream rs) {
         switch (rs.peekNextSid()) {
-            case HorizontalPageBreakRecord.sid:
+            case HorizontalPageBreakRecord.sid -> {
                 checkNotPresent(_rowBreaksRecord);
                 _rowBreaksRecord = (PageBreakRecord) rs.getNext();
-                break;
-            case VerticalPageBreakRecord.sid:
+            }
+            case VerticalPageBreakRecord.sid -> {
                 checkNotPresent(_columnBreaksRecord);
                 _columnBreaksRecord = (PageBreakRecord) rs.getNext();
-                break;
-            case HeaderRecord.sid:
+            }
+            case HeaderRecord.sid -> {
                 checkNotPresent(_header);
                 _header = (HeaderRecord) rs.getNext();
-                break;
-            case FooterRecord.sid:
+            }
+            case FooterRecord.sid -> {
                 checkNotPresent(_footer);
                 _footer = (FooterRecord) rs.getNext();
-                break;
-            case HCenterRecord.sid:
+            }
+            case HCenterRecord.sid -> {
                 checkNotPresent(_hCenter);
                 _hCenter = (HCenterRecord) rs.getNext();
-                break;
-            case VCenterRecord.sid:
+            }
+            case VCenterRecord.sid -> {
                 checkNotPresent(_vCenter);
                 _vCenter = (VCenterRecord) rs.getNext();
-                break;
-            case LeftMarginRecord.sid:
+            }
+            case LeftMarginRecord.sid -> {
                 checkNotPresent(_leftMargin);
                 _leftMargin = (LeftMarginRecord) rs.getNext();
-                break;
-            case RightMarginRecord.sid:
+            }
+            case RightMarginRecord.sid -> {
                 checkNotPresent(_rightMargin);
                 _rightMargin = (RightMarginRecord) rs.getNext();
-                break;
-            case TopMarginRecord.sid:
+            }
+            case TopMarginRecord.sid -> {
                 checkNotPresent(_topMargin);
                 _topMargin = (TopMarginRecord) rs.getNext();
-                break;
-            case BottomMarginRecord.sid:
+            }
+            case BottomMarginRecord.sid -> {
                 checkNotPresent(_bottomMargin);
                 _bottomMargin = (BottomMarginRecord) rs.getNext();
-                break;
-            case UnknownRecord.PLS_004D:
-                _plsRecords.add(new PLSAggregate(rs));
-                break;
-            case PrintSetupRecord.sid:
+            }
+            case UnknownRecord.PLS_004D -> _plsRecords.add(new PLSAggregate(rs));
+            case PrintSetupRecord.sid -> {
                 checkNotPresent(_printSetup);
                 _printSetup = (PrintSetupRecord)rs.getNext();
-                break;
-            case UnknownRecord.BITMAP_00E9:
+            }
+            case UnknownRecord.BITMAP_00E9 -> {
                 checkNotPresent(_bitmap);
                 _bitmap = rs.getNext();
-                break;
-            case UnknownRecord.PRINTSIZE_0033:
+            }
+            case UnknownRecord.PRINTSIZE_0033 -> {
                 checkNotPresent(_printSize);
                 _printSize = rs.getNext();
-                break;
-            case HeaderFooterRecord.sid:
+            }
+            case HeaderFooterRecord.sid -> {
                 //there can be multiple HeaderFooterRecord records belonging to different sheet views
                 HeaderFooterRecord hf = (HeaderFooterRecord)rs.getNext();
                 if(hf.isCurrentSheet()) {
@@ -202,10 +200,11 @@ public final class PageSettingsBlock extends RecordAggregate {
                 } else {
                     _sviewHeaderFooters.add(hf);
                 }
-                break;
-            default:
+            }
+            default -> {
                 // all other record types are not part of the PageSettingsBlock
                 return false;
+            }
         }
         return true;
     }
@@ -672,8 +671,7 @@ public final class PageSettingsBlock extends RecordAggregate {
         // loop through HeaderFooterRecord records having not-empty GUID and match them with
         // CustomViewSettingsRecordAggregate blocks having UserSViewBegin with the same GUID
         for (RecordBase rb : sheetRecords) {
-            if (rb instanceof CustomViewSettingsRecordAggregate) {
-                final CustomViewSettingsRecordAggregate cv = (CustomViewSettingsRecordAggregate) rb;
+            if (rb instanceof CustomViewSettingsRecordAggregate cv) {
                 cv.visitContainedRecords(r -> {
                     if (r.getSid() == UserSViewBegin.sid) {
                         String guid = HexDump.toHex(((UserSViewBegin) r).getGuid());

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/RowRecordsAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/RowRecordsAggregate.java
@@ -103,14 +103,14 @@ public final class RowRecordsAggregate extends RecordAggregate {
                 }
                 continue;
             }
-            if (rec instanceof MulBlankRecord) {
-                _valuesAgg.addMultipleBlanks((MulBlankRecord) rec);
+            if (rec instanceof MulBlankRecord mbr) {
+                _valuesAgg.addMultipleBlanks(mbr);
                 continue;
             }
-            if (!(rec instanceof CellValueRecordInterface)) {
+            if (!(rec instanceof CellValueRecordInterface cvRec)) {
                 throw new IllegalArgumentException("Unexpected record type (" + rec.getClass().getName() + ")");
             }
-            _valuesAgg.construct((CellValueRecordInterface)rec, rs, svm);
+            _valuesAgg.construct(cvRec, rs, svm);
         }
     }
 
@@ -520,8 +520,8 @@ public final class RowRecordsAggregate extends RecordAggregate {
         _valuesAgg.insertCell(cvRec);
     }
     public void removeCell(CellValueRecordInterface cvRec) {
-        if (cvRec instanceof FormulaRecordAggregate) {
-            ((FormulaRecordAggregate)cvRec).notifyFormulaChanging();
+        if (cvRec instanceof FormulaRecordAggregate fra) {
+            fra.notifyFormulaChanging();
         }
         _valuesAgg.removeCell(cvRec);
     }

--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/ValueRecordsAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/ValueRecordsAggregate.java
@@ -166,8 +166,7 @@ public final class ValueRecordsAggregate implements Iterable<CellValueRecordInte
      * @param sfh used to resolve any shared-formulas/arrays/tables for the current sheet
      */
     public void construct(CellValueRecordInterface rec, RecordStream rs, SharedValueManager sfh) {
-        if (rec instanceof FormulaRecord) {
-            FormulaRecord formulaRec = (FormulaRecord)rec;
+        if (rec instanceof FormulaRecord formulaRec) {
             // read optional cached text value
             StringRecord cachedText;
             Class<? extends Record> nextClass = rs.peekNextClass();
@@ -245,8 +244,7 @@ public final class ValueRecordsAggregate implements Iterable<CellValueRecordInte
             if (nBlank > 1) {
                 rv.visitRecord(createMBR(rowCells, i, nBlank));
                 i+=nBlank-1;
-            } else if (cvr instanceof RecordAggregate) {
-                RecordAggregate agg = (RecordAggregate) cvr;
+            } else if (cvr instanceof RecordAggregate agg) {
                 agg.visitContainedRecords(rv);
             } else {
                 rv.visitRecord((org.apache.poi.hssf.record.Record) cvr);
@@ -286,10 +284,9 @@ public final class ValueRecordsAggregate implements Iterable<CellValueRecordInte
                 continue;
             }
             for (CellValueRecordInterface cell : rowCells) {
-                if (cell instanceof FormulaRecordAggregate) {
-                    FormulaRecordAggregate fra = (FormulaRecordAggregate) cell;
+                if (cell instanceof FormulaRecordAggregate fra) {
                     Ptg[] ptgs = fra.getFormulaTokens(); // needs clone() inside this getter?
-                    Ptg[] ptgs2 = ((FormulaRecordAggregate) cell).getFormulaRecord().getParsedExpression(); // needs
+                    Ptg[] ptgs2 = fra.getFormulaRecord().getParsedExpression(); // needs
                     // clone() inside this getter?
 
                     if (shifter.adjustFormula(ptgs, currentExternSheetIndex)) {

--- a/poi/src/main/java/org/apache/poi/hssf/record/common/ExtRst.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/common/ExtRst.java
@@ -170,10 +170,9 @@ public class ExtRst implements Comparable<ExtRst>, GenericRecord {
     }
 
     public boolean equals(Object obj) {
-        if(! (obj instanceof ExtRst)) {
+        if(! (obj instanceof ExtRst other)) {
             return false;
         }
-        ExtRst other = (ExtRst)obj;
         return (compareTo(other) == 0);
     }
     public int compareTo(ExtRst o) {

--- a/poi/src/main/java/org/apache/poi/hssf/record/common/FormatRun.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/common/FormatRun.java
@@ -54,10 +54,9 @@ public class FormatRun implements Comparable<FormatRun>, GenericRecord {
     }
 
     public boolean equals(Object o) {
-        if (!(o instanceof FormatRun)) {
+        if (!(o instanceof FormatRun other)) {
             return false;
         }
-        FormatRun other = (FormatRun) o;
 
         return _character == other._character && _fontIndex == other._fontIndex;
     }

--- a/poi/src/main/java/org/apache/poi/hssf/record/common/UnicodeString.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/common/UnicodeString.java
@@ -123,10 +123,9 @@ public class UnicodeString implements Comparable<UnicodeString>, Duplicatable, G
      */
     public boolean equals(Object o)
     {
-        if (!(o instanceof UnicodeString)) {
+        if (!(o instanceof UnicodeString other)) {
             return false;
         }
-        UnicodeString other = (UnicodeString) o;
 
         //OK lets do this in stages to return quickly, first check the actual string
         if (field_1_charCount != other.field_1_charCount

--- a/poi/src/main/java/org/apache/poi/hssf/record/cont/UnknownLengthRecordOutput.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/cont/UnknownLengthRecordOutput.java
@@ -39,9 +39,8 @@ final class UnknownLengthRecordOutput implements LittleEndianOutput {
     public UnknownLengthRecordOutput(LittleEndianOutput out, int sid) {
         _originalOut = out;
         out.writeShort(sid);
-        if (out instanceof DelayableLittleEndianOutput) {
+        if (out instanceof DelayableLittleEndianOutput dleo) {
             // optimisation
-            DelayableLittleEndianOutput dleo = (DelayableLittleEndianOutput) out;
             _dataSizeOutput = dleo.createDelayedOutput(2);
             _byteBuffer = null;
             _out = out;

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/EscherGraphics2d.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/EscherGraphics2d.java
@@ -150,13 +150,11 @@ public final class EscherGraphics2d extends Graphics2D {
     @Override
     public void draw(Shape shape)
     {
-        if (shape instanceof Line2D)
+        if (shape instanceof Line2D shape2d)
         {
-            Line2D shape2d = (Line2D) shape;
-
             int width = 0;
-            if (_stroke != null && _stroke instanceof BasicStroke) {
-                width = MathUtil.safeDoubleToInt(((BasicStroke)_stroke).getLineWidth() * 12700);
+            if (_stroke != null && _stroke instanceof BasicStroke basicStroke) {
+                width = MathUtil.safeDoubleToInt(basicStroke.getLineWidth() * 12700);
             }
 
             drawLine(MathUtil.safeDoubleToInt(shape2d.getX1()), MathUtil.safeDoubleToInt(shape2d.getY1()), MathUtil.safeDoubleToInt(shape2d.getX2()), MathUtil.safeDoubleToInt(shape2d.getY2()), width);
@@ -248,8 +246,8 @@ public final class EscherGraphics2d extends Graphics2D {
     public void drawLine(int x1, int y1, int x2, int y2)
     {
         int width = 0;
-        if (_stroke != null && _stroke instanceof BasicStroke) {
-            width = MathUtil.safeDoubleToInt(((BasicStroke)_stroke).getLineWidth() * 12700);
+        if (_stroke != null && _stroke instanceof BasicStroke basicStroke) {
+            width = MathUtil.safeDoubleToInt(basicStroke.getLineWidth() * 12700);
         }
         getEscherGraphics().drawLine(x1,y1,x2,y2, width);
 //        draw(new GeneralPath(new java.awt.geom.Line2D.Float(x1, y1, x2, y2)));
@@ -559,8 +557,8 @@ public final class EscherGraphics2d extends Graphics2D {
         if(paint1 != null)
         {
             _paint = paint1;
-            if(paint1 instanceof Color)
-                setColor( (Color)paint1 );
+            if(paint1 instanceof Color color)
+                setColor( color );
         }
     }
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCell.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCell.java
@@ -275,7 +275,7 @@ public class HSSFCell extends CellBase {
         switch (cellType)
         {
 
-            case FORMULA :
+            case FORMULA -> {
                 FormulaRecordAggregate frec;
 
                 if (cellType != _cellType) {
@@ -290,9 +290,9 @@ public class HSSFCell extends CellBase {
                 }
                 frec.setXFIndex(styleIndex);
                 _record = frec;
-                break;
+            }
 
-            case NUMERIC :
+            case NUMERIC -> {
                 NumberRecord nrec;
 
                 if (cellType != _cellType)
@@ -311,9 +311,9 @@ public class HSSFCell extends CellBase {
                 nrec.setXFIndex(styleIndex);
                 nrec.setRow(row);
                 _record = nrec;
-                break;
+            }
 
-            case STRING :
+            case STRING -> {
                 LabelSSTRecord lrec;
 
                 if (cellType == _cellType) {
@@ -340,9 +340,9 @@ public class HSSFCell extends CellBase {
                     }
                 }
                 _record = lrec;
-                break;
+            }
 
-            case BLANK :
+            case BLANK -> {
                 BlankRecord brec;
 
                 if (cellType != _cellType)
@@ -359,9 +359,9 @@ public class HSSFCell extends CellBase {
                 brec.setXFIndex(styleIndex);
                 brec.setRow(row);
                 _record = brec;
-                break;
+            }
 
-            case BOOLEAN :
+            case BOOLEAN -> {
                 BoolErrRecord boolRec;
 
                 if (cellType != _cellType)
@@ -380,9 +380,9 @@ public class HSSFCell extends CellBase {
                 boolRec.setXFIndex(styleIndex);
                 boolRec.setRow(row);
                 _record = boolRec;
-                break;
+            }
 
-            case ERROR :
+            case ERROR -> {
                 BoolErrRecord errRec;
 
                 if (cellType != _cellType)
@@ -401,8 +401,8 @@ public class HSSFCell extends CellBase {
                 errRec.setXFIndex(styleIndex);
                 errRec.setRow(row);
                 _record = errRec;
-                break;
-            default :
+            }
+            default ->
                 throw new IllegalStateException("Invalid cell type: " + cellType);
         }
         if (cellType != _cellType &&
@@ -500,8 +500,7 @@ public class HSSFCell extends CellBase {
             setCellType(CellType.STRING, false, row, col, styleIndex);
         }
 
-        if (value instanceof HSSFRichTextString) {
-            HSSFRichTextString hvalue = (HSSFRichTextString) value;
+        if (value instanceof HSSFRichTextString hvalue) {
             UnicodeString str = hvalue.getUnicodeString();
             int index = _book.getWorkbook().addSSTString(str);
             (( LabelSSTRecord ) _record).setSSTIndex(index);
@@ -563,20 +562,11 @@ public class HSSFCell extends CellBase {
 
     private void restoreValue(CellValue value) {
         switch (value.getCellType()) {
-            case NUMERIC:
-                setCellValue(value.getNumberValue());
-                break;
-            case STRING:
-                setCellValue(value.getStringValue());
-                break;
-            case BOOLEAN:
-                setCellValue(value.getBooleanValue());
-                break;
-            case ERROR:
-                setCellErrorValue(FormulaError.forInt(value.getErrorValue()));
-                break;
-            default:
-                throw new IllegalStateException("Unexpected cell-type " + value.getCellType() + " for cell-value: " + value);
+            case NUMERIC -> setCellValue(value.getNumberValue());
+            case STRING -> setCellValue(value.getStringValue());
+            case BOOLEAN -> setCellValue(value.getBooleanValue());
+            case ERROR -> setCellErrorValue(FormulaError.forInt(value.getErrorValue()));
+            default -> throw new IllegalStateException("Unexpected cell-type " + value.getCellType() + " for cell-value: " + value);
         }
     }
 
@@ -587,24 +577,24 @@ public class HSSFCell extends CellBase {
         notifyFormulaChanging();
 
         switch (getCachedFormulaResultType()) {
-            case NUMERIC:
+            case NUMERIC -> {
                 double numericValue = ((FormulaRecordAggregate)_record).getFormulaRecord().getValue();
                 _record = new NumberRecord();
                 ((NumberRecord)_record).setValue(numericValue);
                 _cellType = CellType.NUMERIC;
-                break;
-            case STRING:
+            }
+            case STRING -> {
                 _record = new NumberRecord();
                 ((NumberRecord)_record).setValue(0);
                 _cellType = CellType.STRING;
-                break;
-            case BOOLEAN:
+            }
+            case BOOLEAN -> {
                 boolean booleanValue = ((FormulaRecordAggregate)_record).getFormulaRecord().getCachedBooleanValue();
                 _record = new BoolErrRecord();
                 ((BoolErrRecord)_record).setValue(booleanValue);
                 _cellType = CellType.BOOLEAN;
-                break;
-            case ERROR:
+            }
+            case ERROR -> {
                 byte errorValue = (byte) ((FormulaRecordAggregate)_record).getFormulaRecord().getCachedErrorValue();
                 _record = new BoolErrRecord();
                 try {
@@ -613,9 +603,8 @@ public class HSSFCell extends CellBase {
                     ((BoolErrRecord)_record).setValue((byte) ErrorEval.REF_INVALID.getErrorCode());
                 }
                 _cellType = CellType.ERROR;
-                break;
-            default:
-                throw new AssertionError();
+            }
+            default -> throw new AssertionError();
         }
     }
 
@@ -624,17 +613,17 @@ public class HSSFCell extends CellBase {
      * Does nothing if this cell currently does not hold a formula
      */
     private void notifyFormulaChanging() {
-        if (_record instanceof FormulaRecordAggregate) {
-            ((FormulaRecordAggregate)_record).notifyFormulaChanging();
+        if (_record instanceof FormulaRecordAggregate fra) {
+            fra.notifyFormulaChanging();
         }
     }
 
     @Override
     public String getCellFormula() {
-        if (!(_record instanceof FormulaRecordAggregate)) {
+        if (!(_record instanceof FormulaRecordAggregate fra)) {
             throw typeMismatch(CellType.FORMULA, _cellType, true);
         }
-        return HSSFFormulaParser.toFormulaString(_book, ((FormulaRecordAggregate)_record).getFormulaTokens());
+        return HSSFFormulaParser.toFormulaString(_book, fra.getFormulaTokens());
     }
 
     private static RuntimeException typeMismatch(CellType expectedTypeCode, CellType actualTypeCode, boolean isFormulaCell) {
@@ -833,28 +822,26 @@ public class HSSFCell extends CellBase {
      */
     private boolean convertCellValueToBoolean() {
 
-        switch (_cellType) {
-            case BOOLEAN:
-                return (( BoolErrRecord ) _record).getBooleanValue();
-            case STRING:
+        return switch (_cellType) {
+            case BOOLEAN -> (( BoolErrRecord ) _record).getBooleanValue();
+            case STRING -> {
                 int sstIndex = ((LabelSSTRecord)_record).getSSTIndex();
                 String text = _book.getWorkbook().getSSTString(sstIndex).getString();
-                return Boolean.parseBoolean(text);
-            case NUMERIC:
-                return ((NumberRecord)_record).getValue() != 0;
+                yield Boolean.parseBoolean(text);
+            }
+            case NUMERIC -> ((NumberRecord)_record).getValue() != 0;
 
-            case FORMULA:
+            case FORMULA -> {
                 // use cached formula result if it's the right type:
                 FormulaRecord fr = ((FormulaRecordAggregate)_record).getFormulaRecord();
                 checkFormulaCachedValueType(CellType.BOOLEAN, fr);
-                return fr.getCachedBooleanValue();
+                yield fr.getCachedBooleanValue();
+            }
             // Other cases convert to false
             // These choices are not well justified.
-            case ERROR:
-            case BLANK:
-                return false;
-        }
-        throw new IllegalStateException("Unexpected cell type (" + _cellType + ")");
+            case ERROR, BLANK -> false;
+            default -> throw new IllegalStateException("Unexpected cell type (" + _cellType + ")");
+        };
     }
 
     private String convertCellValueToString() {
@@ -918,16 +905,15 @@ public class HSSFCell extends CellBase {
      */
     @Override
     public byte getErrorCellValue() {
-        switch(_cellType) {
-            case ERROR:
-                return (( BoolErrRecord ) _record).getErrorValue();
-            case FORMULA:
+        return switch(_cellType) {
+            case ERROR -> (( BoolErrRecord ) _record).getErrorValue();
+            case FORMULA -> {
                 FormulaRecord fr = ((FormulaRecordAggregate)_record).getFormulaRecord();
                 checkFormulaCachedValueType(CellType.ERROR, fr);
-                return (byte) fr.getCachedErrorValue();
-            default:
-                throw typeMismatch(CellType.ERROR, _cellType, false);
-        }
+                yield (byte) fr.getCachedErrorValue();
+            }
+            default -> throw typeMismatch(CellType.ERROR, _cellType, false);
+        };
     }
 
     /**
@@ -1127,8 +1113,8 @@ public class HSSFCell extends CellBase {
         }
 
         HSSFHyperlink link;
-        if (hyperlink instanceof HSSFHyperlink) {
-            link = (HSSFHyperlink)hyperlink;
+        if (hyperlink instanceof HSSFHyperlink hssfHyperlink) {
+            link = hssfHyperlink;
         } else {
             link = new HSSFHyperlink(hyperlink);
         }
@@ -1139,18 +1125,11 @@ public class HSSFCell extends CellBase {
         link.setLastColumn(_record.getColumn());
 
         switch(link.getType()){
-            case EMAIL:
-            case URL:
-                link.setLabel("url");
-                break;
-            case FILE:
-                link.setLabel("file");
-                break;
-            case DOCUMENT:
-                link.setLabel("place");
-                break;
-            default:
-                break;
+            case EMAIL, URL -> link.setLabel("url");
+            case FILE -> link.setLabel("file");
+            case DOCUMENT -> link.setLabel("place");
+            default -> {
+            }
         }
 
         List<RecordBase> records = _sheet.getSheet().getRecords();
@@ -1165,8 +1144,7 @@ public class HSSFCell extends CellBase {
     public void removeHyperlink() {
         for (Iterator<RecordBase> it = _sheet.getSheet().getRecords().iterator(); it.hasNext();) {
             RecordBase rec = it.next();
-            if (rec instanceof HyperlinkRecord) {
-                HyperlinkRecord link = (HyperlinkRecord) rec;
+            if (rec instanceof HyperlinkRecord link) {
                 if (link.getFirstColumn() == _record.getColumn() && link.getFirstRow() == _record.getRow()) {
                     it.remove();
                     return;

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCellStyle.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFCellStyle.java
@@ -692,8 +692,8 @@ public final class HSSFCellStyle implements CellStyle, Duplicatable {
     @Override
     public void setFillBackgroundColor(org.apache.poi.ss.usermodel.Color color)
     {
-        if (color instanceof HSSFColor) {
-            final short index = ((HSSFColor)color).getIndex();
+        if (color instanceof HSSFColor hssfColor) {
+            final short index = hssfColor.getIndex();
             if (index != -1) setFillBackgroundColor(index);
         } else if (color != null) {
             throw new IllegalArgumentException("HSSFCellStyle only accepts HSSFColor instances");
@@ -752,8 +752,8 @@ public final class HSSFCellStyle implements CellStyle, Duplicatable {
     @Override
     public void setFillForegroundColor(org.apache.poi.ss.usermodel.Color color)
     {
-        if (color instanceof HSSFColor) {
-            final short index = ((HSSFColor)color).getIndex();
+        if (color instanceof HSSFColor hssfColor) {
+            final short index = hssfColor.getIndex();
             if (index != -1) setFillForegroundColor(index);
         } else if (color != null) {
             throw new IllegalArgumentException("HSSFCellStyle only accepts HSSFColor instances");
@@ -888,8 +888,8 @@ public final class HSSFCellStyle implements CellStyle, Duplicatable {
      */
     @Override
     public void cloneStyleFrom(CellStyle source) {
-        if(source instanceof HSSFCellStyle) {
-            this.cloneStyleFrom((HSSFCellStyle)source);
+        if(source instanceof HSSFCellStyle style) {
+            this.cloneStyleFrom(style);
         } else {
             CellUtil.cloneStyle(source, this, _hssfWorkbook);
         }
@@ -942,8 +942,7 @@ public final class HSSFCellStyle implements CellStyle, Duplicatable {
         if (obj == null) {
             return false;
         }
-        if (obj instanceof HSSFCellStyle) {
-            final HSSFCellStyle other = (HSSFCellStyle) obj;
+        if (obj instanceof HSSFCellStyle other) {
             if (_format == null) {
                 if (other._format != null) {
                     return false;

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFChart.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFChart.java
@@ -967,20 +967,11 @@ public final class HSSFChart {
         /* package */ void insertData(LinkedDataRecord data){
             switch(data.getLinkType()){
 
-                case LinkedDataRecord.LINK_TYPE_TITLE_OR_TEXT:
-                    dataName = data;
-                    break;
-                case LinkedDataRecord.LINK_TYPE_VALUES:
-                    dataValues = data;
-                    break;
-                case LinkedDataRecord.LINK_TYPE_CATEGORIES:
-                    dataCategoryLabels = data;
-                    break;
-                case LinkedDataRecord.LINK_TYPE_SECONDARY_CATEGORIES:
-                    dataSecondaryCategoryLabels = data;
-                    break;
-                default:
-                    throw new IllegalStateException("Invalid link type: " + data.getLinkType());
+                case LinkedDataRecord.LINK_TYPE_TITLE_OR_TEXT -> dataName = data;
+                case LinkedDataRecord.LINK_TYPE_VALUES -> dataValues = data;
+                case LinkedDataRecord.LINK_TYPE_CATEGORIES -> dataCategoryLabels = data;
+                case LinkedDataRecord.LINK_TYPE_SECONDARY_CATEGORIES -> dataSecondaryCategoryLabels = data;
+                default -> throw new IllegalStateException("Invalid link type: " + data.getLinkType());
             }
         }
 
@@ -1309,9 +1300,8 @@ public final class HSSFChart {
                         seriesIdx++;
                     }
                 }
-            } else if (record instanceof DataFormatRecord) {
+            } else if (record instanceof DataFormatRecord dataFormatRecord) {
                 if (chartEntered && !removeSeries) {
-                    DataFormatRecord dataFormatRecord = (DataFormatRecord) record;
                     dataFormatRecord.setSeriesIndex((short) seriesIdx);
                     dataFormatRecord.setSeriesNumber((short) seriesIdx);
                 }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFComment.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFComment.java
@@ -259,8 +259,8 @@ public class HSSFComment extends HSSFTextbox implements Comment {
     @Override
     public ClientAnchor getClientAnchor() {
         HSSFAnchor ha = super.getAnchor();
-        if (ha instanceof ClientAnchor) {
-            return (ClientAnchor) ha;
+        if (ha instanceof ClientAnchor anchor) {
+            return anchor;
         }
 
         throw new IllegalStateException("Anchor can not be changed in "
@@ -327,10 +327,9 @@ public class HSSFComment extends HSSFTextbox implements Comment {
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof HSSFComment)) {
+        if (!(obj instanceof HSSFComment other)) {
             return false;
         }
-        HSSFComment other = (HSSFComment) obj;
         return getNoteRecord().equals(other.getNoteRecord());
     }
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFConditionalFormattingRule.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFConditionalFormattingRule.java
@@ -84,8 +84,8 @@ public final class HSSFConditionalFormattingRule implements ConditionalFormattin
         return cfRuleRecord;
     }
     private CFRule12Record getCFRule12Record(boolean create) {
-        if (cfRuleRecord instanceof CFRule12Record) {
-            return (CFRule12Record) cfRuleRecord;
+        if (cfRuleRecord instanceof CFRule12Record rule12) {
+            return rule12;
         }
         if (create) {
             throw new IllegalArgumentException("Can't convert a CF into a CF12 record");
@@ -310,9 +310,9 @@ public final class HSSFConditionalFormattingRule implements ConditionalFormattin
         if (conditionType == CELL_COMPARISON) {
             byte comparisonOperation = cfRuleRecord.getComparisonOperation();
             switch(comparisonOperation) {
-                case ComparisonOperator.BETWEEN:
-                case ComparisonOperator.NOT_BETWEEN:
+                case ComparisonOperator.BETWEEN, ComparisonOperator.NOT_BETWEEN -> {
                     return toFormulaString(cfRuleRecord.getParsedExpression2());
+                }
             }
         }
         return null;

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFEvaluationWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFEvaluationWorkbook.java
@@ -285,8 +285,8 @@ public final class HSSFEvaluationWorkbook implements FormulaRenderingWorkbook, E
             String firstSheetName = sheetIdentifier.getName();
             String lastSheetName = firstSheetName;
 
-            if (sheetIden instanceof SheetRangeIdentifier) {
-                lastSheetName = ((SheetRangeIdentifier)sheetIden).getLastSheetIdentifier().getName();
+            if (sheetIden instanceof SheetRangeIdentifier sheetRange) {
+                lastSheetName = sheetRange.getLastSheetIdentifier().getName();
             }
 
             if (workbookName == null) {

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFFont.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFFont.java
@@ -357,8 +357,7 @@ public final class HSSFFont implements Font {
     public boolean equals(Object obj) {
         if (this == obj) return true;
         if (obj == null) return false;
-        if (obj instanceof HSSFFont) {
-            final HSSFFont other = (HSSFFont) obj;
+        if (obj instanceof HSSFFont other) {
             if (font == null) {
                 if (other.font != null) {
                     return false;

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFFormulaEvaluator.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFFormulaEvaluator.java
@@ -199,20 +199,17 @@ public class HSSFFormulaEvaluator extends BaseFormulaEvaluator {
     @Override
     protected CellValue evaluateFormulaCellValue(Cell cell) {
         ValueEval eval = _bookEvaluator.evaluate(new HSSFEvaluationCell((HSSFCell)cell));
-        if (eval instanceof BoolEval) {
-            BoolEval be = (BoolEval) eval;
+        if (eval instanceof BoolEval be) {
             return CellValue.valueOf(be.getBooleanValue());
         }
-        if (eval instanceof NumericValueEval) {
-            NumericValueEval ne = (NumericValueEval) eval;
+        if (eval instanceof NumericValueEval ne) {
             return new CellValue(ne.getNumberValue());
         }
-        if (eval instanceof StringValueEval) {
-            StringValueEval ne = (StringValueEval) eval;
+        if (eval instanceof StringValueEval ne) {
             return new CellValue(ne.getStringValue());
         }
-        if (eval instanceof ErrorEval) {
-            return CellValue.getError(((ErrorEval)eval).getErrorCode());
+        if (eval instanceof ErrorEval ee) {
+            return CellValue.getError(ee.getErrorCode());
         }
         throw new IllegalStateException("Unexpected eval class (" + eval.getClass().getName() + ")");
     }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFHyperlink.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFHyperlink.java
@@ -51,18 +51,10 @@ public class HSSFHyperlink implements Hyperlink, Duplicatable {
         this.link_type = type;
         record = new HyperlinkRecord();
         switch(type){
-            case URL:
-            case EMAIL:
-                record.newUrlLink();
-                break;
-            case FILE:
-                record.newFileLink();
-                break;
-            case DOCUMENT:
-                record.newDocumentLink();
-                break;
-            default:
-                throw new IllegalArgumentException("Invalid type: " + type);
+            case URL, EMAIL -> record.newUrlLink();
+            case FILE -> record.newFileLink();
+            case DOCUMENT -> record.newDocumentLink();
+            default -> throw new IllegalArgumentException("Invalid type: " + type);
         }
     }
 
@@ -94,8 +86,7 @@ public class HSSFHyperlink implements Hyperlink, Duplicatable {
     }
 
     protected HSSFHyperlink(Hyperlink other) {
-        if (other instanceof HSSFHyperlink) {
-            HSSFHyperlink hlink = (HSSFHyperlink) other;
+        if (other instanceof HSSFHyperlink hlink) {
             record = hlink.record.copy();
             link_type = getType(record);
         }
@@ -277,8 +268,7 @@ public class HSSFHyperlink implements Hyperlink, Duplicatable {
     @Override
     public boolean equals(Object other) {
         if (this == other) return true;
-        if (!(other instanceof HSSFHyperlink)) return false;
-        HSSFHyperlink otherLink = (HSSFHyperlink) other;
+        if (!(other instanceof HSSFHyperlink otherLink)) return false;
         return record == otherLink.record;
     }
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFObjectData.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFObjectData.java
@@ -56,8 +56,8 @@ public final class HSSFObjectData extends HSSFPicture implements ObjectData {
         String streamName = "MBD" + HexDump.toHex(streamId);
 
         Entry entry = _root.getEntryCaseInsensitive(streamName);
-        if (entry instanceof DirectoryEntry) {
-            return (DirectoryEntry) entry;
+        if (entry instanceof DirectoryEntry dirEntry) {
+            return dirEntry;
         }
         throw new IOException("Stream " + streamName + " was not an OLE2 directory");
     }
@@ -83,8 +83,8 @@ public final class HSSFObjectData extends HSSFPicture implements ObjectData {
     protected EmbeddedObjectRefSubRecord findObjectRecord() {
 
         for (Object subRecord : getObjRecord().getSubRecords()) {
-            if (subRecord instanceof EmbeddedObjectRefSubRecord) {
-                return (EmbeddedObjectRefSubRecord) subRecord;
+            if (subRecord instanceof EmbeddedObjectRefSubRecord embeddedObjectRef) {
+                return embeddedObjectRef;
             }
         }
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPatriarch.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPatriarch.java
@@ -94,11 +94,10 @@ public final class HSSFPatriarch implements HSSFShapeContainer, Drawing<HSSFShap
 
         EscherRecord child = _mainSpgrContainer.getChild(0);
 
-        if (!(child instanceof EscherContainerRecord)) {
+        if (!(child instanceof EscherContainerRecord spContainer)) {
             throw new IllegalArgumentException("Did not have a EscherContainerRecord: " + child);
         }
 
-        EscherContainerRecord spContainer = (EscherContainerRecord) child;
         _spgrRecord = spContainer.getChildById(EscherSpgrRecord.RECORD_ID);
         buildShapeTree();
     }
@@ -116,8 +115,8 @@ public final class HSSFPatriarch implements HSSFShapeContainer, Drawing<HSSFShap
         newPatriarch.afterCreate();
         for (HSSFShape shape: patriarch.getChildren()){
             HSSFShape newShape;
-            if (shape instanceof HSSFShapeGroup){
-                newShape = ((HSSFShapeGroup)shape).cloneShape(newPatriarch);
+            if (shape instanceof HSSFShapeGroup group){
+                newShape = group.cloneShape(newPatriarch);
             } else {
                 newShape = shape.cloneShape();
             }
@@ -255,18 +254,13 @@ public final class HSSFPatriarch implements HSSFShapeContainer, Drawing<HSSFShap
         FtCfSubRecord ftCf = new FtCfSubRecord();
         HSSFPictureData pictData = getSheet().getWorkbook().getAllPictures().get(pictureIndex-1);
         switch (pictData.getFormat()) {
-            case Workbook.PICTURE_TYPE_WMF:
-            case Workbook.PICTURE_TYPE_EMF:
+            case Workbook.PICTURE_TYPE_WMF, Workbook.PICTURE_TYPE_EMF ->
                 // this needs patch #49658 to be applied to actually work
                 ftCf.setFlags(FtCfSubRecord.METAFILE_BIT);
-                break;
-            case Workbook.PICTURE_TYPE_DIB:
-            case Workbook.PICTURE_TYPE_PNG:
-            case Workbook.PICTURE_TYPE_JPEG:
-            case Workbook.PICTURE_TYPE_PICT:
+            case Workbook.PICTURE_TYPE_DIB, Workbook.PICTURE_TYPE_PNG, Workbook.PICTURE_TYPE_JPEG,
+                 Workbook.PICTURE_TYPE_PICT ->
                 ftCf.setFlags(FtCfSubRecord.BITMAP_BIT);
-                break;
-            default:
+            default ->
                 throw new IllegalStateException("Invalid picture type: " + pictData.getFormat());
         }
         obj.addSubRecord(ftCf);

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPicture.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFPicture.java
@@ -279,7 +279,7 @@ public class HSSFPicture extends HSSFSimpleShape implements Picture {
     @Override
     public HSSFClientAnchor getClientAnchor() {
         HSSFAnchor a = getAnchor();
-        return (a instanceof HSSFClientAnchor) ? (HSSFClientAnchor)a : null;
+        return (a instanceof HSSFClientAnchor anchor) ? anchor : null;
     }
 
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRichTextString.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRichTextString.java
@@ -301,8 +301,8 @@ public final class HSSFRichTextString implements Comparable<HSSFRichTextString>,
 
     @Override
     public boolean equals(Object o) {
-      if (o instanceof HSSFRichTextString) {
-        return _string.equals(((HSSFRichTextString)o)._string);
+      if (o instanceof HSSFRichTextString other) {
+        return _string.equals(other._string);
       }
       return false;
 

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRow.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFRow.java
@@ -709,10 +709,9 @@ public final class HSSFRow implements Row, Comparable<HSSFRow> {
 
     @Override
     public boolean equals(Object obj) {
-        if (!(obj instanceof HSSFRow)) {
+        if (!(obj instanceof HSSFRow other)) {
             return false;
         }
-        HSSFRow other = (HSSFRow) obj;
 
         return (this.getRowNum() == other.getRowNum()) &&
                (this.getSheet() == other.getSheet());

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFShape.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFShape.java
@@ -411,8 +411,8 @@ public abstract class HSSFShape implements Shape {
             return null;
         }
         EscherProperty ep = eor.lookup(EscherPropertyTypes.GROUPSHAPE__SHAPENAME);
-        if (ep instanceof EscherComplexProperty) {
-            return StringUtil.getFromUnicodeLE(((EscherComplexProperty)ep).getComplexData());
+        if (ep instanceof EscherComplexProperty complexProp) {
+            return StringUtil.getFromUnicodeLE(complexProp.getComplexData());
         }
         return null;
     }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFShapeGroup.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFShapeGroup.java
@@ -55,10 +55,10 @@ public class HSSFShapeGroup extends HSSFShape implements HSSFShapeContainer {
         // read internal and external coordinates from spgrContainer
         EscherContainerRecord spContainer = spgrContainer.getChildContainers().get(0);
         final EscherRecord child = spContainer.getChild(0);
-        if (!(child instanceof EscherSpgrRecord)) {
+        if (!(child instanceof EscherSpgrRecord spgr)) {
             throw new IllegalArgumentException("Had unexpected type of child at index 0: " + child.getClass());
         }
-        _spgrRecord = (EscherSpgrRecord) child;
+        _spgrRecord = spgr;
         for (EscherRecord ch : spContainer) {
             switch (EscherRecordTypes.forTypeID(ch.getRecordId())) {
                 case CLIENT_ANCHOR:
@@ -394,8 +394,8 @@ public class HSSFShapeGroup extends HSSFShape implements HSSFShapeContainer {
 
         for (HSSFShape shape: getChildren()){
             HSSFShape newShape;
-            if (shape instanceof HSSFShapeGroup){
-                newShape = ((HSSFShapeGroup)shape).cloneShape(patriarch);
+            if (shape instanceof HSSFShapeGroup shapeGroup){
+                newShape = shapeGroup.cloneShape(patriarch);
             } else {
                 newShape = shape.cloneShape();
             }

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFSheet.java
@@ -238,8 +238,8 @@ public final class HSSFSheet implements Sheet {
                 }
             }
             LOGGER.atTrace().log(() -> {
-                if (cval instanceof Record) {
-                    return new SimpleMessage("record id = " + Integer.toHexString(((Record) cval).getSid()));
+                if (cval instanceof Record record) {
+                    return new SimpleMessage("record id = " + Integer.toHexString(record.getSid()));
                 } else {
                     return new SimpleMessage("record = " + cval);
                 }
@@ -441,10 +441,9 @@ public final class HSSFSheet implements Sheet {
 
             @Override
             public void visitRecord(Record r) {
-                if (!(r instanceof DVRecord)) {
+                if (!(r instanceof DVRecord dvRecord)) {
                     return;
                 }
-                DVRecord dvRecord = (DVRecord) r;
                 CellRangeAddressList regions = dvRecord.getCellRangeAddress().copy();
                 DVConstraint constraint = DVConstraint.createDVConstraint(dvRecord, book);
                 HSSFDataValidation hssfDataValidation = new HSSFDataValidation(regions, constraint);
@@ -1370,14 +1369,9 @@ public final class HSSFSheet implements Sheet {
     @Override
     public void setMargin(PageMargin margin, double size) {
         switch (margin) {
-            case FOOTER:
-                _sheet.getPageSettings().getPrintSetup().setFooterMargin(size);
-                break;
-            case HEADER:
-                _sheet.getPageSettings().getPrintSetup().setHeaderMargin(size);
-                break;
-            default:
-                _sheet.getPageSettings().setMargin(margin.getLegacyApiValue(), size);
+            case FOOTER -> _sheet.getPageSettings().getPrintSetup().setFooterMargin(size);
+            case HEADER -> _sheet.getPageSettings().getPrintSetup().setHeaderMargin(size);
+            default -> _sheet.getPageSettings().setMargin(margin.getLegacyApiValue(), size);
         }
     }
 
@@ -1781,10 +1775,9 @@ public final class HSSFSheet implements Sheet {
     private void moveCommentsForRowShift(int startRow, int endRow, int n) {
         final HSSFPatriarch patriarch = createDrawingPatriarch();
         for (final HSSFShape shape : patriarch.getChildren()) {
-            if (!(shape instanceof HSSFComment)) {
+            if (!(shape instanceof HSSFComment comment)) {
                 continue;
             }
-            final HSSFComment comment = (HSSFComment) shape;
             final int r = comment.getRow();
             if (startRow <= r && r <= endRow) {
                 comment.setRow(clip(r + n));
@@ -2315,8 +2308,7 @@ public final class HSSFSheet implements Sheet {
     @Override
     public HSSFHyperlink getHyperlink(int row, int column) {
         for (RecordBase rec : _sheet.getRecords()) {
-            if (rec instanceof HyperlinkRecord) {
-                HyperlinkRecord link = (HyperlinkRecord) rec;
+            if (rec instanceof HyperlinkRecord link) {
                 if (link.getFirstColumn() == column && link.getFirstRow() == row) {
                     return new HSSFHyperlink(link);
                 }
@@ -2346,8 +2338,7 @@ public final class HSSFSheet implements Sheet {
     public List<HSSFHyperlink> getHyperlinkList() {
         final List<HSSFHyperlink> hyperlinkList = new ArrayList<>();
         for (RecordBase rec : _sheet.getRecords()) {
-            if (rec instanceof HyperlinkRecord) {
-                HyperlinkRecord link = (HyperlinkRecord) rec;
+            if (rec instanceof HyperlinkRecord link) {
                 hyperlinkList.add(new HSSFHyperlink(link));
             }
         }
@@ -2372,8 +2363,7 @@ public final class HSSFSheet implements Sheet {
     protected void removeHyperlink(HyperlinkRecord link) {
         for (Iterator<RecordBase> it = _sheet.getRecords().iterator(); it.hasNext();) {
             RecordBase rec = it.next();
-            if (rec instanceof HyperlinkRecord) {
-                HyperlinkRecord recLink = (HyperlinkRecord) rec;
+            if (rec instanceof HyperlinkRecord recLink) {
                 if (link == recLink) {
                     it.remove();
                     // if multiple HSSFHyperlinks refer to the same record
@@ -2450,11 +2440,10 @@ public final class HSSFSheet implements Sheet {
             throw new IllegalArgumentException("Specified cell does not belong to this sheet.");
         }
         CellValueRecordInterface rec = ((HSSFCell) cell).getCellValueRecord();
-        if (!(rec instanceof FormulaRecordAggregate)) {
+        if (!(rec instanceof FormulaRecordAggregate fra)) {
             String ref = new CellReference(cell).formatAsString();
             throw new IllegalArgumentException("Cell " + ref + " is not part of an array formula.");
         }
-        FormulaRecordAggregate fra = (FormulaRecordAggregate) rec;
         CellRangeAddress range = fra.removeArrayFormula(cell.getRowIndex(), cell.getColumnIndex());
 
         CellRange<HSSFCell> result = getCellRange(range);
@@ -2528,8 +2517,7 @@ public final class HSSFSheet implements Sheet {
                 }
                 continue;
             }
-            if (shape instanceof HSSFComment) {
-                HSSFComment comment = (HSSFComment) shape;
+            if (shape instanceof HSSFComment comment) {
                 if (comment.hasPosition() && comment.getColumn() == column && comment.getRow() == row) {
                     return comment;
                 }
@@ -2563,12 +2551,11 @@ public final class HSSFSheet implements Sheet {
     private void findCellCommentLocations(HSSFShapeContainer container, Map<CellAddress, HSSFComment> locations) {
         for (Object object : container.getChildren()) {
             HSSFShape shape = (HSSFShape) object;
-            if (shape instanceof HSSFShapeGroup) {
-                findCellCommentLocations((HSSFShapeGroup) shape, locations);
+            if (shape instanceof HSSFShapeGroup group) {
+                findCellCommentLocations(group, locations);
                 continue;
             }
-            if (shape instanceof HSSFComment) {
-                HSSFComment comment = (HSSFComment) shape;
+            if (shape instanceof HSSFComment comment) {
                 if (comment.hasPosition()) {
                     locations.put(new CellAddress(comment.getRow(), comment.getColumn()), comment);
                 }
@@ -2693,8 +2680,7 @@ public final class HSSFSheet implements Sheet {
 
         for (Ptg ptg : nameDefinition) {
 
-            if (ptg instanceof Area3DPtg) {
-                Area3DPtg areaPtg = (Area3DPtg) ptg;
+            if (ptg instanceof Area3DPtg areaPtg) {
 
                 if (areaPtg.getFirstColumn() == 0
                         && areaPtg.getLastColumn() == maxColIndex) {

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbook.java
@@ -1869,8 +1869,8 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
 
             RefModeRecord refModeRecord = null;
             for (RecordBase record : records) {
-                if (record instanceof RefModeRecord) {
-                    refModeRecord = (RefModeRecord)record;
+                if (record instanceof RefModeRecord refMode) {
+                    refModeRecord = refMode;
                     break;
                 }
             }
@@ -1905,8 +1905,8 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
 
             RefModeRecord refModeRecord = null;
             for (RecordBase record : records) {
-                if (record instanceof RefModeRecord) {
-                    refModeRecord = (RefModeRecord)record;
+                if (record instanceof RefModeRecord refMode) {
+                    refModeRecord = refMode;
                     break;
                 }
             }
@@ -2110,26 +2110,13 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
 
         blipRecord.setRecordId((short) (EscherBlipRecord.RECORD_ID_START + format));
         switch (format) {
-            case PICTURE_TYPE_EMF:
-                blipRecord.setOptions(HSSFPictureData.MSOBI_EMF);
-                break;
-            case PICTURE_TYPE_WMF:
-                blipRecord.setOptions(HSSFPictureData.MSOBI_WMF);
-                break;
-            case PICTURE_TYPE_PICT:
-                blipRecord.setOptions(HSSFPictureData.MSOBI_PICT);
-                break;
-            case PICTURE_TYPE_PNG:
-                blipRecord.setOptions(HSSFPictureData.MSOBI_PNG);
-                break;
-            case PICTURE_TYPE_JPEG:
-                blipRecord.setOptions(HSSFPictureData.MSOBI_JPEG);
-                break;
-            case PICTURE_TYPE_DIB:
-                blipRecord.setOptions(HSSFPictureData.MSOBI_DIB);
-                break;
-            default:
-                throw new IllegalStateException("Unexpected picture format: " + format);
+            case PICTURE_TYPE_EMF -> blipRecord.setOptions(HSSFPictureData.MSOBI_EMF);
+            case PICTURE_TYPE_WMF -> blipRecord.setOptions(HSSFPictureData.MSOBI_WMF);
+            case PICTURE_TYPE_PICT -> blipRecord.setOptions(HSSFPictureData.MSOBI_PICT);
+            case PICTURE_TYPE_PNG -> blipRecord.setOptions(HSSFPictureData.MSOBI_PNG);
+            case PICTURE_TYPE_JPEG -> blipRecord.setOptions(HSSFPictureData.MSOBI_JPEG);
+            case PICTURE_TYPE_DIB -> blipRecord.setOptions(HSSFPictureData.MSOBI_DIB);
+            default -> throw new IllegalStateException("Unexpected picture format: " + format);
         }
 
         EscherBSERecord r = new EscherBSERecord();
@@ -2157,9 +2144,9 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
         // The drawing group record always exists at the top level, so we won't need to do this recursively.
         List<HSSFPictureData> pictures = new ArrayList<>();
         for (org.apache.poi.hssf.record.Record r : workbook.getRecords()) {
-            if (r instanceof AbstractEscherHolderRecord) {
-                ((AbstractEscherHolderRecord) r).decode();
-                List<EscherRecord> escherRecords = ((AbstractEscherHolderRecord) r).getEscherRecords();
+            if (r instanceof AbstractEscherHolderRecord escherHolder) {
+                escherHolder.decode();
+                List<EscherRecord> escherRecords = escherHolder.getEscherRecords();
                 searchForPictures(escherRecords, pictures);
             }
         }
@@ -2175,8 +2162,8 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
     private void searchForPictures(List<EscherRecord> escherRecords, List<HSSFPictureData> pictures) {
         for (EscherRecord escherRecord : escherRecords) {
 
-            if (escherRecord instanceof EscherBSERecord) {
-                EscherBlipRecord blip = ((EscherBSERecord) escherRecord).getBlipRecord();
+            if (escherRecord instanceof EscherBSERecord bse) {
+                EscherBlipRecord blip = bse.getBlipRecord();
                 if (blip != null) {
                     // TODO: Some kind of structure.
                     HSSFPictureData picture = new HSSFPictureData(blip);
@@ -2332,10 +2319,10 @@ public final class HSSFWorkbook extends POIDocument implements Workbook {
      */
     private void getAllEmbeddedObjects(HSSFShapeContainer parent, List<HSSFObjectData> objects) {
         for (HSSFShape shape : parent.getChildren()) {
-            if (shape instanceof HSSFObjectData) {
-                objects.add((HSSFObjectData) shape);
-            } else if (shape instanceof HSSFShapeContainer) {
-                getAllEmbeddedObjects((HSSFShapeContainer) shape, objects);
+            if (shape instanceof HSSFObjectData objectData) {
+                objects.add(objectData);
+            } else if (shape instanceof HSSFShapeContainer container) {
+                getAllEmbeddedObjects(container, objects);
             }
         }
     }

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/agile/AgileEncryptionInfoBuilder.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/agile/AgileEncryptionInfoBuilder.java
@@ -36,11 +36,11 @@ public class AgileEncryptionInfoBuilder implements EncryptionInfoBuilder {
 
     @Override
     public void initialize(EncryptionInfo info, LittleEndianInput dis) throws IOException {
-        if (!(dis instanceof InputStream)) {
+        if (!(dis instanceof InputStream is)) {
             throw new IllegalArgumentException("Had unexpected type of input: " + (dis == null ? "<null>" : dis.getClass()));
         }
 
-        EncryptionDocument ed = parseDescriptor((InputStream)dis);
+        EncryptionDocument ed = parseDescriptor(is);
         info.setHeader(new AgileEncryptionHeader(ed));
         info.setVerifier(new AgileEncryptionVerifier(ed));
         if (info.getVersionMajor() == EncryptionMode.agile.versionMajor

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/cryptoapi/CryptoAPIDecryptor.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/cryptoapi/CryptoAPIDecryptor.java
@@ -211,10 +211,10 @@ public class CryptoAPIDecryptor extends Decryptor {
             }
         } catch (Exception e) {
             IOUtils.closeQuietly(fsOut);
-            if (e instanceof GeneralSecurityException) {
-                throw (GeneralSecurityException)e;
-            } else if (e instanceof IOException) {
-                throw (IOException)e;
+            if (e instanceof GeneralSecurityException gse) {
+                throw gse;
+            } else if (e instanceof IOException ioe) {
+                throw ioe;
             } else {
                 throw new IOException("summary entries can't be read", e);
             }

--- a/poi/src/main/java/org/apache/poi/poifs/crypt/standard/StandardEncryptionHeader.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/standard/StandardEncryptionHeader.java
@@ -60,14 +60,14 @@ public class StandardEncryptionHeader extends EncryptionHeader implements Encryp
 
         // CSPName may not always be specified
         // In some cases, the salt value of the EncryptionVerifier is the next chunk of data
-        if (is instanceof RecordInputStream) {
-            ((RecordInputStream)is).mark(LittleEndianConsts.INT_SIZE+1);
+        if (is instanceof RecordInputStream ris) {
+            ris.mark(LittleEndianConsts.INT_SIZE+1);
         } else {
             ((InputStream)is).mark(LittleEndianConsts.INT_SIZE+1);
         }
         int checkForSalt = is.readInt();
-        if (is instanceof RecordInputStream) {
-            ((RecordInputStream)is).reset();
+        if (is instanceof RecordInputStream ris) {
+            ris.reset();
         } else {
             ((InputStream)is).reset();
         }

--- a/poi/src/main/java/org/apache/poi/poifs/dev/POIFSLister.java
+++ b/poi/src/main/java/org/apache/poi/poifs/dev/POIFSLister.java
@@ -86,8 +86,8 @@ public class POIFSLister {
       for(Iterator<Entry> it = dir.getEntries(); it.hasNext();) {
          hadChildren = true;
          Entry entry = it.next();
-         if (entry instanceof DirectoryNode) {
-            displayDirectory((DirectoryNode) entry, newIndent, withSizes);
+         if (entry instanceof DirectoryNode dn) {
+            displayDirectory(dn, newIndent, withSizes);
          } else {
             DocumentNode doc = (DocumentNode) entry;
             String name = doc.getName();

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/DocumentOutputStream.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/DocumentOutputStream.java
@@ -93,10 +93,10 @@ public final class DocumentOutputStream extends OutputStream {
     }
 
     private static POIFSDocument getDocument(DocumentEntry document) throws IOException {
-        if (!(document instanceof DocumentNode)) {
+        if (!(document instanceof DocumentNode node)) {
             throw new IOException("Cannot open internal document storage, " + document + " not a Document Node");
         }
-        return new POIFSDocument((DocumentNode)document);
+        return new POIFSDocument(node);
     }
 
     private static DocumentEntry createDocument(DirectoryEntry parent, String name) throws IOException {

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/EntryUtils.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/EntryUtils.java
@@ -132,8 +132,8 @@ public final class EntryUtils {
         try {
             return new DocumentDelegate(docA).equals(new DocumentDelegate(docB));
         } catch (RuntimeException e) {
-            if (e.getCause() instanceof IOException) {
-                throw (IOException)e.getCause();
+            if (e.getCause() instanceof IOException ioe) {
+                throw ioe;
             } else {
                 throw e;
             }
@@ -168,11 +168,9 @@ public final class EntryUtils {
 
         @Override
         public boolean equals(Object other) {
-            if (!(other instanceof DirectoryDelegate)) {
+            if (!(other instanceof DirectoryDelegate dd)) {
                 return false;
             }
-
-            DirectoryDelegate dd = (DirectoryDelegate)other;
 
             if (this == dd) {
                 return true;
@@ -210,11 +208,9 @@ public final class EntryUtils {
 
         @Override
         public boolean equals(Object other) {
-            if (!(other instanceof DocumentDelegate)) {
+            if (!(other instanceof DocumentDelegate dd)) {
                 return false;
             }
-
-            DocumentDelegate dd = (DocumentDelegate)other;
 
             if (this == dd) {
                 return true;

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/FilteringDirectoryNode.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/FilteringDirectoryNode.java
@@ -191,9 +191,9 @@ public class FilteringDirectoryNode implements DirectoryEntry
 
    private Entry wrapEntry(Entry entry) {
       String name = entry.getName();
-      if (childExcludes.containsKey(name) && entry instanceof DirectoryEntry) {
+      if (childExcludes.containsKey(name) && entry instanceof DirectoryEntry de) {
          return new FilteringDirectoryNode(
-               (DirectoryEntry)entry, childExcludes.get(name));
+               de, childExcludes.get(name));
       }
       return entry;
    }

--- a/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSFileSystem.java
+++ b/poi/src/main/java/org/apache/poi/poifs/filesystem/POIFSFileSystem.java
@@ -726,7 +726,7 @@ public class POIFSFileSystem extends BlockStore
      * is supported.
      */
     public boolean isInPlaceWriteable() {
-        return (_data instanceof FileBackedDataSource) && ((FileBackedDataSource) _data).isWriteable();
+        return (_data instanceof FileBackedDataSource fbds) && fbds.isWriteable();
     }
 
     /**
@@ -737,13 +737,13 @@ public class POIFSFileSystem extends BlockStore
      * @throws IOException thrown on errors writing to the stream
      */
     public void writeFilesystem() throws IOException {
-        if (!(_data instanceof FileBackedDataSource)) {
+        if (!(_data instanceof FileBackedDataSource fbds)) {
             throw new IllegalArgumentException(
                     "POIFS opened from an inputstream, so writeFilesystem() may " +
                             "not be called. Use writeFilesystem(OutputStream) instead"
             );
         }
-        if (!((FileBackedDataSource) _data).isWriteable()) {
+        if (!fbds.isWriteable()) {
             throw new IllegalArgumentException(
                     "POIFS opened in read only mode, so writeFilesystem() may " +
                             "not be called. Open the FileSystem in read-write mode first"
@@ -987,8 +987,8 @@ public class POIFSFileSystem extends BlockStore
 
     @Override
     protected void releaseBuffer(ByteBuffer buffer) {
-        if (_data instanceof FileBackedDataSource) {
-            ((FileBackedDataSource)_data).releaseBuffer(buffer);
+        if (_data instanceof FileBackedDataSource fbds) {
+            fbds.releaseBuffer(buffer);
         }
     }
 

--- a/poi/src/main/java/org/apache/poi/poifs/nio/CleanerUtil.java
+++ b/poi/src/main/java/org/apache/poi/poifs/nio/CleanerUtil.java
@@ -78,8 +78,8 @@ public final class CleanerUtil {
     static {
         final Object hack = AccessController.doPrivileged(
                 (PrivilegedAction<Object>) CleanerUtil::unmapHackImpl);
-        if (hack instanceof BufferCleaner) {
-            CLEANER = (BufferCleaner) hack;
+        if (hack instanceof BufferCleaner bc) {
+            CLEANER = bc;
             UNMAP_SUPPORTED = true;
             UNMAP_NOT_SUPPORTED_REASON = null;
         } else {

--- a/poi/src/main/java/org/apache/poi/poifs/property/PropertyTable.java
+++ b/poi/src/main/java/org/apache/poi/poifs/property/PropertyTable.java
@@ -111,8 +111,8 @@ public final class PropertyTable implements BATManaged {
 
         Property property = _properties.get(0);
         if (property != null) {
-            if (property instanceof DirectoryProperty) {
-                populatePropertyTree((DirectoryProperty) property, 0);
+            if (property instanceof DirectoryProperty dp) {
+                populatePropertyTree(dp, 0);
             } else {
                 throw new IOException("Invalid format, cannot convert property " + property + " to DirectoryProperty");
             }
@@ -145,8 +145,8 @@ public final class PropertyTable implements BATManaged {
     public RootProperty getRoot() {
         // it's always the first element in the List
         Property property = _properties.get(0);
-        if (property instanceof RootProperty) {
-            return (RootProperty) property;
+        if (property instanceof RootProperty rp) {
+            return rp;
         } else {
             throw new IllegalStateException("Invalid format, cannot convert property " +
                     property + " to RootProperty");

--- a/poi/src/main/java/org/apache/poi/sl/draw/SLGraphics.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/SLGraphics.java
@@ -1777,8 +1777,7 @@ public class SLGraphics extends Graphics2D implements Cloneable {
     }
 
     protected void applyStroke(SimpleShape<?,?> shape) {
-        if (_stroke instanceof BasicStroke){
-            BasicStroke bs = (BasicStroke)_stroke;
+        if (_stroke instanceof BasicStroke bs){
             shape.setStrokeStyle((double)bs.getLineWidth());
             float[] dash = bs.getDashArray();
             if (dash != null) {
@@ -1789,8 +1788,8 @@ public class SLGraphics extends Graphics2D implements Cloneable {
     }
 
     protected void applyPaint(SimpleShape<?,?> shape) {
-        if (_paint instanceof Color) {
-            shape.setFillColor((Color)_paint);
+        if (_paint instanceof Color c) {
+            shape.setFillColor(c);
         }
     }
 

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/AdjustPoint.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/AdjustPoint.java
@@ -79,8 +79,7 @@ public class AdjustPoint implements AdjustPointIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof AdjustPoint)) return false;
-        AdjustPoint that = (AdjustPoint) o;
+        if (!(o instanceof AdjustPoint that)) return false;
         return Objects.equals(x, that.x) &&
                 Objects.equals(y, that.y);
     }

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/ArcToCommand.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/ArcToCommand.java
@@ -140,32 +140,29 @@ public class ArcToCommand implements ArcToCommandIf {
         // because of tangens nature, the values left [90°-270°] and right [270°-90°] of the axis are mirrored/the same
         // and the result of atan2 need to be justified
         switch ((int)(awtAngle2 / 90)) {
-            case -3:
+            case -3 -> {
                 // -270 to -360
                 awtAngle3 -= 360;
                 awtAngle2 += 360;
-                break;
-            case -2:
-            case -1:
+            }
+            case -2, -1 -> {
                 // -90 to -270
                 awtAngle3 -= 180;
                 awtAngle2 += 180;
-                break;
-            default:
-            case 0:
-                // -90 to 90
-                break;
-            case 2:
-            case 1:
+            }
+            case 2, 1 -> {
                 // 90 to 270
                 awtAngle3 += 180;
                 awtAngle2 -= 180;
-                break;
-            case 3:
+            }
+            case 3 -> {
                 // 270 to 360
                 awtAngle3 += 360;
                 awtAngle2 -= 360;
-                break;
+            }
+            default -> {
+                // -90 to 90
+            }
         }
 
         // skew
@@ -177,8 +174,7 @@ public class ArcToCommand implements ArcToCommandIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ArcToCommand)) return false;
-        ArcToCommand that = (ArcToCommand) o;
+        if (!(o instanceof ArcToCommand that)) return false;
         return Objects.equals(wr, that.wr) &&
                 Objects.equals(hr, that.hr) &&
                 Objects.equals(stAng, that.stAng) &&

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/ConnectionSite.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/ConnectionSite.java
@@ -79,8 +79,7 @@ public final class ConnectionSite implements ConnectionSiteIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ConnectionSite)) return false;
-        ConnectionSite that = (ConnectionSite) o;
+        if (!(o instanceof ConnectionSite that)) return false;
         return Objects.equals(pos, that.pos) &&
                 Objects.equals(ang, that.ang);
     }

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/CurveToCommand.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/CurveToCommand.java
@@ -93,8 +93,7 @@ public final class CurveToCommand implements CurveToCommandIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CurveToCommand)) return false;
-        CurveToCommand that = (CurveToCommand) o;
+        if (!(o instanceof CurveToCommand that)) return false;
         return Objects.equals(pt1, that.pt1) &&
                 Objects.equals(pt2, that.pt2) &&
                 Objects.equals(pt3, that.pt3);

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/CustomGeometry.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/CustomGeometry.java
@@ -127,8 +127,7 @@ public final class CustomGeometry implements Iterable<PathIf>{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof CustomGeometry)) return false;
-        CustomGeometry that = (CustomGeometry) o;
+        if (!(o instanceof CustomGeometry that)) return false;
         return Objects.equals(adjusts, that.adjusts) &&
                 Objects.equals(guides, that.guides) &&
                 Objects.equals(handles, that.handles) &&

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/LineToCommand.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/LineToCommand.java
@@ -64,8 +64,7 @@ public final class LineToCommand implements LineToCommandIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof LineToCommand)) return false;
-        LineToCommand that = (LineToCommand) o;
+        if (!(o instanceof LineToCommand that)) return false;
         return Objects.equals(pt, that.pt);
     }
 

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/MoveToCommand.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/MoveToCommand.java
@@ -63,8 +63,7 @@ public final class MoveToCommand implements MoveToCommandIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MoveToCommand)) return false;
-        MoveToCommand that = (MoveToCommand) o;
+        if (!(o instanceof MoveToCommand that)) return false;
         return Objects.equals(pt, that.pt);
     }
 

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/Path.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/Path.java
@@ -158,8 +158,7 @@ public final class Path implements PathIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Path)) return false;
-        Path ctPath2D = (Path) o;
+        if (!(o instanceof Path ctPath2D)) return false;
         return Objects.equals(commands, ctPath2D.commands) &&
                 Objects.equals(w, ctPath2D.w) &&
                 Objects.equals(h, ctPath2D.h) &&

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/PolarAdjustHandle.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/PolarAdjustHandle.java
@@ -264,8 +264,7 @@ public final class PolarAdjustHandle implements AdjustHandle {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PolarAdjustHandle)) return false;
-        PolarAdjustHandle that = (PolarAdjustHandle) o;
+        if (!(o instanceof PolarAdjustHandle that)) return false;
         return Objects.equals(pos, that.pos) &&
                 Objects.equals(gdRefR, that.gdRefR) &&
                 Objects.equals(minR, that.minR) &&

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/QuadToCommand.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/QuadToCommand.java
@@ -78,8 +78,7 @@ public final class QuadToCommand implements QuadToCommandIf {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof QuadToCommand)) return false;
-        QuadToCommand that = (QuadToCommand) o;
+        if (!(o instanceof QuadToCommand that)) return false;
         return Objects.equals(pt1, that.pt1) &&
                 Objects.equals(pt2, that.pt2);
     }

--- a/poi/src/main/java/org/apache/poi/sl/draw/geom/XYAdjustHandle.java
+++ b/poi/src/main/java/org/apache/poi/sl/draw/geom/XYAdjustHandle.java
@@ -254,8 +254,7 @@ public final class XYAdjustHandle implements AdjustHandle {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof XYAdjustHandle)) return false;
-        XYAdjustHandle that = (XYAdjustHandle) o;
+        if (!(o instanceof XYAdjustHandle that)) return false;
         return Objects.equals(pos, that.pos) &&
                 Objects.equals(gdRefX, that.gdRefX) &&
                 Objects.equals(minX, that.minX) &&

--- a/poi/src/main/java/org/apache/poi/sl/usermodel/AbstractColorStyle.java
+++ b/poi/src/main/java/org/apache/poi/sl/usermodel/AbstractColorStyle.java
@@ -33,10 +33,10 @@ public abstract class AbstractColorStyle implements ColorStyle {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ColorStyle)) {
+        if (!(o instanceof ColorStyle cs)) {
             return false;
         }
-        return Objects.equals(DrawPaint.applyColorTransform(this), DrawPaint.applyColorTransform((ColorStyle)o));
+        return Objects.equals(DrawPaint.applyColorTransform(this), DrawPaint.applyColorTransform(cs));
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/sl/usermodel/Insets2D.java
+++ b/poi/src/main/java/org/apache/poi/sl/usermodel/Insets2D.java
@@ -95,8 +95,7 @@ public final class Insets2D implements Duplicatable {
      * @since      JDK1.1
      */
     public boolean equals(Object obj) {
-    if (obj instanceof Insets2D) {
-        Insets2D insets = (Insets2D)obj;
+    if (obj instanceof Insets2D insets) {
         return ((top == insets.top) && (left == insets.left) &&
             (bottom == insets.bottom) && (right == insets.right));
     }

--- a/poi/src/main/java/org/apache/poi/ss/format/CellFormatPart.java
+++ b/poi/src/main/java/org/apache/poi/ss/format/CellFormatPart.java
@@ -29,7 +29,6 @@ import java.util.*;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.apache.poi.ss.format.CellFormatter.quote;
 import static org.apache.poi.util.StringUtil.equalsIgnoreCase;
@@ -103,7 +102,7 @@ public class CellFormatPart {
         INDEXED_COLORS = Collections.unmodifiableList(
             Arrays.asList(indexedColors)
             .stream().map(Color::new)
-            .collect(Collectors.toList()));
+            .toList());
 
         // Build initial named color map
         Map<String, Color> namedColors = new TreeMap<>(
@@ -254,12 +253,11 @@ public class CellFormatPart {
      * @return {@code true} if this format part applies to the given value.
      */
     public boolean applies(Object valueObject) {
-        if (condition == null || !(valueObject instanceof Number)) {
+        if (condition == null || !(valueObject instanceof Number num)) {
             if (valueObject == null)
                 throw new NullPointerException("valueObject");
             return true;
         } else {
-            Number num = (Number) valueObject;
             return condition.pass(num.doubleValue());
         }
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/DataValidationEvaluator.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/DataValidationEvaluator.java
@@ -204,8 +204,7 @@ public class DataValidationEvaluator {
             ValueEval eval = context.getEvaluator().getWorkbookEvaluator().evaluateList(formula, context.getTarget(), context.getRegion());
             // formula is a StringEval if the validation is by a fixed list.  Use the explicit list later.
             // there is no way from the model to tell if the list is fixed values or formula based.
-            if (eval instanceof TwoDEval) {
-                TwoDEval twod = (TwoDEval) eval;
+            if (eval instanceof TwoDEval twod) {
                 for (int i=0; i < twod.getHeight(); i++) {
                     final ValueEval cellValue = twod.getValue(i,  0);
                     values.add(cellValue);
@@ -296,25 +295,25 @@ public class DataValidationEvaluator {
 
                 // compare cell value to each item
                 for (ValueEval listVal : valueList) {
-                    ValueEval comp = listVal instanceof RefEval ? ((RefEval) listVal).getInnerValueEval(context.getSheetIndex()) : listVal;
+                    ValueEval comp = listVal instanceof RefEval re ? re.getInnerValueEval(context.getSheetIndex()) : listVal;
 
                     // any value is valid if the list contains a blank value per Excel help
                     if (comp instanceof BlankEval) return true;
                     if (comp instanceof ErrorEval) continue; // nothing to check
-                    if (comp instanceof BoolEval) {
-                        if (isType(cell, CellType.BOOLEAN) && ((BoolEval) comp).getBooleanValue() == cell.getBooleanCellValue() ) {
+                    if (comp instanceof BoolEval be) {
+                        if (isType(cell, CellType.BOOLEAN) && be.getBooleanValue() == cell.getBooleanCellValue() ) {
                             return true;
                         } else {
                             continue; // check the rest
                         }
                     }
-                    if (comp instanceof NumberEval) {
+                    if (comp instanceof NumberEval ne) {
                         // could this have trouble with double precision/rounding errors and date/time values?
                         // do we need to allow a "close enough" double fractional range?
                         // I see 17 digits after the decimal separator in XSSF files, and for time values,
                         // there are sometimes discrepancies in the final decimal place.
                         // I don't have a validation test case yet though. - GW
-                        if (isType(cell, CellType.NUMERIC) && ((NumberEval) comp).getNumberValue() == cell.getNumericCellValue()) {
+                        if (isType(cell, CellType.NUMERIC) && ne.getNumberValue() == cell.getNumericCellValue()) {
                             return true;
                         } else {
                             continue; // check the rest
@@ -352,19 +351,19 @@ public class DataValidationEvaluator {
             public boolean isValidValue(Cell cell, DataValidationContext context) {
                 // unwrapped single value
                 ValueEval comp = context.getEvaluator().getWorkbookEvaluator().evaluate(context.getFormula1(), context.getTarget(), context.getRegion());
-                if (comp instanceof RefEval) {
-                    comp = ((RefEval) comp).getInnerValueEval(((RefEval) comp).getFirstSheetIndex());
+                if (comp instanceof RefEval re) {
+                    comp = re.getInnerValueEval(re.getFirstSheetIndex());
                 }
 
                 if (comp instanceof BlankEval) return true;
                 if (comp instanceof ErrorEval) return false;
-                if (comp instanceof BoolEval) {
-                    return ((BoolEval) comp).getBooleanValue();
+                if (comp instanceof BoolEval be) {
+                    return be.getBooleanValue();
                 }
                 // empirically tested in Excel - 0=false, any other number = true/valid
                 // see test file DataValidationEvaluations.xlsx
-                if (comp instanceof NumberEval) {
-                    return ((NumberEval) comp).getNumberValue() != 0;
+                if (comp instanceof NumberEval ne) {
+                    return ne.getNumberValue() != 0;
                 }
                 return false; // anything else is false, such as text
             }

--- a/poi/src/main/java/org/apache/poi/ss/formula/FormulaParser.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/FormulaParser.java
@@ -209,10 +209,10 @@ public final class FormulaParser {
     public static Area3DPxg parseStructuredReference(String tableText, FormulaParsingWorkbook workbook, int rowIndex) {
         final int sheetIndex = -1; //don't care?
         Ptg[] arr = FormulaParser.parse(tableText, workbook, FormulaType.CELL, sheetIndex, rowIndex);
-        if (arr.length != 1 || !(arr[0] instanceof Area3DPxg) ) {
+        if (arr.length != 1 || !(arr[0] instanceof Area3DPxg area) ) {
             throw new IllegalStateException("Illegal structured reference, had length: " + arr.length);
         }
-        return (Area3DPxg) arr[0];
+        return area;
     }
 
     /** Read New Character From Input Stream */
@@ -680,23 +680,12 @@ public final class FormulaParser {
                 break;
             }
             switch (specName) {
-                case specAll:
-                    isAllSpec = true;
-                    break;
-                case specData:
-                    isDataSpec = true;
-                    break;
-                case specHeaders:
-                    isHeadersSpec = true;
-                    break;
-                case specThisRow:
-                    isThisRowSpec = true;
-                    break;
-                case specTotals:
-                    isTotalsSpec = true;
-                    break;
-                default:
-                    throw new FormulaParseException("Unknown special quantifier " + specName);
+                case specAll -> isAllSpec = true;
+                case specData -> isDataSpec = true;
+                case specHeaders -> isHeadersSpec = true;
+                case specThisRow -> isThisRowSpec = true;
+                case specTotals -> isTotalsSpec = true;
+                default -> throw new FormulaParseException("Unknown special quantifier " + specName);
             }
             nSpecQuantifiers++;
             if (look == ','){
@@ -743,23 +732,12 @@ public final class FormulaParser {
                 String name = parseAsSpecialQuantifier();
                 if (name!=null) {
                     switch (name) {
-                        case specAll:
-                            isAllSpec = true;
-                            break;
-                        case specData:
-                            isDataSpec = true;
-                            break;
-                        case specHeaders:
-                            isHeadersSpec = true;
-                            break;
-                        case specThisRow:
-                            isThisRowSpec = true;
-                            break;
-                        case specTotals:
-                            isTotalsSpec = true;
-                            break;
-                        default:
-                            throw new FormulaParseException("Unknown special quantifier " + name);
+                        case specAll -> isAllSpec = true;
+                        case specData -> isDataSpec = true;
+                        case specHeaders -> isHeadersSpec = true;
+                        case specThisRow -> isThisRowSpec = true;
+                        case specTotals -> isTotalsSpec = true;
+                        default -> throw new FormulaParseException("Unknown special quantifier " + name);
                     }
                     nSpecQuantifiers++;
                 } else {
@@ -1364,17 +1342,16 @@ public final class FormulaParser {
                     LOGGER.atWarn().log("FormulaParser.function: Name '{}' is completely unknown in the current workbook.", name);
                     // name is probably the name of an unregistered User-Defined Function
                     switch (_book.getSpreadsheetVersion()) {
-                        case EXCEL97:
+                        case EXCEL97 -> {
                             // HSSFWorkbooks require a name to be added to Workbook defined names table
                             addName(name);
                             hName = _book.getName(name, _sheetIndex);
                             nameToken = hName.createPtg();
-                            break;
-                        case EXCEL2007:
+                        }
+                        case EXCEL2007 ->
                             // XSSFWorkbooks store formula names as strings.
                             nameToken = new NameXPxg(name);
-                            break;
-                        default:
+                        default ->
                             throw new IllegalStateException("Unexpected spreadsheet version: " + _book.getSpreadsheetVersion().name());
                     }
                 }
@@ -1596,18 +1573,18 @@ public final class FormulaParser {
             // + or - directly next to a number is parsed with the number
 
             Ptg token = factor.getToken();
-            if (token instanceof NumberPtg) {
+            if (token instanceof NumberPtg numberPtg) {
                 if (isPlus) {
                     return factor;
                 }
-                token = new NumberPtg(-((NumberPtg)token).getValue());
+                token = new NumberPtg(-numberPtg.getValue());
                 return new ParseNode(token);
             }
-            if (token instanceof IntPtg) {
+            if (token instanceof IntPtg intPtg) {
                 if (isPlus) {
                     return factor;
                 }
-                int intVal = ((IntPtg)token).getValue();
+                int intVal = intPtg.getValue();
                 // note - cannot use IntPtg for negatives
                 token = new NumberPtg(-intVal);
                 return new ParseNode(token);
@@ -1701,10 +1678,10 @@ public final class FormulaParser {
 
     private static Double convertArrayNumber(Ptg ptg, boolean isPositive) {
         double value;
-        if (ptg instanceof IntPtg) {
-            value = ((IntPtg)ptg).getValue();
-        } else  if (ptg instanceof NumberPtg) {
-            value = ((NumberPtg)ptg).getValue();
+        if (ptg instanceof IntPtg ip) {
+            value = ip.getValue();
+        } else  if (ptg instanceof NumberPtg np) {
+            value = np.getValue();
         } else {
             throw new IllegalStateException("Unexpected ptg (" + ptg.getClass().getName() + ")");
         }
@@ -1759,7 +1736,7 @@ public final class FormulaParser {
         part1 = part1.toUpperCase(Locale.ROOT);
 
         switch(part1.charAt(0)) {
-            case 'V': {
+            case 'V' -> {
                 FormulaError fe = FormulaError.VALUE;
                 if(part1.equals(fe.name())) {
                     match('!');
@@ -1767,7 +1744,7 @@ public final class FormulaParser {
                 }
                 throw expected(fe.getString());
             }
-            case 'R': {
+            case 'R' -> {
                 FormulaError fe = FormulaError.REF;
                 if(part1.equals(fe.name())) {
                     match('!');
@@ -1775,7 +1752,7 @@ public final class FormulaParser {
                 }
                 throw expected(fe.getString());
             }
-            case 'D': {
+            case 'D' -> {
                 FormulaError fe = FormulaError.DIV0;
                 if(part1.equals("DIV")) {
                     match('/');
@@ -1785,7 +1762,7 @@ public final class FormulaParser {
                 }
                 throw expected(fe.getString());
             }
-            case 'N': {
+            case 'N' -> {
                 FormulaError fe = FormulaError.NAME;
                 if(part1.equals(fe.name())) {
                     // only one that ends in '?'
@@ -1902,16 +1879,17 @@ public final class FormulaParser {
             skipWhite();
             Ptg operator;
             switch(look) {
-                case '*':
+                case '*' -> {
                     match('*');
                     operator = MultiplyPtg.instance;
-                    break;
-                case '/':
+                }
+                case '/' -> {
                     match('/');
                     operator = DividePtg.instance;
-                    break;
-                default:
+                }
+                default -> {
                     return result; // finished with Term
+                }
             }
             ParseNode other = powerFactor();
             result = new ParseNode(operator, result, other);
@@ -2031,16 +2009,17 @@ public final class FormulaParser {
             skipWhite();
             Ptg operator;
             switch(look) {
-                case '+':
+                case '+' -> {
                     match('+');
                     operator = AddPtg.instance;
-                    break;
-                case '-':
+                }
+                case '-' -> {
                     match('-');
                     operator = SubtractPtg.instance;
-                    break;
-                default:
+                }
+                default -> {
                     return result; // finished with additive expression
+                }
             }
             ParseNode other = Term();
             result = new ParseNode(operator, result, other);

--- a/poi/src/main/java/org/apache/poi/ss/formula/FormulaRenderer.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/FormulaRenderer.java
@@ -60,8 +60,7 @@ public class FormulaRenderer {
                 stack.push ("(" + contents + ")");
                 continue;
             }
-            if (ptg instanceof AttrPtg) {
-                AttrPtg attrPtg = ((AttrPtg) ptg);
+            if (ptg instanceof AttrPtg attrPtg) {
                 if (attrPtg.isOptimizedIf() || attrPtg.isOptimizedChoose() || attrPtg.isSkip()) {
                     continue;
                 }
@@ -84,17 +83,15 @@ public class FormulaRenderer {
                 throw new IllegalStateException("Unexpected tAttr: " + attrPtg);
             }
 
-            if (ptg instanceof WorkbookDependentFormula) {
-                WorkbookDependentFormula optg = (WorkbookDependentFormula) ptg;
+            if (ptg instanceof WorkbookDependentFormula optg) {
                 stack.push(optg.toFormulaString(book));
                 continue;
             }
-            if (! (ptg instanceof OperationPtg)) {
+            if (! (ptg instanceof OperationPtg o)) {
                 stack.push(ptg.toFormulaString());
                 continue;
             }
 
-            OperationPtg o = (OperationPtg) ptg;
             String[] operands = getOperands(stack, o.getNumberOfOperands());
             stack.push(o.toFormulaString(operands));
         }

--- a/poi/src/main/java/org/apache/poi/ss/formula/FormulaUsedBlankCellSet.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/FormulaUsedBlankCellSet.java
@@ -43,10 +43,9 @@ final class FormulaUsedBlankCellSet {
         }
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof BookSheetKey)) {
+            if (!(obj instanceof BookSheetKey other)) {
                 return false;
             }
-            BookSheetKey other = (BookSheetKey) obj;
             return _bookIndex == other._bookIndex && _sheetIndex == other._sheetIndex;
         }
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/OperandClassTransformer.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/OperandClassTransformer.java
@@ -120,8 +120,8 @@ final class OperandClassTransformer {
             }
             return;
         }
-        if (token instanceof AbstractFunctionPtg) {
-            transformFunctionNode((AbstractFunctionPtg) token, children, desiredOperandClass, callerForceArrayFlag);
+        if (token instanceof AbstractFunctionPtg afp) {
+            transformFunctionNode(afp, children, desiredOperandClass, callerForceArrayFlag);
             return;
         }
         if (children.length > 0) {
@@ -140,16 +140,14 @@ final class OperandClassTransformer {
     }
 
     private static boolean isSingleArgSum(Ptg token) {
-        if (token instanceof AttrPtg) {
-            AttrPtg attrPtg = (AttrPtg) token;
+        if (token instanceof AttrPtg attrPtg) {
             return attrPtg.isSum();
         }
         return false;
     }
 
     private static boolean isSimpleValueFunction(Ptg token) {
-        if (token instanceof AbstractFunctionPtg) {
-            AbstractFunctionPtg aptg = (AbstractFunctionPtg) token;
+        if (token instanceof AbstractFunctionPtg aptg) {
             if (aptg.getDefaultOperandClass() != Ptg.CLASS_VALUE) {
                 return false;
             }

--- a/poi/src/main/java/org/apache/poi/ss/formula/OperationEvaluationContext.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/OperationEvaluationContext.java
@@ -124,8 +124,8 @@ public final class OperationEvaluationContext {
                 otherFirstSheetIndex = _workbook.getSheetIndex(externalSheet.getSheetName());
             }
 
-            if (externalSheet instanceof ExternalSheetRange) {
-                String lastSheetName = ((ExternalSheetRange) externalSheet).getLastSheetName();
+            if (externalSheet instanceof ExternalSheetRange esr) {
+                String lastSheetName = esr.getLastSheetName();
                 otherLastSheetIndex = _workbook.getSheetIndex(lastSheetName);
             }
         } else {
@@ -138,8 +138,8 @@ public final class OperationEvaluationContext {
             }
 
             otherFirstSheetIndex = targetEvaluator.getSheetIndex(externalSheet.getSheetName());
-            if (externalSheet instanceof ExternalSheetRange) {
-                String lastSheetName = ((ExternalSheetRange) externalSheet).getLastSheetName();
+            if (externalSheet instanceof ExternalSheetRange esr) {
+                String lastSheetName = esr.getLastSheetName();
                 otherLastSheetIndex = targetEvaluator.getSheetIndex(lastSheetName);
             }
 
@@ -419,17 +419,17 @@ public final class OperationEvaluationContext {
         if (token == null) {
             throw new IllegalStateException("Array item cannot be null");
         }
-        if (token instanceof String) {
-            return new StringEval((String) token);
+        if (token instanceof String s) {
+            return new StringEval(s);
         }
-        if (token instanceof Double) {
-            return new NumberEval((Double) token);
+        if (token instanceof Double d) {
+            return new NumberEval(d);
         }
-        if (token instanceof Boolean) {
-            return BoolEval.valueOf((Boolean) token);
+        if (token instanceof Boolean b) {
+            return BoolEval.valueOf(b);
         }
-        if (token instanceof ErrorConstant) {
-            return ErrorEval.valueOf(((ErrorConstant) token).getErrorCode());
+        if (token instanceof ErrorConstant ec) {
+            return ErrorEval.valueOf(ec.getErrorCode());
         }
         throw new IllegalArgumentException("Unexpected constant class (" + token.getClass().getName() + ")");
     }
@@ -541,17 +541,13 @@ public final class OperationEvaluationContext {
                         refWorkbookEvaluator, refWorkbookEvaluator.getWorkbook(), -1, -1, -1, _tracker);
 
                 Ptg ptg = evaluationName.getNameDefinition()[0];
-                if (ptg instanceof Ref3DPtg) {
-                    Ref3DPtg ref3D = (Ref3DPtg) ptg;
+                if (ptg instanceof Ref3DPtg ref3D) {
                     return refWorkbookContext.getRef3DEval(ref3D);
-                } else if (ptg instanceof Ref3DPxg) {
-                    Ref3DPxg ref3D = (Ref3DPxg) ptg;
+                } else if (ptg instanceof Ref3DPxg ref3D) {
                     return refWorkbookContext.getRef3DEval(ref3D);
-                } else if (ptg instanceof Area3DPtg) {
-                    Area3DPtg area3D = (Area3DPtg) ptg;
+                } else if (ptg instanceof Area3DPtg area3D) {
                     return refWorkbookContext.getArea3DEval(area3D);
-                } else if (ptg instanceof Area3DPxg) {
-                    Area3DPxg area3D = (Area3DPxg) ptg;
+                } else if (ptg instanceof Area3DPxg area3D) {
                     return refWorkbookContext.getArea3DEval(area3D);
                 }
             }

--- a/poi/src/main/java/org/apache/poi/ss/formula/OperatorEnum.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/OperatorEnum.java
@@ -77,15 +77,15 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean between(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
                 double n1 = 0;
                 double n2 = v2 == null ? 0 : ((Number) v2).doubleValue();
-                return Double.compare( ((Number) cellValue).doubleValue(), n1) >= 0 && Double.compare(((Number) cellValue).doubleValue(), n2) <= 0;
-            } else if (cellValue instanceof String) {
+                return Double.compare( num.doubleValue(), n1) >= 0 && Double.compare(num.doubleValue(), n2) <= 0;
+            } else if (cellValue instanceof String str) {
                 String n1 = "";
                 String n2 = v2 == null ? "" : (String) v2;
-                return ((String) cellValue).compareToIgnoreCase(n1) >= 0 && ((String) cellValue).compareToIgnoreCase(n2) <= 0;
+                return str.compareToIgnoreCase(n1) >= 0 && str.compareToIgnoreCase(n2) <= 0;
             } else if (cellValue instanceof Boolean) return false;
             return false; // just in case - not a typical possibility
         }
@@ -94,15 +94,15 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean notBetween(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
                 double n1 = 0;
                 double n2 = v2 == null ? 0 : ((Number) v2).doubleValue();
-                return Double.compare( ((Number) cellValue).doubleValue(), n1) < 0 || Double.compare(((Number) cellValue).doubleValue(), n2) > 0;
-            } else if (cellValue instanceof String) {
+                return Double.compare( num.doubleValue(), n1) < 0 || Double.compare(num.doubleValue(), n2) > 0;
+            } else if (cellValue instanceof String str) {
                 String n1 = "";
                 String n2 = v2 == null ? "" : (String) v2;
-                return ((String) cellValue).compareToIgnoreCase(n1) < 0 || ((String) cellValue).compareToIgnoreCase(n2) > 0;
+                return str.compareToIgnoreCase(n1) < 0 || str.compareToIgnoreCase(n2) > 0;
             } else {
                 // just in case - not a typical possibility
                 return cellValue instanceof Boolean;
@@ -113,9 +113,9 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean equalCheck(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
-                return Double.compare( ((Number) cellValue).doubleValue(), 0) == 0;
+                return Double.compare( num.doubleValue(), 0) == 0;
             } else if (cellValue instanceof String) {
                 return false; // even an empty string is not equal the empty cell, only another empty cell is, handled higher up
             } else if (cellValue instanceof Boolean) return false;
@@ -139,9 +139,9 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean greaterThan(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
-                return Double.compare( ((Number) cellValue).doubleValue(), 0) > 0;
+                return Double.compare( num.doubleValue(), 0) > 0;
             } else if (cellValue instanceof String) {
                 return true; // non-null string greater than empty cell
             } else {
@@ -154,9 +154,9 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean lessThan(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
-                return Double.compare( ((Number) cellValue).doubleValue(), 0) < 0;
+                return Double.compare( num.doubleValue(), 0) < 0;
             } else if (cellValue instanceof String) {
                 return false; // non-null string greater than empty cell
             } else if (cellValue instanceof Boolean) return false;
@@ -167,9 +167,9 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean greaterOrEqual(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
-                return Double.compare( ((Number) cellValue).doubleValue(), 0) >= 0;
+                return Double.compare( num.doubleValue(), 0) >= 0;
             } else if (cellValue instanceof String) {
                 return true; // non-null string greater than empty cell
             } else {
@@ -182,9 +182,9 @@ enum OperatorEnum {
 
     private static <C extends Comparable<C>> boolean lessOrEqual(C cellValue, C v1, C v2) {
         if (v1 == null) {
-            if (cellValue instanceof Number) {
+            if (cellValue instanceof Number num) {
                 // use zero for null
-                return Double.compare( ((Number) cellValue).doubleValue(), 0) <= 0;
+                return Double.compare( num.doubleValue(), 0) <= 0;
             } else if (cellValue instanceof String) {
                 return false; // non-null string not less than empty cell
             } else if (cellValue instanceof Boolean) return false; // for completeness

--- a/poi/src/main/java/org/apache/poi/ss/formula/ParseNode.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/ParseNode.java
@@ -148,8 +148,7 @@ final class ParseNode {
     }
 
     private static boolean isIf(Ptg token) {
-        if (token instanceof FuncVarPtg) {
-            FuncVarPtg func = (FuncVarPtg) token;
+        if (token instanceof FuncVarPtg func) {
             return FunctionMetadataRegistry.FUNCTION_NAME_IF.equals(func.getName());
         }
         return false;

--- a/poi/src/main/java/org/apache/poi/ss/formula/SharedFormula.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/SharedFormula.java
@@ -49,15 +49,13 @@ public class SharedFormula {
             if (!ptg.isBaseToken()) {
                 originalOperandClass = ptg.getPtgClass();
             }
-            if (ptg instanceof RefPtgBase) {
-                RefPtgBase refNPtg = (RefPtgBase)ptg;
+            if (ptg instanceof RefPtgBase refNPtg) {
                 ptg = new RefPtg(fixupRelativeRow(formulaRow,refNPtg.getRow(),refNPtg.isRowRelative()),
                                      fixupRelativeColumn(formulaColumn,refNPtg.getColumn(),refNPtg.isColRelative()),
                                      refNPtg.isRowRelative(),
                                      refNPtg.isColRelative());
                 ptg.setClass(originalOperandClass);
-            } else if (ptg instanceof AreaPtgBase) {
-                AreaPtgBase areaNPtg = (AreaPtgBase)ptg;
+            } else if (ptg instanceof AreaPtgBase areaNPtg) {
                 ptg = new AreaPtg(fixupRelativeRow(formulaRow,areaNPtg.getFirstRow(),areaNPtg.isFirstRowRelative()),
                                 fixupRelativeRow(formulaRow,areaNPtg.getLastRow(),areaNPtg.isLastRowRelative()),
                                 fixupRelativeColumn(formulaColumn,areaNPtg.getFirstColumn(),areaNPtg.isFirstColRelative()),
@@ -67,9 +65,9 @@ public class SharedFormula {
                                 areaNPtg.isFirstColRelative(),
                                 areaNPtg.isLastColRelative());
                 ptg.setClass(originalOperandClass);
-            } else if (ptg instanceof OperandPtg) {
+            } else if (ptg instanceof OperandPtg optg) {
                 // Any subclass of OperandPtg is mutable, so it's safest to not share these instances.
-                ptg = ((OperandPtg) ptg).copy();
+                ptg = optg.copy();
             }
             // all other Ptgs are immutable and can be shared
             newPtgStack[k] = ptg;

--- a/poi/src/main/java/org/apache/poi/ss/formula/SheetRefEvaluator.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/SheetRefEvaluator.java
@@ -67,8 +67,7 @@ final class SheetRefEvaluator {
         if(cell != null && cell.getCellType() == CellType.FORMULA){
             EvaluationWorkbook wb = _bookEvaluator.getWorkbook();
             for(Ptg ptg : wb.getFormulaTokens(cell)){
-                if(ptg instanceof FuncVarPtg){
-                    FuncVarPtg f = (FuncVarPtg)ptg;
+                if(ptg instanceof FuncVarPtg f){
                     if("SUBTOTAL".equals(f.getName())) {
                         subtotal = true;
                         break;

--- a/poi/src/main/java/org/apache/poi/ss/formula/WorkbookEvaluator.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/WorkbookEvaluator.java
@@ -724,8 +724,8 @@ public final class WorkbookEvaluator {
     }
 
     private ValueEval processNameEval(ValueEval eval, OperationEvaluationContext ec) {
-        if (eval instanceof ExternalNameEval) {
-            EvaluationName name = ((ExternalNameEval) eval).getName();
+        if (eval instanceof ExternalNameEval ene) {
+            EvaluationName name = ene.getName();
             return getEvalForNameRecord(name, ec);
         }
         return eval;
@@ -871,8 +871,7 @@ public final class WorkbookEvaluator {
         boolean shifted = false;
         for (Ptg ptg : ptgs) {
             // base class for cell reference "things"
-            if (ptg instanceof RefPtgBase) {
-                RefPtgBase ref = (RefPtgBase) ptg;
+            if (ptg instanceof RefPtgBase ref) {
                 // re-calculate cell references
                 final SpreadsheetVersion version = _workbook.getSpreadsheetVersion();
                 if (ref.isRowRelative() && deltaRow > 0) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/atp/ArgumentsEvaluator.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/atp/ArgumentsEvaluator.java
@@ -52,8 +52,8 @@ final class ArgumentsEvaluator {
     public double evaluateDateArg(ValueEval arg, int srcCellRow, int srcCellCol) throws EvaluationException {
         ValueEval ve = OperandResolver.getSingleValue(arg, srcCellRow, (short) srcCellCol);
 
-        if (ve instanceof StringEval) {
-            String strVal = ((StringEval) ve).getStringValue();
+        if (ve instanceof StringEval se) {
+            String strVal = se.getStringValue();
             Double dVal = OperandResolver.parseDouble(strVal);
             if (dVal != null) {
                 return dVal.doubleValue();
@@ -80,9 +80,8 @@ final class ArgumentsEvaluator {
 
         if (arg instanceof StringEval) {
             return new double[]{ evaluateDateArg(arg, srcCellRow, srcCellCol) };
-        } else if (arg instanceof AreaEvalBase) {
+        } else if (arg instanceof AreaEvalBase area) {
             List<Double> valuesList = new ArrayList<>();
-            AreaEvalBase area = (AreaEvalBase) arg;
             for (int i = area.getFirstRow(); i <= area.getLastRow(); i++) {
                 for (int j = area.getFirstColumn(); j <= area.getLastColumn(); j++) {
                     // getValue() is replaced with getAbsoluteValue() because loop variables i, j are

--- a/poi/src/main/java/org/apache/poi/ss/formula/atp/PercentRankExcFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/atp/PercentRankExcFunction.java
@@ -138,15 +138,15 @@ final class PercentRankExcFunction implements FreeRefFunction {
         } else {
             int intermediateSignificance = significance < 5 ? 8 : significance + 3;
             ValueEval belowRank = calculateRank(numbers, closestMatchBelow, intermediateSignificance, false);
-            if (!(belowRank instanceof NumberEval)) {
+            if (!(belowRank instanceof NumberEval belowNum)) {
                 return belowRank;
             }
             ValueEval aboveRank = calculateRank(numbers, closestMatchAbove, intermediateSignificance, false);
-            if (!(aboveRank instanceof NumberEval)) {
+            if (!(aboveRank instanceof NumberEval aboveNum)) {
                 return aboveRank;
             }
             return PercentRank.interpolate(x, closestMatchBelow, closestMatchAbove,
-                    (NumberEval)belowRank, (NumberEval)aboveRank, significance);
+                    belowNum, aboveNum, significance);
         }
     }
 }

--- a/poi/src/main/java/org/apache/poi/ss/formula/atp/Switch.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/atp/Switch.java
@@ -65,8 +65,7 @@ public final class Switch implements FreeRefFunction {
 
 
                 final ValueEval evaluate = EqualEval.evaluate(new ValueEval[]{expression, value}, ec.getRowIndex(), ec.getColumnIndex());
-                if (evaluate instanceof BoolEval) {
-                    BoolEval boolEval = (BoolEval) evaluate;
+                if (evaluate instanceof BoolEval boolEval) {
                     final boolean booleanValue = boolEval.getBooleanValue();
                     if (booleanValue) {
                         return result;

--- a/poi/src/main/java/org/apache/poi/ss/formula/atp/TextJoinFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/atp/TextJoinFunction.java
@@ -129,8 +129,7 @@ final class TextJoinFunction implements FreeRefFunction {
     //this is why lastRowOnly is supported
     private List<ValueEval> getValues(ValueEval eval, int srcRowIndex, int srcColumnIndex,
                                       boolean lastRowOnly) throws EvaluationException {
-        if (eval instanceof AreaEval) {
-            AreaEval ae = (AreaEval)eval;
+        if (eval instanceof AreaEval ae) {
             List<ValueEval> list = new ArrayList<>();
             int startRow = lastRowOnly ? ae.getLastRow() : ae.getFirstRow();
             for (int r = startRow; r <= ae.getLastRow(); r++) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/atp/XLookupFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/atp/XLookupFunction.java
@@ -117,8 +117,7 @@ final class XLookupFunction implements FreeRefFunction, ArrayFunction {
             } catch (EvaluationException e) {
                 if (ErrorEval.NA.equals(e.getErrorEval())) {
                     if (notFound != BlankEval.instance) {
-                        if (returnEval instanceof AreaEval) {
-                            AreaEval area = (AreaEval)returnEval;
+                        if (returnEval instanceof AreaEval area) {
                             int width = area.getWidth();
                             if (width <= 1) {
                                 return notFound;
@@ -133,8 +132,7 @@ final class XLookupFunction implements FreeRefFunction, ArrayFunction {
                     return e.getErrorEval();
                 }
             }
-            if (returnEval instanceof AreaEval) {
-                AreaEval area = (AreaEval)returnEval;
+            if (returnEval instanceof AreaEval area) {
                 if (tableArray.isColumn()) {
                     return area.offset(matchedIdx, matchedIdx,0, area.getWidth() - 1);
                 } else {

--- a/poi/src/main/java/org/apache/poi/ss/formula/atp/YearFrac.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/atp/YearFrac.java
@@ -88,8 +88,8 @@ final class YearFrac implements FreeRefFunction {
     private static double evaluateDateArg(ValueEval arg, int srcCellRow, int srcCellCol) throws EvaluationException {
         ValueEval ve = OperandResolver.getSingleValue(arg, srcCellRow, (short) srcCellCol);
 
-        if (ve instanceof StringEval) {
-            String strVal = ((StringEval) ve).getStringValue();
+        if (ve instanceof StringEval se) {
+            String strVal = se.getStringValue();
             Double dVal = OperandResolver.parseDouble(strVal);
             if (dVal != null) {
                 return dVal;

--- a/poi/src/main/java/org/apache/poi/ss/formula/constant/ConstantValueParser.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/constant/ConstantValueParser.java
@@ -126,27 +126,23 @@ public final class ConstantValueParser {
             out.writeLong(0L);
             return;
         }
-        if (value instanceof Boolean) {
-            Boolean bVal = ((Boolean)value);
+        if (value instanceof Boolean bVal) {
             out.writeByte(TYPE_BOOLEAN);
             long longVal = bVal ? 1L : 0L;
             out.writeLong(longVal);
             return;
         }
-        if (value instanceof Double) {
-            Double dVal = (Double) value;
+        if (value instanceof Double dVal) {
             out.writeByte(TYPE_NUMBER);
             out.writeDouble(dVal);
             return;
         }
-        if (value instanceof String) {
-            String val = (String) value;
+        if (value instanceof String val) {
             out.writeByte(TYPE_STRING);
             StringUtil.writeUnicodeString(out, val);
             return;
         }
-        if (value instanceof ErrorConstant) {
-            ErrorConstant ecVal = (ErrorConstant) value;
+        if (value instanceof ErrorConstant ecVal) {
             out.writeByte(TYPE_ERROR_CODE);
             long longVal = ecVal.getErrorCode();
             out.writeLong(longVal);

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/ConcatEval.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/ConcatEval.java
@@ -44,8 +44,7 @@ public final class ConcatEval  extends Fixed2ArgFunction {
     }
 
     private Object getText(ValueEval ve) {
-        if (ve instanceof StringValueEval) {
-            StringValueEval sve = (StringValueEval) ve;
+        if (ve instanceof StringValueEval sve) {
             return sve.getStringValue();
         }
         if (ve == BlankEval.instance) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/IntersectionEval.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/IntersectionEval.java
@@ -80,14 +80,14 @@ public final class IntersectionEval  extends Fixed2ArgFunction {
     }
 
     private static AreaEval evaluateRef(ValueEval arg) throws EvaluationException {
-        if (arg instanceof AreaEval) {
-            return (AreaEval) arg;
+        if (arg instanceof AreaEval ae) {
+            return ae;
         }
-        if (arg instanceof RefEval) {
-            return ((RefEval) arg).offset(0, 0, 0, 0);
+        if (arg instanceof RefEval re) {
+            return re.offset(0, 0, 0, 0);
         }
-        if (arg instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval)arg);
+        if (arg instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         throw new IllegalArgumentException("Unexpected ref arg class (" + arg.getClass().getName() + ")");
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/NumberEval.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/NumberEval.java
@@ -36,10 +36,10 @@ public final class NumberEval implements NumericValueEval, StringValueEval {
         if (ptg == null) {
             throw new IllegalArgumentException("ptg must not be null");
         }
-        if (ptg instanceof IntPtg) {
-            _value = ((IntPtg) ptg).getValue();
-        } else if (ptg instanceof NumberPtg) {
-            _value = ((NumberPtg) ptg).getValue();
+        if (ptg instanceof IntPtg ip) {
+            _value = ip.getValue();
+        } else if (ptg instanceof NumberPtg np) {
+            _value = np.getValue();
         } else {
             throw new IllegalArgumentException("bad argument type (" + ptg.getClass().getName() + ")");
         }

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/OperandResolver.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/OperandResolver.java
@@ -63,15 +63,15 @@ public final class OperandResolver {
     public static ValueEval getSingleValue(ValueEval arg, int srcCellRow, int srcCellCol)
             throws EvaluationException {
         final ValueEval result;
-        if (arg instanceof RefEval) {
-            result = chooseSingleElementFromRef((RefEval) arg);
-        } else if (arg instanceof AreaEval) {
-            result = chooseSingleElementFromArea((AreaEval) arg, srcCellRow, srcCellCol);
+        if (arg instanceof RefEval re) {
+            result = chooseSingleElementFromRef(re);
+        } else if (arg instanceof AreaEval ae) {
+            result = chooseSingleElementFromArea(ae, srcCellRow, srcCellCol);
         } else {
             result = arg;
         }
-        if (result instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) result);
+        if (result instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         return result;
     }
@@ -158,8 +158,8 @@ public final class OperandResolver {
     public static ValueEval chooseSingleElementFromArea(AreaEval ae,
             int srcCellRow, int srcCellCol) throws EvaluationException {
         ValueEval result = chooseSingleElementFromAreaInternal(ae, srcCellRow, srcCellCol);
-        if (result instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) result);
+        if (result instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         return result;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/RangeEval.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/RangeEval.java
@@ -58,14 +58,14 @@ public final class RangeEval extends Fixed2ArgFunction {
     }
 
     private static AreaEval evaluateRef(ValueEval arg) throws EvaluationException {
-        if (arg instanceof AreaEval) {
-            return (AreaEval) arg;
+        if (arg instanceof AreaEval ae) {
+            return ae;
         }
-        if (arg instanceof RefEval) {
-            return ((RefEval) arg).offset(0, 0, 0, 0);
+        if (arg instanceof RefEval re) {
+            return re.offset(0, 0, 0, 0);
         }
-        if (arg instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval)arg);
+        if (arg instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         throw new IllegalArgumentException("Unexpected ref arg class (" + arg.getClass().getName() + ")");
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/RefListEval.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/RefListEval.java
@@ -33,8 +33,8 @@ public class RefListEval implements ValueEval {
 
     private void add(ValueEval v) {
         // flatten multiple nested RefListEval
-        if(v instanceof RefListEval) {
-            list.addAll(((RefListEval)v).list);
+        if(v instanceof RefListEval rle) {
+            list.addAll(rle.list);
         } else {
             list.add(v);
         }

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/forked/ForkedEvaluationSheet.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/forked/ForkedEvaluationSheet.java
@@ -144,10 +144,9 @@ final class ForkedEvaluationSheet implements EvaluationSheet {
         }
         @Override
         public boolean equals(Object obj) {
-            if (!(obj instanceof RowColKey)) {
+            if (!(obj instanceof RowColKey other)) {
                 return false;
             }
-            RowColKey other = (RowColKey) obj;
             return _rowIndex == other._rowIndex && _columnIndex == other._columnIndex;
         }
         @Override

--- a/poi/src/main/java/org/apache/poi/ss/formula/eval/forked/ForkedEvaluationWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/eval/forked/ForkedEvaluationWorkbook.java
@@ -129,8 +129,7 @@ final class ForkedEvaluationWorkbook implements EvaluationWorkbook {
 
     @Override
     public int getSheetIndex(EvaluationSheet sheet) {
-        if (sheet instanceof ForkedEvaluationSheet) {
-            ForkedEvaluationSheet mes = (ForkedEvaluationSheet) sheet;
+        if (sheet instanceof ForkedEvaluationSheet mes) {
             return mes.getSheetIndex(_masterBook);
         }
         return _masterBook.getSheetIndex(sheet);

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Areas.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Areas.java
@@ -36,8 +36,7 @@ public final class Areas implements Function {
         try {
             ValueEval valueEval = args[0];
             int result = 1;
-            if (valueEval instanceof RefListEval) {
-                RefListEval refListEval = (RefListEval) valueEval;
+            if (valueEval instanceof RefListEval refListEval) {
                 result = refListEval.getList().size();
             }
             return new NumberEval(new NumberPtg(result));

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/ArrayFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/ArrayFunction.java
@@ -71,14 +71,12 @@ public interface ArrayFunction {
         BiFunction<ValueEval, ValueEval, ValueEval> evalFunc) {
         int w1, w2, h1, h2;
         int a1FirstCol = 0, a1FirstRow = 0;
-        if (arg0 instanceof AreaEval) {
-            AreaEval ae = (AreaEval)arg0;
+        if (arg0 instanceof AreaEval ae) {
             w1 = ae.getWidth();
             h1 = ae.getHeight();
             a1FirstCol = ae.getFirstColumn();
             a1FirstRow = ae.getFirstRow();
-        } else if (arg0 instanceof RefEval){
-            RefEval ref = (RefEval)arg0;
+        } else if (arg0 instanceof RefEval ref){
             w1 = 1;
             h1 = 1;
             a1FirstCol = ref.getColumn();
@@ -88,14 +86,12 @@ public interface ArrayFunction {
             h1 = 1;
         }
         int a2FirstCol = 0, a2FirstRow = 0;
-        if (arg1 instanceof AreaEval) {
-            AreaEval ae = (AreaEval)arg1;
+        if (arg1 instanceof AreaEval ae) {
             w2 = ae.getWidth();
             h2 = ae.getHeight();
             a2FirstCol = ae.getFirstColumn();
             a2FirstRow = ae.getFirstRow();
-        } else if (arg1 instanceof RefEval){
-            RefEval ref = (RefEval)arg1;
+        } else if (arg1 instanceof RefEval ref){
             w2 = 1;
             h2 = 1;
             a2FirstCol = ref.getColumn();
@@ -164,14 +160,12 @@ public interface ArrayFunction {
         java.util.function.Function<ValueEval, ValueEval> evalFunc){
         int w1, w2, h1, h2;
         int a1FirstCol = 0, a1FirstRow = 0;
-        if (arg0 instanceof AreaEval) {
-            AreaEval ae = (AreaEval)arg0;
+        if (arg0 instanceof AreaEval ae) {
             w1 = ae.getWidth();
             h1 = ae.getHeight();
             a1FirstCol = ae.getFirstColumn();
             a1FirstRow = ae.getFirstRow();
-        } else if (arg0 instanceof RefEval){
-            RefEval ref = (RefEval)arg0;
+        } else if (arg0 instanceof RefEval ref){
             w1 = 1;
             h1 = 1;
             a1FirstCol = ref.getColumn();

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/ArrayFunctionUtils.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/ArrayFunctionUtils.java
@@ -54,8 +54,7 @@ final class ArrayFunctionUtils {
 
     private static DoubleList collectValuesWithBlanks(ValueEval operand) throws EvaluationException {
         DoubleList doubleList = new DoubleList();
-        if (operand instanceof ThreeDEval) {
-            ThreeDEval ae = (ThreeDEval) operand;
+        if (operand instanceof ThreeDEval ae) {
             for (int sIx = ae.getFirstSheetIndex(); sIx <= ae.getLastSheetIndex(); sIx++) {
                 int width = ae.getWidth();
                 int height = ae.getHeight();
@@ -73,8 +72,7 @@ final class ArrayFunctionUtils {
             }
             return doubleList;
         }
-        if (operand instanceof TwoDEval) {
-            TwoDEval ae = (TwoDEval) operand;
+        if (operand instanceof TwoDEval ae) {
             int width = ae.getWidth();
             int height = ae.getHeight();
             for (int rrIx = 0; rrIx < height; rrIx++) {
@@ -90,8 +88,7 @@ final class ArrayFunctionUtils {
             }
             return doubleList;
         }
-        if (operand instanceof RefEval) {
-            RefEval re = (RefEval) operand;
+        if (operand instanceof RefEval re) {
             for (int sIx = re.getFirstSheetIndex(); sIx <= re.getLastSheetIndex(); sIx++) {
                 Double d = collectValue(re.getInnerValueEval(sIx));
                 if (d == null) {
@@ -115,16 +112,15 @@ final class ArrayFunctionUtils {
         if (ve == null) {
             throw new IllegalArgumentException("ve must not be null");
         }
-        if (ve instanceof NumericValueEval) {
-            NumericValueEval ne = (NumericValueEval) ve;
+        if (ve instanceof NumericValueEval ne) {
             return ne.getNumberValue();
         }
-        if (ve instanceof StringValueEval) {
-            String s = ((StringValueEval) ve).getStringValue().trim();
+        if (ve instanceof StringValueEval sve) {
+            String s = sve.getStringValue().trim();
             return OperandResolver.parseDouble(s);
         }
-        if (ve instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) ve);
+        if (ve instanceof ErrorEval errorEval) {
+            throw new EvaluationException(errorEval);
         }
         if (ve == BlankEval.instance) {
             return null;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/AverageIf.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/AverageIf.java
@@ -48,8 +48,8 @@ public class AverageIf extends Baseifs {
             AreaEval ae = convertRangeArg(args[0]);
             I_MatchPredicate mp = Countif.createCriteriaPredicate(args[1], ec.getRowIndex(), ec.getColumnIndex());
 
-            if (mp instanceof Countif.ErrorMatcher) {
-                throw new EvaluationException(ErrorEval.valueOf(((Countif.ErrorMatcher) mp).getValue()));
+            if (mp instanceof Countif.ErrorMatcher errorMatcher) {
+                throw new EvaluationException(ErrorEval.valueOf(errorMatcher.getValue()));
             }
 
             return aggregateMatchingCells(createAggregator(), sumRange, ae, mp);
@@ -72,8 +72,8 @@ public class AverageIf extends Baseifs {
 
                 if (mp != null && mp.matches(_testValue)) {
                     // aggregate only if all of the corresponding criteria specified are true for that cell.
-                    if (_testValue instanceof ErrorEval) {
-                        throw new EvaluationException((ErrorEval) _testValue);
+                    if (_testValue instanceof ErrorEval errorEval) {
+                        throw new EvaluationException(errorEval);
                     }
                     aggregator.addValue(_sumValue);
                 }
@@ -96,9 +96,9 @@ public class AverageIf extends Baseifs {
             @Override
             public void addValue(ValueEval value) {
 
-                if (!(value instanceof NumberEval)) return;
+                if (!(value instanceof NumberEval ne)) return;
 
-                final double d = ((NumberEval) value).getNumberValue();
+                final double d = ne.getNumberValue();
                 sum += d;
                 count++;
 

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Averageifs.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Averageifs.java
@@ -65,9 +65,9 @@ public final class Averageifs extends Baseifs {
 
             @Override
             public void addValue(ValueEval value) {
-                if(!(value instanceof NumberEval)) return;
+                if(!(value instanceof NumberEval ne)) return;
 
-                double d = ((NumberEval) value).getNumberValue();
+                double d = ne.getNumberValue();
                 sum += d;
                 count++;
 

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Baseifs.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Baseifs.java
@@ -82,8 +82,7 @@ import org.apache.poi.ss.formula.functions.Countif.ErrorMatcher;
             // yield the wrong single value or produce an ERROR when the formula cell
             // lies outside the array's row/column bounds (Bug 70005).
             for (int k = 0; k < numPairs; k++) {
-                if (criteriaArgs[k] instanceof AreaEval) {
-                    AreaEval arrayCrit = (AreaEval) criteriaArgs[k];
+                if (criteriaArgs[k] instanceof AreaEval arrayCrit) {
                     if (arrayCrit.getHeight() * arrayCrit.getWidth() > 1) {
                         double total = 0.0;
                         for (int r = 0; r < arrayCrit.getHeight(); r++) {
@@ -98,8 +97,8 @@ import org.apache.poi.ss.formula.functions.Countif.ErrorMatcher;
                                 validateCriteria(mp);
                                 ValueEval partial = aggregateMatchingCells(createAggregator(), sumRange, ae, mp);
                                 if (partial instanceof ErrorEval) return partial;
-                                if (partial instanceof NumberEval) {
-                                    total += ((NumberEval) partial).getNumberValue();
+                                if (partial instanceof NumberEval ne) {
+                                    total += ne.getNumberValue();
                                 }
                             }
                         }
@@ -155,8 +154,8 @@ import org.apache.poi.ss.formula.functions.Countif.ErrorMatcher;
         for(I_MatchPredicate predicate : criteria) {
 
             // check for errors in predicate and return immediately using this error code
-            if(predicate instanceof ErrorMatcher) {
-                throw new EvaluationException(ErrorEval.valueOf(((ErrorMatcher)predicate).getValue()));
+            if(predicate instanceof ErrorMatcher errorMatcher) {
+                throw new EvaluationException(ErrorEval.valueOf(errorMatcher.getValue()));
             }
         }
     }
@@ -192,8 +191,8 @@ import org.apache.poi.ss.formula.functions.Countif.ErrorMatcher;
                 if(matches) { // aggregate only if all of the corresponding criteria specified are true for that cell.
                     if(sumRange != null) {
                         ValueEval value = sumRange.getRelativeValue(r, c);
-                        if (value instanceof ErrorEval) {
-                            throw new EvaluationException((ErrorEval)value);
+                        if (value instanceof ErrorEval errorEval) {
+                            throw new EvaluationException(errorEval);
                         }
                         aggregator.addValue(value);
                     } else {
@@ -206,11 +205,11 @@ import org.apache.poi.ss.formula.functions.Countif.ErrorMatcher;
     }
 
     protected static AreaEval convertRangeArg(ValueEval eval) throws EvaluationException {
-        if (eval instanceof AreaEval) {
-            return (AreaEval) eval;
+        if (eval instanceof AreaEval areaEval) {
+            return areaEval;
         }
-        if (eval instanceof RefEval) {
-            return ((RefEval)eval).offset(0, 0, 0, 0);
+        if (eval instanceof RefEval refEval) {
+            return refEval.offset(0, 0, 0, 0);
         }
         throw new EvaluationException(ErrorEval.VALUE_INVALID);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Bin2Dec.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Bin2Dec.java
@@ -47,8 +47,7 @@ public class Bin2Dec extends Fixed1ArgFunction implements FreeRefFunction {
     @Override
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval numberVE) {
         final String number;
-        if (numberVE instanceof RefEval) {
-            RefEval re = (RefEval) numberVE;
+        if (numberVE instanceof RefEval re) {
             number = OperandResolver.coerceValueToString(re.getInnerValueEval(re.getFirstSheetIndex()));
         } else {
             number = OperandResolver.coerceValueToString(numberVE);

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/BooleanFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/BooleanFunction.java
@@ -61,8 +61,7 @@ public abstract class BooleanFunction implements Function,ArrayFunction {
          */
         for (final ValueEval arg : args) {
             Boolean tempVe;
-            if (arg instanceof TwoDEval) {
-                TwoDEval ae = (TwoDEval) arg;
+            if (arg instanceof TwoDEval ae) {
                 int height = ae.getHeight();
                 int width = ae.getWidth();
                 for (int rrIx=0; rrIx<height; rrIx++) {
@@ -77,8 +76,7 @@ public abstract class BooleanFunction implements Function,ArrayFunction {
                 }
                 continue;
             }
-            if (arg instanceof RefEval) {
-                RefEval re = (RefEval) arg;
+            if (arg instanceof RefEval re) {
                 final int firstSheetIndex = re.getFirstSheetIndex();
                 final int lastSheetIndex = re.getLastSheetIndex();
                 for (int sIx = firstSheetIndex; sIx <= lastSheetIndex; sIx++) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Column.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Column.java
@@ -32,10 +32,10 @@ public final class Column {
         int rnum;
         if (args.length == 0) {
             rnum = srcColumnIndex;
-        } else if (args[0] instanceof AreaEval) {
-            rnum = ((AreaEval) args[0]).getFirstColumn();
-        } else if (args[0] instanceof RefEval) {
-            rnum = ((RefEval) args[0]).getColumn();
+        } else if (args[0] instanceof AreaEval ae) {
+            rnum = ae.getFirstColumn();
+        } else if (args[0] instanceof RefEval re) {
+            rnum = re.getColumn();
         } else {
             // anything else is not valid argument
             return ErrorEval.VALUE_INVALID;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Columns.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Columns.java
@@ -31,8 +31,8 @@ public final class Columns extends Fixed1ArgFunction {
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval arg0) {
 
         int result;
-        if (arg0 instanceof TwoDEval) {
-            result = ((TwoDEval) arg0).getWidth();
+        if (arg0 instanceof TwoDEval twoDEval) {
+            result = twoDEval.getWidth();
         } else if (arg0 instanceof RefEval) {
             result = 1;
         } else { // anything else is not valid argument

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/CountUtils.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/CountUtils.java
@@ -56,8 +56,7 @@ final class CountUtils {
                 for (int rcIx=0; rcIx<width; rcIx++) {
                     ValueEval ve = areaEval.getValue(sIx, rrIx, rcIx);
 
-                    if(criteriaPredicate instanceof I_MatchAreaPredicate){
-                        I_MatchAreaPredicate areaPredicate = (I_MatchAreaPredicate)criteriaPredicate;
+                    if(criteriaPredicate instanceof I_MatchAreaPredicate areaPredicate){
                         if(!areaPredicate.matches(areaEval, rrIx, rcIx)) continue;
                     }
 
@@ -89,14 +88,14 @@ final class CountUtils {
         if (eval == null) {
             throw new IllegalArgumentException("eval must not be null");
         }
-        if (eval instanceof ThreeDEval) {
-            return countMatchingCellsInArea((ThreeDEval) eval, criteriaPredicate);
+        if (eval instanceof ThreeDEval threeDEval) {
+            return countMatchingCellsInArea(threeDEval, criteriaPredicate);
         }
         if (eval instanceof TwoDEval) {
             throw new IllegalArgumentException("Count requires 3D Evals, 2D ones aren't supported");
         }
-        if (eval instanceof RefEval) {
-            return CountUtils.countMatchingCellsInRef((RefEval) eval, criteriaPredicate);
+        if (eval instanceof RefEval refEval) {
+            return CountUtils.countMatchingCellsInRef(refEval, criteriaPredicate);
         }
         return criteriaPredicate.matches(eval) ? 1 : 0;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Countblank.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Countblank.java
@@ -36,10 +36,10 @@ public final class Countblank extends Fixed1ArgFunction {
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval arg0) {
 
         double result;
-        if (arg0 instanceof RefEval) {
-            result = CountUtils.countMatchingCellsInRef((RefEval) arg0, predicate);
-        } else if (arg0 instanceof ThreeDEval) {
-            result = CountUtils.countMatchingCellsInArea((ThreeDEval) arg0, predicate);
+        if (arg0 instanceof RefEval refEval) {
+            result = CountUtils.countMatchingCellsInRef(refEval, predicate);
+        } else if (arg0 instanceof ThreeDEval threeDEval) {
+            result = CountUtils.countMatchingCellsInArea(threeDEval, predicate);
         } else {
             throw new IllegalArgumentException("Bad range arg type (" + arg0.getClass().getName() + ")");
         }
@@ -51,6 +51,6 @@ public final class Countblank extends Fixed1ArgFunction {
         return valueEval == BlankEval.instance ||
                 // see https://support.office.com/en-us/article/COUNTBLANK-function-6a92d772-675c-4bee-b346-24af6bd3ac22
                 // "Cells with formulas that return "" (empty text) are also counted."
-                (valueEval instanceof StringEval && ((StringEval)valueEval).getStringValue().isEmpty());
+                (valueEval instanceof StringEval stringEval && stringEval.getStringValue().isEmpty());
     };
 }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Countif.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Countif.java
@@ -290,16 +290,11 @@ public final class Countif extends Fixed2ArgFunction {
         public StringMatcher(String value, CmpOp operator) {
             super(operator);
             _value = value;
-            switch(operator.getCode()) {
-                case CmpOp.NONE:
-                case CmpOp.EQ:
-                case CmpOp.NE:
-                    _pattern = getWildCardPattern(value);
-                    break;
-                default:
-                    // pattern matching is never used for < > <= =>
-                    _pattern = null;
-            }
+            _pattern = switch (operator.getCode()) {
+                case CmpOp.NONE, CmpOp.EQ, CmpOp.NE -> getWildCardPattern(value);
+                // pattern matching is never used for < > <= =>
+                default -> null;
+            };
         }
         @Override
         protected String getValueText() {
@@ -446,8 +441,8 @@ public final class Countif extends Fixed2ArgFunction {
         if(evaluatedCriteriaArg instanceof StringEval stringEval) {
             return createGeneralMatchPredicate(stringEval);
         }
-        if(evaluatedCriteriaArg instanceof ErrorEval) {
-            return new ErrorMatcher(((ErrorEval)evaluatedCriteriaArg).getErrorCode(), CmpOp.OP_NONE);
+        if(evaluatedCriteriaArg instanceof ErrorEval errorEval) {
+            return new ErrorMatcher(errorEval.getErrorCode(), CmpOp.OP_NONE);
         }
         if(evaluatedCriteriaArg == BlankEval.instance) {
             return null;
@@ -529,18 +524,16 @@ public final class Countif extends Fixed2ArgFunction {
             return null;
         }
         switch(strRep.charAt(0)) {
-            case 't':
-            case 'T':
+            case 't', 'T' -> {
                 if(StringUtil.equalsIgnoreCase("TRUE", strRep)) {
                     return Boolean.TRUE;
                 }
-                break;
-            case 'f':
-            case 'F':
+            }
+            case 'f', 'F' -> {
                 if(StringUtil.equalsIgnoreCase("FALSE", strRep)) {
                     return Boolean.FALSE;
                 }
-                break;
+            }
         }
         return null;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DAverage.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DAverage.java
@@ -34,9 +34,9 @@ public final class DAverage implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if (eval instanceof NumericValueEval) {
+        if (eval instanceof NumericValueEval num) {
             count++;
-            total += ((NumericValueEval)eval).getNumberValue();
+            total += num.getNumberValue();
         }
         return true;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DMax.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DMax.java
@@ -33,11 +33,11 @@ public final class DMax implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if(eval instanceof NumericValueEval) {
+        if(eval instanceof NumericValueEval num) {
             if(maximumValue == null) { // First match, just set the value.
                 maximumValue = eval;
             } else { // There was a previous match, find the new minimum.
-                double currentValue = ((NumericValueEval)eval).getNumberValue();
+                double currentValue = num.getNumberValue();
                 double oldValue = ((NumericValueEval)maximumValue).getNumberValue();
                 if(currentValue > oldValue) {
                     maximumValue = eval;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DMin.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DMin.java
@@ -33,11 +33,11 @@ public final class DMin implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if(eval instanceof NumericValueEval) {
+        if(eval instanceof NumericValueEval num) {
             if(minimumValue == null) { // First match, just set the value.
                 minimumValue = eval;
             } else { // There was a previous match, find the new minimum.
-                double currentValue = ((NumericValueEval)eval).getNumberValue();
+                double currentValue = num.getNumberValue();
                 double oldValue = ((NumericValueEval)minimumValue).getNumberValue();
                 if(currentValue < oldValue) {
                     minimumValue = eval;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DProduct.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DProduct.java
@@ -31,11 +31,11 @@ public final class DProduct implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if (eval instanceof NumericValueEval) {
+        if (eval instanceof NumericValueEval num) {
             if (initDone) {
-                product *= ((NumericValueEval) eval).getNumberValue();
+                product *= num.getNumberValue();
             } else {
-                product = ((NumericValueEval) eval).getNumberValue();
+                product = num.getNumberValue();
                 initDone = true;
             }
         }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DStarRunner.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DStarRunner.java
@@ -110,11 +110,9 @@ public final class DStarRunner implements Function3Arg {
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex,
             ValueEval database, ValueEval filterColumn, ValueEval conditionDatabase) {
         // Input processing and error checks.
-        if(!(database instanceof AreaEval) || !(conditionDatabase instanceof AreaEval)) {
+        if(!(database instanceof AreaEval db) || !(conditionDatabase instanceof AreaEval cdb)) {
             return ErrorEval.VALUE_INVALID;
         }
-        AreaEval db = (AreaEval)database;
-        AreaEval cdb = (AreaEval)conditionDatabase;
 
         // Create an algorithm runner.
         final IDStarAlgorithm algorithm = algoType.newInstance();
@@ -306,8 +304,8 @@ public final class DStarRunner implements Function3Arg {
      */
     private static boolean testNormalCondition(ValueEval value, ValueEval condition)
             throws EvaluationException {
-        if(condition instanceof StringEval) {
-            String conditionString = ((StringEval)condition).getStringValue();
+        if(condition instanceof StringEval se) {
+            String conditionString = se.getStringValue();
 
             if(conditionString.startsWith("<")) { // It's a </<=/<> condition.
                 String number = conditionString.substring(1);
@@ -361,13 +359,13 @@ public final class DStarRunner implements Function3Arg {
                     }
                 }
             }
-        } else if(condition instanceof NumericValueEval) {
-            double conditionNumber = ((NumericValueEval) condition).getNumberValue();
+        } else if(condition instanceof NumericValueEval num) {
+            double conditionNumber = num.getNumberValue();
             Double valueNumber = getNumberFromValueEval(value);
             return valueNumber != null && conditionNumber == valueNumber;
-        } else if(condition instanceof ErrorEval) {
-            if(value instanceof ErrorEval) {
-                return ((ErrorEval)condition).getErrorCode() == ((ErrorEval)value).getErrorCode();
+        } else if(condition instanceof ErrorEval conditionError) {
+            if(value instanceof ErrorEval valueError) {
+                return conditionError.getErrorCode() == valueError.getErrorCode();
             } else {
                 return false;
             }
@@ -388,9 +386,9 @@ public final class DStarRunner implements Function3Arg {
             ValueEval valueEval, operator op, String condition)
             throws EvaluationException {
         // Construct double from ValueEval.
-        if(!(valueEval instanceof NumericValueEval))
+        if(!(valueEval instanceof NumericValueEval num))
             return false;
-        double value = ((NumericValueEval)valueEval).getNumberValue();
+        double value = num.getNumberValue();
 
         // Construct double from condition.
         double conditionValue;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DStdev.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DStdev.java
@@ -34,8 +34,8 @@ public final class DStdev implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if (eval instanceof NumericValueEval) {
-            values.add((NumericValueEval) eval);
+        if (eval instanceof NumericValueEval num) {
+            values.add(num);
         }
         return true;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DStdevp.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DStdevp.java
@@ -34,8 +34,8 @@ public final class DStdevp implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if (eval instanceof NumericValueEval) {
-            values.add((NumericValueEval) eval);
+        if (eval instanceof NumericValueEval num) {
+            values.add(num);
         }
         return true;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DSum.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DSum.java
@@ -33,8 +33,8 @@ public final class DSum implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if(eval instanceof NumericValueEval) {
-            double currentValue = ((NumericValueEval)eval).getNumberValue();
+        if(eval instanceof NumericValueEval num) {
+            double currentValue = num.getNumberValue();
             totalValue += currentValue;
         }
 

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DVar.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DVar.java
@@ -34,8 +34,8 @@ public final class DVar implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if (eval instanceof NumericValueEval) {
-            values.add((NumericValueEval) eval);
+        if (eval instanceof NumericValueEval num) {
+            values.add(num);
         }
         return true;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DVarp.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DVarp.java
@@ -34,8 +34,8 @@ public final class DVarp implements IDStarAlgorithm {
 
     @Override
     public boolean processMatch(ValueEval eval) {
-        if (eval instanceof NumericValueEval) {
-            values.add((NumericValueEval) eval);
+        if (eval instanceof NumericValueEval num) {
+            values.add(num);
         }
         return true;
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/EDate.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/EDate.java
@@ -59,22 +59,21 @@ public class EDate implements FreeRefFunction {
     }
 
     private double getValue(ValueEval arg) throws EvaluationException {
-        if (arg instanceof NumberEval) {
-            return ((NumberEval) arg).getNumberValue();
+        if (arg instanceof NumberEval ne) {
+            return ne.getNumberValue();
         }
         if(arg instanceof BlankEval) {
             return 0;
         }
-        if (arg instanceof RefEval) {
-            RefEval refEval = (RefEval)arg;
+        if (arg instanceof RefEval refEval) {
             if (refEval.getNumberOfSheets() > 1) {
                 // Multi-Sheet references are not supported
                 throw new EvaluationException(ErrorEval.VALUE_INVALID);
             }
             
             ValueEval innerValueEval = refEval.getInnerValueEval(refEval.getFirstSheetIndex());
-            if(innerValueEval instanceof NumberEval) {
-                return ((NumberEval) innerValueEval).getNumberValue();
+            if(innerValueEval instanceof NumberEval innerNumber) {
+                return innerNumber.getNumberValue();
             }
             if(innerValueEval instanceof BlankEval) {
                 return 0;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Hex2Dec.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Hex2Dec.java
@@ -43,8 +43,7 @@ public class Hex2Dec extends Fixed1ArgFunction implements FreeRefFunction {
     @Override
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval numberVE) {
         final String hex;
-        if (numberVE instanceof RefEval) {
-            RefEval re = (RefEval) numberVE;
+        if (numberVE instanceof RefEval re) {
             hex = OperandResolver.coerceValueToString(re.getInnerValueEval(re.getFirstSheetIndex()));
         } else {
             hex = OperandResolver.coerceValueToString(numberVE);

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/IfFunc.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/IfFunc.java
@@ -99,14 +99,12 @@ public final class IfFunc extends Var2or3ArgFunction implements ArrayFunction {
     ValueEval evaluateArrayArgs(ValueEval arg0, ValueEval arg1, ValueEval arg2, int srcRowIndex, int srcColumnIndex) {
         int w1, w2, h1, h2;
         int a1FirstCol = 0, a1FirstRow = 0;
-        if (arg0 instanceof AreaEval) {
-            AreaEval ae = (AreaEval)arg0;
+        if (arg0 instanceof AreaEval ae) {
             w1 = ae.getWidth();
             h1 = ae.getHeight();
             a1FirstCol = ae.getFirstColumn();
             a1FirstRow = ae.getFirstRow();
-        } else if (arg0 instanceof RefEval){
-            RefEval ref = (RefEval)arg0;
+        } else if (arg0 instanceof RefEval ref){
             w1 = 1;
             h1 = 1;
             a1FirstCol = ref.getColumn();
@@ -116,14 +114,12 @@ public final class IfFunc extends Var2or3ArgFunction implements ArrayFunction {
             h1 = 1;
         }
         int a2FirstCol = 0, a2FirstRow = 0;
-        if (arg1 instanceof AreaEval) {
-            AreaEval ae = (AreaEval)arg1;
+        if (arg1 instanceof AreaEval ae) {
             w2 = ae.getWidth();
             h2 = ae.getHeight();
             a2FirstCol = ae.getFirstColumn();
             a2FirstRow = ae.getFirstRow();
-        } else if (arg1 instanceof RefEval){
-            RefEval ref = (RefEval)arg1;
+        } else if (arg1 instanceof RefEval ref){
             w2 = 1;
             h2 = 1;
             a2FirstCol = ref.getColumn();
@@ -134,12 +130,10 @@ public final class IfFunc extends Var2or3ArgFunction implements ArrayFunction {
         }
 
         int a3FirstCol = 0, a3FirstRow = 0;
-        if (arg2 instanceof AreaEval) {
-            AreaEval ae = (AreaEval)arg2;
+        if (arg2 instanceof AreaEval ae) {
             a3FirstCol = ae.getFirstColumn();
             a3FirstRow = ae.getFirstRow();
-        } else if (arg2 instanceof RefEval){
-            RefEval ref = (RefEval)arg2;
+        } else if (arg2 instanceof RefEval ref){
             a3FirstCol = ref.getColumn();
             a3FirstRow = ref.getRow();
         }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Index.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Index.java
@@ -94,12 +94,12 @@ public final class Index implements Function2Arg, Function3Arg, Function4Arg, Ar
     }
 
     private static TwoDEval convertFirstArg(ValueEval arg0) {
-        if (arg0 instanceof RefEval) {
+        if (arg0 instanceof RefEval refEval) {
             // convert to area ref for simpler code in getValueFromArea()
-            return ((RefEval) arg0).offset(0, 0, 0, 0);
+            return refEval.offset(0, 0, 0, 0);
         }
-        if((arg0 instanceof TwoDEval)) {
-            return (TwoDEval) arg0;
+        if((arg0 instanceof TwoDEval twoDEval)) {
+            return twoDEval;
         }
         // else the other variation of this function takes an array as the first argument
         // it seems like interface 'ArrayEval' does not even exist yet
@@ -110,15 +110,12 @@ public final class Index implements Function2Arg, Function3Arg, Function4Arg, Ar
 
     @Override
     public ValueEval evaluate(ValueEval[] args, int srcRowIndex, int srcColumnIndex) {
-        switch (args.length) {
-            case 2:
-                return evaluate(srcRowIndex, srcColumnIndex, args[0], args[1]);
-            case 3:
-                return evaluate(srcRowIndex, srcColumnIndex, args[0], args[1], args[2]);
-            case 4:
-                return evaluate(srcRowIndex, srcColumnIndex, args[0], args[1], args[2], args[3]);
-        }
-        return ErrorEval.VALUE_INVALID;
+        return switch (args.length) {
+            case 2 -> evaluate(srcRowIndex, srcColumnIndex, args[0], args[1]);
+            case 3 -> evaluate(srcRowIndex, srcColumnIndex, args[0], args[1], args[2]);
+            case 4 -> evaluate(srcRowIndex, srcColumnIndex, args[0], args[1], args[2], args[3]);
+            default -> ErrorEval.VALUE_INVALID;
+        };
     }
 
     private static ValueEval getValueFromArea(TwoDEval ae, int pRowIx, int pColumnIx)

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/LinearRegressionFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/LinearRegressionFunction.java
@@ -143,21 +143,19 @@ public final class LinearRegressionFunction extends Fixed2ArgFunction {
         for (int i = 0; i < size; i++) {
             ValueEval vx = x.getItem(i);
             ValueEval vy = y.getItem(i);
-            if (vx instanceof ErrorEval) {
-                throw new EvaluationException((ErrorEval) vx);
+            if (vx instanceof ErrorEval err) {
+                throw new EvaluationException(err);
             }
-            if (vy instanceof ErrorEval) {
+            if (vy instanceof ErrorEval err) {
                 if (firstYerr == null) {
-                    firstYerr = (ErrorEval) vy;
+                    firstYerr = err;
                     continue;
                 }
             }
             // only count pairs if both elements are numbers
             // all other combinations of value types are silently ignored
-            if (vx instanceof NumberEval && vy instanceof NumberEval) {
+            if (vx instanceof NumberEval nx && vy instanceof NumberEval ny) {
                 accumlatedSome = true;
-                NumberEval nx = (NumberEval) vx;
-                NumberEval ny = (NumberEval) vy;
                 sumx  += nx.getNumberValue();
                 sumy  += ny.getNumberValue();
             }
@@ -182,9 +180,7 @@ public final class LinearRegressionFunction extends Fixed2ArgFunction {
 
             // only count pairs if both elements are numbers
             // all other combinations of value types are silently ignored
-            if (vx instanceof NumberEval && vy instanceof NumberEval) {
-                NumberEval nx = (NumberEval) vx;
-                NumberEval ny = (NumberEval) vy;
+            if (vx instanceof NumberEval nx && vy instanceof NumberEval ny) {
                 xxbar += (nx.getNumberValue() - xbar) * (nx.getNumberValue() - xbar);
                 xybar += (nx.getNumberValue() - xbar) * (ny.getNumberValue() - ybar);
             }
@@ -201,14 +197,14 @@ public final class LinearRegressionFunction extends Fixed2ArgFunction {
     }
 
     private static ValueVector createValueVector(ValueEval arg) throws EvaluationException {
-        if (arg instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) arg);
+        if (arg instanceof ErrorEval errorEval) {
+            throw new EvaluationException(errorEval);
         }
-        if (arg instanceof TwoDEval) {
-            return new AreaValueArray((TwoDEval) arg);
+        if (arg instanceof TwoDEval twoDEval) {
+            return new AreaValueArray(twoDEval);
         }
-        if (arg instanceof RefEval) {
-            return new RefValueArray((RefEval) arg);
+        if (arg instanceof RefEval refEval) {
+            return new RefValueArray(refEval);
         }
         return new SingleCellValueArray(arg);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/LookupUtils.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/LookupUtils.java
@@ -631,20 +631,15 @@ public final class LookupUtils {
 
     public static int xlookupIndexOfValue(ValueEval lookupValue, ValueVector vector, MatchMode matchMode, SearchMode searchMode) throws EvaluationException {
         ValueEval modifiedLookup = lookupValue;
-        if (lookupValue instanceof StringEval &&
+        if (lookupValue instanceof StringEval se &&
                 (matchMode == MatchMode.ExactMatchFallbackToLargerValue || matchMode == MatchMode.ExactMatchFallbackToSmallerValue)) {
-            String lookupText = ((StringEval)lookupValue).getStringValue();
+            String lookupText = se.getStringValue();
             StringBuilder sb = new StringBuilder(lookupText.length());
             boolean containsWildcard = false;
             for (char c : lookupText.toCharArray()) {
                 switch (c) {
-                    case '~':
-                    case '?':
-                    case '*':
-                        containsWildcard = true;
-                        break;
-                    default:
-                        sb.append(c);
+                    case '~', '?', '*' -> containsWildcard = true;
+                    default -> sb.append(c);
                 }
                 if (containsWildcard)
                     break;
@@ -709,7 +704,7 @@ public final class LookupUtils {
                 return i;
             }
             switch (matchMode) {
-                case ExactMatchFallbackToLargerValue:
+                case ExactMatchFallbackToLargerValue -> {
                     if (result.isLessThan()) {
                         if (bestMatchEval == null) {
                             bestMatchIdx = i;
@@ -722,8 +717,8 @@ public final class LookupUtils {
                             }
                         }
                     }
-                    break;
-                case ExactMatchFallbackToSmallerValue:
+                }
+                case ExactMatchFallbackToSmallerValue -> {
                     if (result.isGreaterThan()) {
                         if (bestMatchEval == null) {
                             bestMatchIdx = i;
@@ -736,7 +731,7 @@ public final class LookupUtils {
                             }
                         }
                     }
-                    break;
+                }
             }
         }
         return bestMatchIdx;
@@ -760,7 +755,7 @@ public final class LookupUtils {
                 return i;
             }
             switch (matchMode) {
-                case ExactMatchFallbackToLargerValue:
+                case ExactMatchFallbackToLargerValue -> {
                     if (result.isLessThan()) {
                         if (bestMatchEval == null) {
                             bestMatchIdx = i;
@@ -773,8 +768,8 @@ public final class LookupUtils {
                             }
                         }
                     }
-                    break;
-                case ExactMatchFallbackToSmallerValue:
+                }
+                case ExactMatchFallbackToSmallerValue -> {
                     if (result.isGreaterThan()) {
                         if (bestMatchEval == null) {
                             bestMatchIdx = i;
@@ -787,7 +782,7 @@ public final class LookupUtils {
                             }
                         }
                     }
-                    break;
+                }
             }
             if (result.isTypeMismatch()) {
                 int newIdx = handleMidValueTypeMismatch(lookupComparer, vector, bsi, i, reverse);
@@ -945,15 +940,15 @@ public final class LookupUtils {
             // empty string in the lookup column/row can only be matched by explicit empty string
             return new NumberLookupComparer(NumberEval.ZERO);
         }
-        if (lookupValue instanceof StringEval) {
+        if (lookupValue instanceof StringEval stringEval) {
             //TODO eventually here return a WildcardStringLookupComparer
-            return new StringLookupComparer((StringEval) lookupValue, matchExact, isMatchFunction);
+            return new StringLookupComparer(stringEval, matchExact, isMatchFunction);
         }
-        if (lookupValue instanceof NumberEval) {
-            return new NumberLookupComparer((NumberEval) lookupValue);
+        if (lookupValue instanceof NumberEval numberEval) {
+            return new NumberLookupComparer(numberEval);
         }
-        if (lookupValue instanceof BoolEval) {
-            return new BooleanLookupComparer((BoolEval) lookupValue);
+        if (lookupValue instanceof BoolEval boolEval) {
+            return new BooleanLookupComparer(boolEval);
         }
         throw new IllegalArgumentException("Bad lookup value type (" + lookupValue.getClass().getName() + ")");
     }
@@ -962,11 +957,11 @@ public final class LookupUtils {
         if (lookupValue == BlankEval.instance) {
             return new TolerantStringLookupComparer(new StringEval(""), matchExact, isMatchFunction);
         }
-        if (lookupValue instanceof BoolEval) {
-            return new BooleanLookupComparer((BoolEval) lookupValue);
+        if (lookupValue instanceof BoolEval boolEval) {
+            return new BooleanLookupComparer(boolEval);
         }
-        if (matchExact && lookupValue instanceof NumberEval) {
-            return new NumberLookupComparer((NumberEval) lookupValue);
+        if (matchExact && lookupValue instanceof NumberEval numberEval) {
+            return new NumberLookupComparer(numberEval);
         }
         return new TolerantStringLookupComparer(lookupValue, matchExact, isMatchFunction);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Match.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Match.java
@@ -130,16 +130,15 @@ public final class Match extends Var2or3ArgFunction {
     }
 
     private static ValueVector evaluateLookupRange(ValueEval eval) throws EvaluationException {
-        if (eval instanceof RefEval) {
-            RefEval re = (RefEval) eval;
+        if (eval instanceof RefEval re) {
             if (re.getNumberOfSheets() == 1) {
                 return new SingleValueVector(re.getInnerValueEval(re.getFirstSheetIndex()));
             } else {
                 return LookupUtils.createVector(re);
             }
         }
-        if (eval instanceof TwoDEval) {
-            ValueVector result = LookupUtils.createVector((TwoDEval)eval);
+        if (eval instanceof TwoDEval td) {
+            ValueVector result = LookupUtils.createVector(td);
             if (result == null) {
                 throw new EvaluationException(ErrorEval.NA);
             }
@@ -150,8 +149,7 @@ public final class Match extends Var2or3ArgFunction {
         if(eval instanceof NumericValueEval) {
             throw new EvaluationException(ErrorEval.NA);
         }
-        if (eval instanceof StringEval) {
-            StringEval se = (StringEval) eval;
+        if (eval instanceof StringEval se) {
             Double d = OperandResolver.parseDouble(se.getStringValue());
             if(d == null) {
                 // plain string
@@ -169,15 +167,13 @@ public final class Match extends Var2or3ArgFunction {
             throws EvaluationException {
         ValueEval match_type = OperandResolver.getSingleValue(arg, srcCellRow, srcCellCol);
 
-        if(match_type instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval)match_type);
+        if(match_type instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
-        if(match_type instanceof NumericValueEval) {
-            NumericValueEval ne = (NumericValueEval) match_type;
+        if(match_type instanceof NumericValueEval ne) {
             return ne.getNumberValue();
         }
-        if (match_type instanceof StringEval) {
-            StringEval se = (StringEval) match_type;
+        if (match_type instanceof StringEval se) {
             Double d = OperandResolver.parseDouble(se.getStringValue());
             if(d == null) {
                 // plain string

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/MatrixFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/MatrixFunction.java
@@ -92,14 +92,14 @@ public abstract class MatrixFunction implements Function{
 
         @Override
         public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval arg0) {
-            if (arg0 instanceof AreaEval) {
+            if (arg0 instanceof AreaEval ae) {
                 double[] result;
                 double[][] resultArray;
                 int width, height;
 
                 try {
                     double[] values = collectValues(arg0);
-                    double[][] array = fillDoubleArray(values, ((AreaEval) arg0).getHeight(), ((AreaEval) arg0).getWidth());
+                    double[][] array = fillDoubleArray(values, ae.getHeight(), ae.getWidth());
                     resultArray = evaluate(array);
                     width = resultArray[0].length;
                     height = resultArray.length;
@@ -122,9 +122,9 @@ public abstract class MatrixFunction implements Function{
                 }
                 else {
                     /* find a better solution */
-                    return new CacheAreaEval(((AreaEval) arg0).getFirstRow(), ((AreaEval) arg0).getFirstColumn(),
-                                            ((AreaEval) arg0).getFirstRow() + height - 1,
-                                            ((AreaEval) arg0).getFirstColumn() + width - 1, vals);
+                    return new CacheAreaEval(ae.getFirstRow(), ae.getFirstColumn(),
+                                            ae.getFirstRow() + height - 1,
+                                            ae.getFirstColumn() + width - 1, vals);
                 }
             }
             else {
@@ -162,10 +162,10 @@ public abstract class MatrixFunction implements Function{
                 double[][] array1;
                 double[][] resultArray;
 
-                if (arg0 instanceof AreaEval) {
+                if (arg0 instanceof AreaEval ae) {
                     try {
                         double[] values = collectValues(arg0);
-                        array0 = fillDoubleArray(values, ((AreaEval) arg0).getHeight(), ((AreaEval) arg0).getWidth());
+                        array0 = fillDoubleArray(values, ae.getHeight(), ae.getWidth());
                     }
                     catch(EvaluationException e) {
                         return e.getErrorEval();
@@ -181,10 +181,10 @@ public abstract class MatrixFunction implements Function{
                     }
                 }
 
-                if (arg1 instanceof AreaEval) {
+                if (arg1 instanceof AreaEval ae) {
                    try {
                        double[] values = collectValues(arg1);
-                      array1 = fillDoubleArray(values, ((AreaEval) arg1).getHeight(),((AreaEval) arg1).getWidth());
+                      array1 = fillDoubleArray(values, ae.getHeight(), ae.getWidth());
                    }
                    catch (EvaluationException e) {
                       return e.getErrorEval();

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Maxifs.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Maxifs.java
@@ -63,7 +63,7 @@ public final class Maxifs extends Baseifs {
 
             @Override
             public void addValue(ValueEval value) {
-                double d = (value instanceof NumberEval) ? ((NumberEval) value).getNumberValue() : 0.0;
+                double d = (value instanceof NumberEval ne) ? ne.getNumberValue() : 0.0;
                 if(accumulator == null || accumulator < d) {
                     accumulator = d;
                 }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Minifs.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Minifs.java
@@ -63,7 +63,7 @@ public final class Minifs extends Baseifs {
 
             @Override
             public void addValue(ValueEval value) {
-                double d = (value instanceof NumberEval) ? ((NumberEval) value).getNumberValue() : 0.0;
+                double d = (value instanceof NumberEval ne) ? ne.getNumberValue() : 0.0;
                 if(accumulator == null || accumulator > d) {
                     accumulator = d;
                 }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Mode.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Mode.java
@@ -88,8 +88,7 @@ public final class Mode implements Function {
     }
 
     private static void collectValues(ValueEval arg, List<Double> temp) throws EvaluationException {
-        if (arg instanceof TwoDEval) {
-            TwoDEval ae = (TwoDEval) arg;
+        if (arg instanceof TwoDEval ae) {
             int width = ae.getWidth();
             int height = ae.getHeight();
             for (int rrIx = 0; rrIx < height; rrIx++) {
@@ -100,8 +99,7 @@ public final class Mode implements Function {
             }
             return;
         }
-        if (arg instanceof RefEval) {
-            RefEval re = (RefEval) arg;
+        if (arg instanceof RefEval re) {
             final int firstSheetIndex = re.getFirstSheetIndex();
             final int lastSheetIndex = re.getLastSheetIndex();
             for (int sIx = firstSheetIndex; sIx <= lastSheetIndex; sIx++) {
@@ -115,8 +113,8 @@ public final class Mode implements Function {
 
     private static void collectValue(ValueEval arg, List<Double> temp, boolean mustBeNumber)
             throws EvaluationException {
-        if (arg instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) arg);
+        if (arg instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         if (arg == BlankEval.instance || arg instanceof BoolEval || arg instanceof StringEval) {
             if (mustBeNumber) {
@@ -124,8 +122,8 @@ public final class Mode implements Function {
             }
             return;
         }
-        if (arg instanceof NumberEval) {
-            temp.add(Double.valueOf(((NumberEval) arg).getNumberValue()));
+        if (arg instanceof NumberEval ne) {
+            temp.add(Double.valueOf(ne.getNumberValue()));
             return;
         }
         throw new IllegalStateException("Unexpected value type (" + arg.getClass().getName() + ")");

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/MultiOperandNumericFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/MultiOperandNumericFunction.java
@@ -139,8 +139,7 @@ public abstract class MultiOperandNumericFunction implements Function {
      * Collects values from a single argument
      */
     private void collectValues(ValueEval operand, DoubleList temp) throws EvaluationException {
-        if (operand instanceof ThreeDEval) {
-            ThreeDEval ae = (ThreeDEval) operand;
+        if (operand instanceof ThreeDEval ae) {
             for (int sIx = ae.getFirstSheetIndex(); sIx <= ae.getLastSheetIndex(); sIx++) {
                 int width = ae.getWidth();
                 int height = ae.getHeight();
@@ -155,8 +154,7 @@ public abstract class MultiOperandNumericFunction implements Function {
             }
             return;
         }
-        if (operand instanceof TwoDEval) {
-            TwoDEval ae = (TwoDEval) operand;
+        if (operand instanceof TwoDEval ae) {
             int width = ae.getWidth();
             int height = ae.getHeight();
             for (int rrIx = 0; rrIx < height; rrIx++) {
@@ -168,8 +166,7 @@ public abstract class MultiOperandNumericFunction implements Function {
             }
             return;
         }
-        if (operand instanceof RefEval) {
-            RefEval re = (RefEval) operand;
+        if (operand instanceof RefEval re) {
             for (int sIx = re.getFirstSheetIndex(); sIx <= re.getLastSheetIndex(); sIx++) {
                 collectValue(re.getInnerValueEval(sIx), !treatStringsAsZero(), temp);
             }
@@ -182,8 +179,7 @@ public abstract class MultiOperandNumericFunction implements Function {
         if (ve == null) {
             throw new IllegalArgumentException("ve must not be null");
         }
-        if (ve instanceof BoolEval) {
-            BoolEval boolEval = (BoolEval) ve;
+        if (ve instanceof BoolEval boolEval) {
             if (isViaReference) {
                 boolByRefConsumer.accept(boolEval, temp);
             } else {
@@ -191,12 +187,11 @@ public abstract class MultiOperandNumericFunction implements Function {
             }
             return;
         }
-        if (ve instanceof NumericValueEval) {
-            NumericValueEval ne = (NumericValueEval) ve;
+        if (ve instanceof NumericValueEval ne) {
             temp.add(ne.getNumberValue());
             return;
         }
-        if (ve instanceof StringValueEval) {
+        if (ve instanceof StringValueEval sve) {
             if (isViaReference) {
                 // ignore all ref strings
                 return;
@@ -204,7 +199,7 @@ public abstract class MultiOperandNumericFunction implements Function {
             if (treatStringsAsZero()) {
                 temp.add(0.0);
             } else {
-                String s = ((StringValueEval) ve).getStringValue().trim();
+                String s = sve.getStringValue().trim();
                 Double d = OperandResolver.parseDouble(s);
                 if (d == null) {
                     throw new EvaluationException(ErrorEval.VALUE_INVALID);
@@ -214,8 +209,8 @@ public abstract class MultiOperandNumericFunction implements Function {
             }
             return;
         }
-        if (ve instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) ve);
+        if (ve instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         if (ve == BlankEval.instance) {
             blankConsumer.accept((BlankEval) ve, temp);
@@ -248,16 +243,12 @@ public abstract class MultiOperandNumericFunction implements Function {
         }
 
         private static <T> EvalConsumer<T, DoubleList> createAny(EvalConsumer<T, DoubleList> coercer, Policy policy) {
-            switch (policy) {
-                case COERCE:
-                    return coercer;
-                case SKIP:
-                    return doNothing();
-                case ERROR:
-                    return throwValueInvalid();
-                default:
-                    throw new AssertionError();
-            }
+            return switch (policy) {
+                case COERCE -> coercer;
+                case SKIP -> doNothing();
+                case ERROR -> throwValueInvalid();
+                default -> throw new AssertionError();
+            };
         }
 
         private static <T> EvalConsumer<T, DoubleList> doNothing() {

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/NumericFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/NumericFunction.java
@@ -258,8 +258,8 @@ public abstract class NumericFunction implements Function {
                 double d1 = singleOperandEvaluate(args[0], srcCellRow, srcCellCol);
                 double d2 = singleOperandEvaluate(args[1], srcCellRow, srcCellCol);
                 Object res = doubleFun.apply(d1, d2);
-                if (res instanceof ErrorEval) {
-                    return (ErrorEval)res;
+                if (res instanceof ErrorEval ee) {
+                    return ee;
                 }
                 if (!(res instanceof Double d)) {
                     throw new AssertionError("Expected Double");

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Offset.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Offset.java
@@ -207,14 +207,14 @@ public final class Offset implements Function {
 
     private static BaseRef evaluateBaseRef(ValueEval eval) throws EvaluationException {
 
-        if(eval instanceof RefEval) {
-            return new BaseRef((RefEval)eval);
+        if(eval instanceof RefEval re) {
+            return new BaseRef(re);
         }
-        if(eval instanceof AreaEval) {
-            return new BaseRef((AreaEval)eval);
+        if(eval instanceof AreaEval ae) {
+            return new BaseRef(ae);
         }
-        if (eval instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) eval);
+        if (eval instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         throw new EvaluationException(ErrorEval.VALUE_INVALID);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/PercentRank.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/PercentRank.java
@@ -132,14 +132,14 @@ public final class PercentRank implements Function {
         } else {
             int intermediateSignificance = significance < 5 ? 8 : significance + 3;
             ValueEval belowRank = calculateRank(numbers, closestMatchBelow, intermediateSignificance, false);
-            if (!(belowRank instanceof NumberEval)) {
+            if (!(belowRank instanceof NumberEval belowNum)) {
                 return belowRank;
             }
             ValueEval aboveRank = calculateRank(numbers, closestMatchAbove, intermediateSignificance, false);
-            if (!(aboveRank instanceof NumberEval)) {
+            if (!(aboveRank instanceof NumberEval aboveNum)) {
                 return aboveRank;
             }
-            return interpolate(x, closestMatchBelow, closestMatchAbove, (NumberEval)belowRank, (NumberEval)aboveRank, significance);
+            return interpolate(x, closestMatchBelow, closestMatchAbove, belowNum, aboveNum, significance);
         }
     }
 
@@ -163,8 +163,7 @@ public final class PercentRank implements Function {
 
     @Internal
     public static List<ValueEval> getValues(ValueEval eval, int srcRowIndex, int srcColumnIndex) throws EvaluationException {
-        if (eval instanceof AreaEval) {
-            AreaEval ae = (AreaEval)eval;
+        if (eval instanceof AreaEval ae) {
             List<ValueEval> list = new ArrayList<>();
             for (int r = ae.getFirstRow(); r <= ae.getLastRow(); r++) {
                 for (int c = ae.getFirstColumn(); c <= ae.getLastColumn(); c++) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Rank.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Rank.java
@@ -52,8 +52,8 @@ public class Rank extends Var2or3ArgFunction {
                 throw new EvaluationException(ErrorEval.NUM_ERROR);
             }
 
-            if (arg1 instanceof RefListEval) {
-                return eval(result, ((RefListEval)arg1), true);
+            if (arg1 instanceof RefListEval rle) {
+                return eval(result, rle, true);
             }
 
             final AreaEval aeRange = convertRangeArg(arg1);
@@ -84,8 +84,8 @@ public class Rank extends Var2or3ArgFunction {
                 throw new EvaluationException(ErrorEval.NUM_ERROR);
             }
 
-            if (arg1 instanceof RefListEval) {
-                return eval(result, ((RefListEval)arg1), order);
+            if (arg1 instanceof RefListEval rle) {
+                return eval(result, rle, order);
             }
 
             final AreaEval aeRange = convertRangeArg(arg1);
@@ -117,13 +117,13 @@ public class Rank extends Var2or3ArgFunction {
     private static ValueEval eval(double arg0, RefListEval aeRange, boolean descending_order) {
         int rank = 1;
         for(ValueEval ve : aeRange.getList()) {
-            if (ve instanceof RefEval) {
-                ve = ((RefEval) ve).getInnerValueEval(((RefEval) ve).getFirstSheetIndex());
+            if (ve instanceof RefEval re) {
+                ve = re.getInnerValueEval(re.getFirstSheetIndex());
             }
 
             final double value;
-            if (ve instanceof NumberEval) {
-                value = ((NumberEval)ve).getNumberValue();
+            if (ve instanceof NumberEval ne) {
+                value = ne.getNumberValue();
             } else {
                 continue;
             }
@@ -138,19 +138,19 @@ public class Rank extends Var2or3ArgFunction {
 
     private static Double getValue(AreaEval aeRange, int relRowIndex, int relColIndex) {
         ValueEval addend = aeRange.getRelativeValue(relRowIndex, relColIndex);
-        if (addend instanceof NumberEval) {
-            return ((NumberEval)addend).getNumberValue();
+        if (addend instanceof NumberEval ne) {
+            return ne.getNumberValue();
         }
         // everything else (including string and boolean values) counts as zero
         return null;
     }
 
     private static AreaEval convertRangeArg(ValueEval eval) throws EvaluationException {
-        if (eval instanceof AreaEval) {
-            return (AreaEval) eval;
+        if (eval instanceof AreaEval ae) {
+            return ae;
         }
-        if (eval instanceof RefEval) {
-            return ((RefEval)eval).offset(0, 0, 0, 0);
+        if (eval instanceof RefEval re) {
+            return re.offset(0, 0, 0, 0);
         }
         throw new EvaluationException(ErrorEval.VALUE_INVALID);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/RowFunc.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/RowFunc.java
@@ -35,10 +35,10 @@ public final class RowFunc {
         int rnum;
         if (args.length == 0) {
             rnum = srcRowIndex;
-        } else if (args[0] instanceof AreaEval) {
-            rnum = ((AreaEval) args[0]).getFirstRow();
-        } else if (args[0] instanceof RefEval) {
-            rnum = ((RefEval) args[0]).getRow();
+        } else if (args[0] instanceof AreaEval ae) {
+            rnum = ae.getFirstRow();
+        } else if (args[0] instanceof RefEval re) {
+            rnum = re.getRow();
         } else {
             // anything else is not valid argument
             return ErrorEval.VALUE_INVALID;

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Rows.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Rows.java
@@ -31,8 +31,8 @@ public final class Rows extends Fixed1ArgFunction {
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval arg0) {
 
         int result;
-        if (arg0 instanceof TwoDEval) {
-            result = ((TwoDEval) arg0).getHeight();
+        if (arg0 instanceof TwoDEval td) {
+            result = td.getHeight();
         } else if (arg0 instanceof RefEval) {
             result = 1;
         } else { // anything else is not valid argument

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Sheet.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Sheet.java
@@ -55,19 +55,17 @@ public class Sheet implements FreeRefFunction {
             } else {
                 ValueEval arg = args[0];
 
-                if (arg instanceof RefEval) {
+                if (arg instanceof RefEval ref) {
                     // Argument is a single cell reference → return the sheet index of that reference +1
-                    RefEval ref = (RefEval) arg;
                     int sheetIndex = ref.getFirstSheetIndex();
                     return new NumberEval((double) sheetIndex + 1);
-                } else if (arg instanceof AreaEval) {
+                } else if (arg instanceof AreaEval area) {
                     // Argument is a cell range → return the sheet index of that area +1
-                    AreaEval area = (AreaEval) arg;
                     int sheetIndex = area.getFirstSheetIndex();
                     return new NumberEval((double) sheetIndex + 1);
-                } else if (arg instanceof StringEval) {
+                } else if (arg instanceof StringEval se) {
                     // Argument is a string (sheet name, e.g., "Sheet3") → look up the sheet index by name
-                    String sheetName = ((StringEval) arg).getStringValue();
+                    String sheetName = se.getStringValue();
                     EvaluationWorkbook wb = ec.getWorkbook();
                     int sheetIndex = wb.getSheetIndex(sheetName);
                     if (sheetIndex >= 0) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Single.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Single.java
@@ -40,9 +40,7 @@ public final class Single implements FreeRefFunction {
         int row = ec.getRowIndex();
 
         for (ValueEval val : args) {
-            if (val instanceof AreaEvalBase) {
-                AreaEvalBase area = (AreaEvalBase)val;
-
+            if (val instanceof AreaEvalBase area) {
                 if (area.contains(row, col)) {
                     if (intersect != null) return ErrorEval.VALUE_INVALID; 
                     intersect = area.getAbsoluteValue(row, col);

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Subtotal.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Subtotal.java
@@ -127,8 +127,7 @@ public class Subtotal implements Function {
         // For array references it is handled in other evaluation steps, but we need to handle this here for references to subtotal-functions
         while(it.hasNext()) {
             ValueEval eval = it.next();
-            if(eval instanceof LazyRefEval) {
-                LazyRefEval lazyRefEval = (LazyRefEval) eval;
+            if(eval instanceof LazyRefEval lazyRefEval) {
                 if(lazyRefEval.isSubTotal()) {
                     it.remove();
                 }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Sumif.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Sumif.java
@@ -100,10 +100,10 @@ public final class Sumif extends Var2or3ArgFunction {
             return 0.0D;
         } else {
             ValueEval addend = aeSum.getRelativeValue(relRowIndex, relColIndex);
-            if (addend instanceof NumberEval) {
-                return ((NumberEval) addend).getNumberValue();
-            } else if (addend instanceof ErrorEval) {
-                throw new EvaluationException((ErrorEval)addend);
+            if (addend instanceof NumberEval ne) {
+                return ne.getNumberValue();
+            } else if (addend instanceof ErrorEval ee) {
+                throw new EvaluationException(ee);
             } else {
                 // everything else (including string and boolean values) counts as zero
                 return 0.0;
@@ -116,21 +116,21 @@ public final class Sumif extends Var2or3ArgFunction {
      * @throws EvaluationException if eval is not a reference
      */
     private static AreaEval createSumRange(ValueEval eval, AreaEval aeRange) throws EvaluationException {
-        if (eval instanceof AreaEval) {
-            return ((AreaEval) eval).offset(0, aeRange.getHeight()-1, 0, aeRange.getWidth()-1);
+        if (eval instanceof AreaEval ae) {
+            return ae.offset(0, aeRange.getHeight()-1, 0, aeRange.getWidth()-1);
         }
-        if (eval instanceof RefEval) {
-            return ((RefEval)eval).offset(0, aeRange.getHeight()-1, 0, aeRange.getWidth()-1);
+        if (eval instanceof RefEval re) {
+            return re.offset(0, aeRange.getHeight()-1, 0, aeRange.getWidth()-1);
         }
         throw new EvaluationException(ErrorEval.VALUE_INVALID);
     }
 
     private static AreaEval convertRangeArg(ValueEval eval) throws EvaluationException {
-        if (eval instanceof AreaEval) {
-            return (AreaEval) eval;
+        if (eval instanceof AreaEval ae) {
+            return ae;
         }
-        if (eval instanceof RefEval) {
-            return ((RefEval)eval).offset(0, 0, 0, 0);
+        if (eval instanceof RefEval re) {
+            return re.offset(0, 0, 0, 0);
         }
         throw new EvaluationException(ErrorEval.VALUE_INVALID);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Sumifs.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Sumifs.java
@@ -63,7 +63,7 @@ public final class Sumifs extends Baseifs {
 
             @Override
             public void addValue(ValueEval value) {
-                accumulator += (value instanceof NumberEval) ? ((NumberEval) value).getNumberValue() : 0.0;
+                accumulator += (value instanceof NumberEval ne) ? ne.getNumberValue() : 0.0;
             }
 
             @Override

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Sumproduct.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Sumproduct.java
@@ -78,8 +78,7 @@ public final class Sumproduct implements Function, ArrayMode {
             if(firstArg instanceof RefEval) {
                 return evaluateSingleProduct(args);
             }
-            if (firstArg instanceof TwoDEval) {
-                TwoDEval ae = (TwoDEval) firstArg;
+            if (firstArg instanceof TwoDEval ae) {
                 if(ae.isRow() && ae.isColumn()) {
                     return evaluateSingleProduct(args);
                 }
@@ -105,8 +104,7 @@ public final class Sumproduct implements Function, ArrayMode {
     private static double getScalarValue(ValueEval arg) throws EvaluationException {
 
         ValueEval eval;
-        if (arg instanceof RefEval) {
-            RefEval re = (RefEval) arg;
+        if (arg instanceof RefEval re) {
             if (re.getNumberOfSheets() > 1) {
                 throw new EvaluationException(ErrorEval.VALUE_INVALID);
             }
@@ -118,8 +116,7 @@ public final class Sumproduct implements Function, ArrayMode {
         if (eval == null) {
             throw new IllegalStateException("parameter may not be null");
         }
-        if (eval instanceof AreaEval) {
-            AreaEval ae = (AreaEval) eval;
+        if (eval instanceof AreaEval ae) {
             // an area ref can work as a scalar value if it is 1x1
             if(!ae.isColumn() || !ae.isRow()) {
                 throw new EvaluationException(ErrorEval.VALUE_INVALID);
@@ -178,8 +175,8 @@ public final class Sumproduct implements Function, ArrayMode {
         for (int rrIx=0; rrIx<height; rrIx++) {
             for (int rcIx=0; rcIx<width; rcIx++) {
                 ValueEval ve = areaEval.getValue(rrIx, rcIx);
-                if (ve instanceof ErrorEval) {
-                    throw new EvaluationException((ErrorEval) ve);
+                if (ve instanceof ErrorEval ee) {
+                    throw new EvaluationException(ee);
                 }
             }
         }
@@ -220,8 +217,8 @@ public final class Sumproduct implements Function, ArrayMode {
             return 0;
         }
 
-        if(ve instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval)ve);
+        if(ve instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
         if(ve instanceof StringEval) {
             if(isScalarProduct) {
@@ -231,8 +228,7 @@ public final class Sumproduct implements Function, ArrayMode {
             // even if they would parse as valid numeric values
             return 0;
         }
-        if(ve instanceof NumericValueEval) {
-            NumericValueEval nve = (NumericValueEval) ve;
+        if(ve instanceof NumericValueEval nve) {
             return nve.getNumberValue();
         }
         throw new IllegalStateException("Unexpected value eval class ("

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/T.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/T.java
@@ -34,13 +34,12 @@ public final class T extends Fixed1ArgFunction {
 
     public ValueEval evaluate(int srcRowIndex, int srcColumnIndex, ValueEval arg0) {
         ValueEval arg = arg0;
-        if (arg instanceof RefEval) {
+        if (arg instanceof RefEval re) {
             // always use the first sheet
-            RefEval re = (RefEval)arg;
             arg = re.getInnerValueEval(re.getFirstSheetIndex());
-        } else if (arg instanceof AreaEval) {
+        } else if (arg instanceof AreaEval ae) {
             // when the arg is an area, choose the top left cell
-            arg = ((AreaEval) arg).getRelativeValue(0, 0);
+            arg = ae.getRelativeValue(0, 0);
         }
 
         if (arg instanceof StringEval) {

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/TextFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/TextFunction.java
@@ -291,8 +291,7 @@ public abstract class TextFunction implements Function {
         StringBuilder sb = new StringBuilder();
         for (ValueEval arg : args) {
             try {
-                if (arg instanceof AreaEval) {
-                    AreaEval area = (AreaEval)arg;
+                if (arg instanceof AreaEval area) {
                     for (int rn=0; rn<area.getHeight(); rn++) {
                         for (int cn=0; cn<area.getWidth(); cn++) {
                             ValueEval ve = area.getRelativeValue(rn, cn);
@@ -363,12 +362,12 @@ public abstract class TextFunction implements Function {
 
                     if (valueVe == BlankEval.instance) {
                         valueDouble = 0.0;
-                    } else if (valueVe instanceof BoolEval) {
-                        evaluated = ((BoolEval) valueVe).getStringValue();
-                    } else if (valueVe instanceof NumericValueEval) {
-                        valueDouble = ((NumericValueEval) valueVe).getNumberValue();
-                    } else if (valueVe instanceof StringEval) {
-                        evaluated = ((StringEval) valueVe).getStringValue();
+                    } else if (valueVe instanceof BoolEval be) {
+                        evaluated = be.getStringValue();
+                    } else if (valueVe instanceof NumericValueEval ne) {
+                        valueDouble = ne.getNumberValue();
+                    } else if (valueVe instanceof StringEval se) {
+                        evaluated = se.getStringValue();
                         valueDouble = OperandResolver.parseDouble(evaluated);
                         if (valueDouble == null) {
                             try {
@@ -398,8 +397,7 @@ public abstract class TextFunction implements Function {
          */
         private String formatPatternValueEval2String(ValueEval ve) {
             final String format;
-            if (!(ve instanceof BoolEval) && (ve instanceof StringValueEval)) {
-                StringValueEval sve = (StringValueEval) ve;
+            if (!(ve instanceof BoolEval) && (ve instanceof StringValueEval sve)) {
                 format = sve.getStringValue();
             } else if (ve == BlankEval.instance) {
                 format = "";

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/Trend.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/Trend.java
@@ -98,8 +98,7 @@ public final class Trend implements Function {
         if (arg instanceof MissingArgEval) {
             return new double[0][0];
         }
-        if (arg instanceof RefEval) {
-            RefEval re = (RefEval) arg;
+        if (arg instanceof RefEval re) {
             if (re.getNumberOfSheets() > 1) {
                 throw new EvaluationException(ErrorEval.VALUE_INVALID);
             }
@@ -111,23 +110,22 @@ public final class Trend implements Function {
             throw new IllegalStateException("Parameter may not be null.");
         }
 
-        if (eval instanceof AreaEval) {
-            AreaEval ae = (AreaEval) eval;
+        if (eval instanceof AreaEval ae) {
             int w = ae.getWidth();
             int h = ae.getHeight();
             ar = new double[h][w];
             for (int i = 0; i < h; i++) {
                 for (int j = 0; j < w; j++) {
                     ValueEval ve = ae.getRelativeValue(i, j);
-                    if (!(ve instanceof NumericValueEval)) {
+                    if (!(ve instanceof NumericValueEval nve)) {
                         throw new EvaluationException(ErrorEval.VALUE_INVALID);
                     }
-                    ar[i][j] = ((NumericValueEval)ve).getNumberValue();
+                    ar[i][j] = nve.getNumberValue();
                 }
             }
-        } else if (eval instanceof NumericValueEval) {
+        } else if (eval instanceof NumericValueEval nve) {
             ar = new double[1][1];
-            ar[0][0] = ((NumericValueEval)eval).getNumberValue();
+            ar[0][0] = nve.getNumberValue();
         } else {
             throw new EvaluationException(ErrorEval.VALUE_INVALID);
         }
@@ -239,11 +237,11 @@ public final class Trend implements Function {
             yOrig = evalToArray(args[0]);
             xOrig = evalToArray(args[1]);
             newXOrig = evalToArray(args[2]);
-            if (!(args[3] instanceof BoolEval)) {
+            if (!(args[3] instanceof BoolEval be)) {
                 throw new EvaluationException(ErrorEval.VALUE_INVALID);
             }
             // The argument in Excel is false when it *should* pass through the origin.
-            passThroughOrigin = !((BoolEval)args[3]).getBooleanValue();
+            passThroughOrigin = !be.getBooleanValue();
             break;
         default:
             throw new EvaluationException(ErrorEval.VALUE_INVALID);

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/XYNumericFunction.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/XYNumericFunction.java
@@ -135,23 +135,21 @@ public abstract class XYNumericFunction extends Fixed2ArgFunction {
         for (int i = 0; i < size; i++) {
             ValueEval vx = x.getItem(i);
             ValueEval vy = y.getItem(i);
-            if (vx instanceof ErrorEval) {
+            if (vx instanceof ErrorEval ex) {
                 if (firstXerr == null) {
-                    firstXerr = (ErrorEval) vx;
+                    firstXerr = ex;
                     continue;
                 }
             }
-            if (vy instanceof ErrorEval) {
+            if (vy instanceof ErrorEval ey) {
                 if (firstYerr == null) {
-                    firstYerr = (ErrorEval) vy;
+                    firstYerr = ey;
                     continue;
                 }
             }
             // only count pairs if both elements are numbers
-            if (vx instanceof NumberEval && vy instanceof NumberEval) {
+            if (vx instanceof NumberEval nx && vy instanceof NumberEval ny) {
                 accumlatedSome = true;
-                NumberEval nx = (NumberEval) vx;
-                NumberEval ny = (NumberEval) vy;
                 result += acc.accumulate(nx.getNumberValue(), ny.getNumberValue());
             } else {
                 // all other combinations of value types are silently ignored
@@ -170,14 +168,14 @@ public abstract class XYNumericFunction extends Fixed2ArgFunction {
     }
 
     private static ValueVector createValueVector(ValueEval arg) throws EvaluationException {
-        if (arg instanceof ErrorEval) {
-            throw new EvaluationException((ErrorEval) arg);
+        if (arg instanceof ErrorEval ee) {
+            throw new EvaluationException(ee);
         }
-        if (arg instanceof TwoDEval) {
-            return new AreaValueArray((TwoDEval) arg);
+        if (arg instanceof TwoDEval td) {
+            return new AreaValueArray(td);
         }
-        if (arg instanceof RefEval) {
-            return new RefValueArray((RefEval) arg);
+        if (arg instanceof RefEval re) {
+            return new RefValueArray(re);
         }
         return new SingleCellValueArray(arg);
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/ptg/Area3DPxg.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/ptg/Area3DPxg.java
@@ -55,8 +55,8 @@ public final class Area3DPxg extends AreaPtgBase implements Pxg3D {
         super(arearef);
         this.externalWorkbookNumber = externalWorkbookNumber;
         this.firstSheetName = sheetName.getSheetIdentifier().getName();
-        if (sheetName instanceof SheetRangeIdentifier) {
-            this.lastSheetName = ((SheetRangeIdentifier)sheetName).getLastSheetIdentifier().getName();
+        if (sheetName instanceof SheetRangeIdentifier sri) {
+            this.lastSheetName = sri.getLastSheetIdentifier().getName();
         } else {
             this.lastSheetName = null;
         }

--- a/poi/src/main/java/org/apache/poi/ss/formula/ptg/ArrayPtg.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/ptg/ArrayPtg.java
@@ -197,14 +197,14 @@ public final class ArrayPtg extends Ptg {
         if (o instanceof String) {
             return "\"" + o + "\"";
         }
-        if (o instanceof Double) {
-            return NumberToTextConverter.toText((Double) o);
+        if (o instanceof Double d) {
+            return NumberToTextConverter.toText(d);
         }
-        if (o instanceof Boolean) {
-            return (Boolean) o ? "TRUE" : "FALSE";
+        if (o instanceof Boolean b) {
+            return b ? "TRUE" : "FALSE";
         }
-        if (o instanceof ErrorConstant) {
-            return ((ErrorConstant)o).getText();
+        if (o instanceof ErrorConstant ec) {
+            return ec.getText();
         }
         throw new IllegalArgumentException("Unexpected constant class (" + o.getClass().getName() + ")");
     }

--- a/poi/src/main/java/org/apache/poi/ss/formula/ptg/ExternSheetNameResolver.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/ptg/ExternSheetNameResolver.java
@@ -40,8 +40,7 @@ final class ExternSheetNameResolver {
                 sb = new StringBuilder(sheetName.length() + cellRefText.length() + 4);
                 SheetNameFormatter.appendFormat(sb, sheetName);
             }
-            if (externalSheet instanceof ExternalSheetRange) {
-                ExternalSheetRange r = (ExternalSheetRange)externalSheet;
+            if (externalSheet instanceof ExternalSheetRange r) {
                 if (! r.getFirstSheetName().equals(r.getLastSheetName())) {
                     sb.append(':');
                     // quote should appear at the beginning and end.

--- a/poi/src/main/java/org/apache/poi/ss/formula/ptg/Ptg.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/ptg/Ptg.java
@@ -76,8 +76,8 @@ public abstract class Ptg implements Duplicatable, GenericRecord {
         if (hasArrayPtgs) {
             Ptg[] result = toPtgArray(temp);
             for (int i=0;i<result.length;i++) {
-                if (result[i] instanceof ArrayInitialPtg) {
-                    result[i] = ((ArrayInitialPtg) result[i]).finishReading(in);
+                if (result[i] instanceof ArrayInitialPtg aip) {
+                    result[i] = aip.finishReading(in);
                 }
             }
             return result;

--- a/poi/src/main/java/org/apache/poi/ss/formula/ptg/Ref3DPxg.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/ptg/Ref3DPxg.java
@@ -54,8 +54,8 @@ public final class Ref3DPxg extends RefPtgBase implements Pxg3D {
         this.externalWorkbookNumber = externalWorkbookNumber;
 
         this.firstSheetName = sheetName.getSheetIdentifier().getName();
-        if (sheetName instanceof SheetRangeIdentifier) {
-            this.lastSheetName = ((SheetRangeIdentifier)sheetName).getLastSheetIdentifier().getName();
+        if (sheetName instanceof SheetRangeIdentifier sri) {
+            this.lastSheetName = sri.getLastSheetIdentifier().getName();
         } else {
             this.lastSheetName = null;
         }

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/DataFormatter.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/DataFormatter.java
@@ -364,8 +364,8 @@ public class DataFormatter {
     }
 
     private boolean isDate1904(Cell cell) {
-        if ( cell != null && cell.getSheet().getWorkbook() instanceof Date1904Support) {
-            return ((Date1904Support)cell.getSheet().getWorkbook()).isDate1904();
+        if ( cell != null && cell.getSheet().getWorkbook() instanceof Date1904Support date1904Support) {
+            return date1904Support.isDate1904();
 
         }
         return false;
@@ -1006,9 +1006,9 @@ public class DataFormatter {
         if(DateUtil.isADateFormat(formatIndex,formatString)) {
             if(DateUtil.isValidExcelDate(value)) {
                 Format dateFormat = getFormat(value, formatIndex, formatString, use1904Windowing);
-                if(dateFormat instanceof ExcelStyleDateFormatter) {
+                if(dateFormat instanceof ExcelStyleDateFormatter formatter) {
                     // Hint about the raw excel value
-                    ((ExcelStyleDateFormatter)dateFormat).setDateToBeFormatted(value);
+                    formatter.setDateToBeFormatted(value);
                 }
                 Date d = DateUtil.getJavaDate(value, use1904Windowing);
                 return performDateFormatting(d, dateFormat);

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/ExcelStyleDateFormatter.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/ExcelStyleDateFormatter.java
@@ -188,11 +188,10 @@ public class ExcelStyleDateFormatter extends SimpleDateFormat {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ExcelStyleDateFormatter)) {
+        if (!(o instanceof ExcelStyleDateFormatter other)) {
             return false;
         }
 
-        ExcelStyleDateFormatter other = (ExcelStyleDateFormatter) o;
         return dateToBeFormatted == other.dateToBeFormatted;
     }
 

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/FractionFormat.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/FractionFormat.java
@@ -190,11 +190,11 @@ public class FractionFormat extends Format {
 
     @Override
     public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
-        if (!(obj instanceof Number)) {
+        if (!(obj instanceof Number number)) {
             throw new IllegalArgumentException("Cannot format object of " + obj.getClass() + " to number: " + obj);
         }
 
-        return toAppendTo.append(format((Number)obj));
+        return toAppendTo.append(format(number));
     }
 
     @Override

--- a/poi/src/main/java/org/apache/poi/ss/util/CellAddress.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellAddress.java
@@ -145,11 +145,10 @@ public class CellAddress implements Comparable<CellAddress> {
         if (this == o) {
             return true;
         }
-        if(!(o instanceof CellAddress)) {
+        if(!(o instanceof CellAddress other)) {
             return false;
         }
 
-        CellAddress other = (CellAddress) o;
         return _row == other._row &&
                _col == other._col;
     }

--- a/poi/src/main/java/org/apache/poi/ss/util/CellRangeAddressBase.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellRangeAddressBase.java
@@ -386,8 +386,7 @@ public abstract class CellRangeAddressBase implements Iterable<CellAddress>, Dup
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof CellRangeAddressBase) {
-            CellRangeAddressBase o = (CellRangeAddressBase) other;
+        if (other instanceof CellRangeAddressBase o) {
             return ((getMinRow() == o.getMinRow()) &&
                     (getMaxRow() == o.getMaxRow()) &&
                     (getMinColumn() == o.getMinColumn()) &&

--- a/poi/src/main/java/org/apache/poi/ss/util/CellReference.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/CellReference.java
@@ -638,10 +638,9 @@ public class CellReference implements GenericRecord {
         if (this == o) {
             return true;
         }
-        if(!(o instanceof CellReference)) {
+        if(!(o instanceof CellReference cr)) {
             return false;
         }
-        CellReference cr = (CellReference) o;
         return _rowIndex == cr._rowIndex
                 && _colIndex == cr._colIndex
                 && _isRowAbs == cr._isRowAbs

--- a/poi/src/main/java/org/apache/poi/ss/util/PaneInformation.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/PaneInformation.java
@@ -123,9 +123,7 @@ public class PaneInformation
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PaneInformation)) return false;
-
-        PaneInformation that = (PaneInformation) o;
+        if (!(o instanceof PaneInformation that)) return false;
 
         if (x != that.x) return false;
         if (y != that.y) return false;

--- a/poi/src/main/java/org/apache/poi/util/GenericRecordXmlWriter.java
+++ b/poi/src/main/java/org/apache/poi/util/GenericRecordXmlWriter.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.output.NullOutputStream;
@@ -188,7 +187,7 @@ public class GenericRecordXmlWriter implements Closeable {
 
         final int oldChildIndex = childIndex;
         childIndex = 0;
-        List<Map.Entry<String,Supplier<?>>> complex = prop.entrySet().stream().flatMap(this::writeProp).collect(Collectors.toList());
+        List<Map.Entry<String,Supplier<?>>> complex = prop.entrySet().stream().flatMap(this::writeProp).toList();
 
         attributePhase = false;
         if (!complex.isEmpty()) {


### PR DESCRIPTION
Follow-up to #1237 and #1238, same treatment for the core poi module. Mechanical, behavior-preserving modernization now that the build targets Java 17:

- pattern-matching `instanceof` in place of instanceof-then-cast (~400 sites across ss/formula (engine, eval, ptg, atp, and the function library), hssf, hpsf, ddf, poifs, sl, and ss usermodel/util/format)
- arrow-form `switch` statements / switch expressions where cases had no fall-through or shared state (e.g. `HSSFCell` accessors, `VariantSupport` read/write, `FormulaParser`, `OldExcelExtractor`, `EscherPropertyFactory`)
- `Stream.toList()` instead of `collect(Collectors.toList())` where the resulting list is never mutated (`GenericRecordXmlWriter`, `EscherArrayProperty`, `CellFormatPart`)

Deliberately left alone: switches with deliberate fall-through (`@SuppressWarnings("fallthrough")` sites in `HSSFCell`/`HSSFWorkbook`, `OperandClassTransformer`, `YearFrac`), `case X: default:` shared labels that Java 17 arrow form cannot express, casts guarded by something other than the instanceof (null-tolerant paths, different variables/types, `||`-guards without definite assignment), and the `Collectors.toList()` in `UnicodeString` whose copied list is mutated afterwards.

No public API signatures changed. `compileJava`/`compileTestJava` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)