### PR TITLE
Fix ContentType.equals and the M1.10 part name segment check

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackagePartName.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/PackagePartName.java
@@ -263,7 +263,7 @@ public final class PackagePartName implements Comparable<PackagePartName> {
                     "A segment shall not end with a dot ('.') character [M1.9]: " + partUri.getPath());
             }
 
-            if (seg.replaceAll("\\\\.", "").isEmpty()) {
+            if (isAllDots(seg)) {
                 // Normally will never been invoked with the previous
                 // implementation rule [M1.9]
                 throw new InvalidFormatException(
@@ -273,6 +273,22 @@ public final class PackagePartName implements Comparable<PackagePartName> {
             // Check for rule M1.6, M1.7, M1.8
             checkPCharCompliance(seg);
         }
+    }
+
+    /**
+     * Checks if a segment consists of dot ('.') characters only.
+     *
+     * @param segment
+     *            The non-empty segment to check.
+     * @return <code>true</code> if the segment holds nothing but dots.
+     */
+    private static boolean isAllDots(String segment) {
+        for (int i = 0; i < segment.length(); i++) {
+            if (segment.charAt(i) != '.') {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/ContentType.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/openxml4j/opc/internal/ContentType.java
@@ -20,8 +20,8 @@ package org.apache.poi.openxml4j.opc.internal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -206,13 +206,14 @@ public final class ContentType {
 
     @Override
     public boolean equals(Object obj) {
-        return (!(obj instanceof ContentType))
-                || (StringUtil.equalsIgnoreCase(this.toString(), obj.toString()));
+        return (obj instanceof ContentType)
+                && StringUtil.equalsIgnoreCase(this.toString(), obj.toString());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type,subType,parameters);
+        // must be consistent with the case-insensitive comparison in equals()
+        return this.toString().toLowerCase(Locale.ROOT).hashCode();
     }
 
     /* Getters */

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
@@ -529,6 +529,7 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
         for (CTCell ctCell : _row.getCArray()) {
             if(ctCell == removed.getCTCell()) {
                 _row.removeC(i);
+                break;
             }
             i++;
         }

--- a/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestContentType.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/openxml4j/opc/TestContentType.java
@@ -20,6 +20,7 @@ package org.apache.poi.openxml4j.opc;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -111,6 +112,27 @@ public final class TestContentType {
     void testContentTypeParameterFailure(String contentType) {
         assertThrows(InvalidFormatException.class, () -> new ContentType(contentType),
             "Must have fail for content type: '" + contentType + "' !");
+    }
+
+    /**
+     * A content type is only ever equal to another content type, and the
+     * comparison ignores case (RFC 2616 media types are case-insensitive).
+     */
+    @Test
+    void testEqualsAndHashCode() throws InvalidFormatException {
+        ContentType type = new ContentType("text/xml");
+
+        assertEquals(type, new ContentType("text/xml"));
+        assertEquals(type, new ContentType("TEXT/XML"));
+        assertEquals(type.hashCode(), new ContentType("TEXT/XML").hashCode(),
+            "equal content types must have equal hash codes");
+
+        assertNotEquals(type, new ContentType("text/plain"));
+
+        // must not claim equality with unrelated types
+        assertNotEquals(type, "text/xml");
+        assertNotEquals(type, new Object());
+        assertNotEquals(null, type);
     }
 
     /**


### PR DESCRIPTION
Three defects found while reviewing poi-ooxml. All are independent and small.

### `ContentType.equals()` is inverted

```java
return (!(obj instanceof ContentType))
        || (StringUtil.equalsIgnoreCase(this.toString(), obj.toString()));
```

This returns **true** for every argument that is not a `ContentType`, including unrelated types and `String`. Fixed to require a `ContentType`.

While fixing it: `equals()` compares `toString()` case-insensitively, but `hashCode()` was `Objects.hash(type, subType, parameters)`, which is case-sensitive. Two content types differing only in case therefore compared equal but hashed differently, violating the `equals`/`hashCode` contract. That matters here because `ContentType` is a live `HashMap` key — `OPCPackage.partMarshallers` and `partUnmarshallers` are looked up per part on the open and save paths (`ZipPackage:701`, `OPCPackage:968`), so a content type declared with different casing could miss its marshaller. RFC 2616 media types are case-insensitive, so `hashCode()` is now derived from the same case-insensitive form `equals()` uses.

Added `TestContentType.testEqualsAndHashCode` covering both the case-insensitive equality and the non-`ContentType` argument.

### `PackagePartName` [M1.10] check never tested what it claimed

```java
if (seg.replaceAll("\\\\.", "").isEmpty()) {
```

In a Java string literal that regex is `\\.`, which matches a literal backslash followed by any character — not dots. The rule ("a segment shall include at least one non-dot character") was therefore never enforced by this code. Replaced with an explicit all-dots check, which is also allocation-free.

Note this branch stays effectively unreachable in practice, since the preceding [M1.9] check already rejects any segment ending in a dot, and an all-dot segment always does — the existing comment says as much. The fix makes the check correct rather than changing observable behaviour.

### `XSSFRow.removeCell` continues scanning after removal

The loop iterates a snapshot from `getCArray()` and calls `_row.removeC(i)`, which shifts the underlying list, but then keeps scanning with a now-misaligned `i`. Only one entry can match by object identity, so this does not misbehave today, but the loop should stop at the match.

`poi-ooxml` OPC tests (183) plus `TestXSSFRow` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)