### PR TITLE
Cache the TransformerFactory and skip unwanted comment lookups

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFExcelExtractor.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/extractor/XSSFExcelExtractor.java
@@ -169,13 +169,15 @@ public class XSSFExcelExtractor
                     }
 
                     // Output the comment, if requested and exists
-                    Comment comment = cell.getCellComment();
-                    if(includeCellComments && comment != null) {
-                        // Replace any newlines with spaces, otherwise it
-                        //  breaks the output
-                        String commentText = comment.getString().getString().replace('\n', ' ');
-                        checkMaxTextSize(text, commentText);
-                        text.append(" Comment by ").append(comment.getAuthor()).append(": ").append(commentText);
+                    if(includeCellComments) {
+                        Comment comment = cell.getCellComment();
+                        if(comment != null) {
+                            // Replace any newlines with spaces, otherwise it
+                            //  breaks the output
+                            String commentText = comment.getString().getString().replace('\n', ' ');
+                            checkMaxTextSize(text, commentText);
+                            text.append(" Comment by ").append(comment.getAuthor()).append(": ").append(commentText);
+                        }
                     }
 
                     if(ri.hasNext()) {

--- a/poi/src/main/java/org/apache/poi/util/XMLHelper.java
+++ b/poi/src/main/java/org/apache/poi/util/XMLHelper.java
@@ -83,12 +83,18 @@ public final class XMLHelper {
     private static final Logger LOG = PoiLogManager.getLogger(XMLHelper.class);
     private static long lastLog;
 
-    // DocumentBuilderFactory.newDocumentBuilder is thread-safe
+    // JAXP does not state whether these two factories may be used by several threads at once, but
+    // the JDK implementations only read their feature/attribute state when creating a parser, and
+    // both are configured here once and never mutated afterwards, so they are shared unguarded.
+    // Guarding them would serialize the much hotter parser-creation paths.
     private static final DocumentBuilderFactory documentBuilderFactory = getDocumentBuilderFactory();
 
     private static final SAXParserFactory saxFactory = getSaxParserFactory();
 
-    // TransformerFactory is not thread-safe, so access to it is synchronized in newTransformer
+    // TransformerFactory differs: its javadoc says "Different TransformerFactories can be used
+    // concurrently by different Threads", i.e. one factory is not meant to be shared, so
+    // newTransformer synchronizes on it. Only the (cheap) transformer creation is guarded -
+    // the transformation itself runs outside the lock.
     private static final TransformerFactory transformerFactory = getTransformerFactory();
 
     @FunctionalInterface

--- a/poi/src/main/java/org/apache/poi/util/XMLHelper.java
+++ b/poi/src/main/java/org/apache/poi/util/XMLHelper.java
@@ -88,6 +88,9 @@ public final class XMLHelper {
 
     private static final SAXParserFactory saxFactory = getSaxParserFactory();
 
+    // TransformerFactory is not thread-safe, so access to it is synchronized in newTransformer
+    private static final TransformerFactory transformerFactory = getTransformerFactory();
+
     @FunctionalInterface
     private interface SecurityFeature {
         void accept(String name, boolean value) throws ParserConfigurationException, SAXException, TransformerException;
@@ -237,7 +240,10 @@ public final class XMLHelper {
     }
 
     public static Transformer newTransformer() throws TransformerConfigurationException {
-        Transformer serializer = getTransformerFactory().newTransformer();
+        final Transformer serializer;
+        synchronized (transformerFactory) {
+            serializer = transformerFactory.newTransformer();
+        }
         // TODO set encoding from a command argument
         serializer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
         serializer.setOutputProperty(OutputKeys.INDENT, "no");


### PR DESCRIPTION
Two small, independent performance fixes found while reviewing poi-ooxml. (The third item from that review, `ContentType.equals`, is in #1240.)

### Cache the `TransformerFactory` in `XMLHelper`

`XMLHelper.newTransformer()` called `TransformerFactory.newInstance()` on every invocation, redoing the JAXP provider lookup and re-applying the security configuration each time. It runs once per part that has relationships on every OPC save (`ZipPartMarshaller.marshallRelationshipPart`), plus once for the content types part, and is also used by the HWPF/HSSF converters. The `DocumentBuilderFactory` and `SAXParserFactory` in the same class are already cached this way; the `TransformerFactory` was the odd one out.

Measured on JDK 17 with the built-in `TransformerFactoryImpl` (2000 iterations, warmed up):

| | single-threaded | 8 threads |
|---|---|---|
| current: `newInstance()` per call | 83.1 µs/op | 124.7 µs/op |
| cached + `synchronized` (this PR) | 8.1 µs/op | 16.9 µs/op |
| cached + `ThreadLocal` | 12.8 µs/op | 4.1 µs/op |

`newInstance()` plus the configuration is ~87% of the cost, which is what caching removes.

`TransformerFactory` is not guaranteed thread-safe and the implementation is pluggable via system property, so the creation call is synchronized rather than assumed safe. The lock was free when uncontended in the measurements above (the difference against an unsynchronized cached factory was within noise), and it guards only the identity-transformer creation, not the transform itself.

A `ThreadLocal` is ~4x better than the lock under 8-way contention, but both are well clear of the status quo, the absolute numbers are small next to the surrounding document save, and a library-held `ThreadLocal` retaining a pluggable factory is a known classloader-leak hazard when POI runs inside an application server. Happy to switch if you would rather have the contended throughput.

### Don't fetch comments the extractor is going to discard

`XSSFExcelExtractor` called `cell.getCellComment()` for every cell and only then checked `includeCellComments`. With the default `includeCellComments = false`, that is a comments-table lookup per cell — plus a linear VML shape scan for every cell that does have a comment (`XSSFVMLDrawing.findCommentShape`) — purely to throw the result away. Moved the call inside the guard.

`TestXMLHelper`, the poi-ooxml extractor and openxml4j suites (272 tests), and the poi-scratchpad converter suites (1507 tests, the heaviest `newTransformer()` users) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)