### PR TITLE
Avoid quadratic XmlBeans element access on hot paths

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSourcesFactory.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xddf/usermodel/chart/XDDFDataSourcesFactory.java
@@ -29,7 +29,9 @@ import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTAxDataSource;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumData;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumDataSource;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTNumVal;
 import org.openxmlformats.schemas.drawingml.x2006.chart.CTStrData;
+import org.openxmlformats.schemas.drawingml.x2006.chart.CTStrVal;
 
 /**
  * Class {@code XDDFDataSourcesFactory} is a factory for {@link XDDFDataSource}
@@ -48,6 +50,9 @@ public class XDDFDataSourcesFactory {
         if (categoryDS.getNumRef() != null && categoryDS.getNumRef().getNumCache() != null) {
             return new XDDFCategoryDataSource() {
                 private final CTNumData category = (CTNumData) categoryDS.getNumRef().getNumCache().copy();
+                // the points are read once, as the indexed accessor of XmlBeans walks
+                // the list of elements from the start on every call
+                private final CTNumVal[] points = category.getPtArray();
                 private final String formatCode = category.isSetFormatCode() ? category.getFormatCode() : null;
 
                 @Override
@@ -72,11 +77,11 @@ public class XDDFDataSourcesFactory {
 
                 @Override
                 public String getPointAt(int index) {
-                    if (category.sizeOfPtArray() <= index) {
+                    if (points.length <= index) {
                         throw new IllegalArgumentException("Cannot access 0-based index " + index +
-                                " in point-array with " + category.sizeOfPtArray() + " items");
+                                " in point-array with " + points.length + " items");
                     }
-                    return category.getPtArray(index).getV();
+                    return points[index].getV();
                 }
 
                 @Override
@@ -85,6 +90,9 @@ public class XDDFDataSourcesFactory {
         } else if (categoryDS.getStrRef() != null && categoryDS.getStrRef().getStrCache() != null) {
             return new XDDFCategoryDataSource() {
                 private final CTStrData category = (CTStrData) categoryDS.getStrRef().getStrCache().copy();
+                // the points are read once, as the indexed accessor of XmlBeans walks
+                // the list of elements from the start on every call
+                private final CTStrVal[] points = category.getPtArray();
 
                 @Override
                 public boolean isCellRange() {
@@ -103,7 +111,7 @@ public class XDDFDataSourcesFactory {
 
                 @Override
                 public String getPointAt(int index) {
-                    return category.getPtArray(index).getV();
+                    return points[index].getV();
                 }
 
                 @Override
@@ -112,6 +120,9 @@ public class XDDFDataSourcesFactory {
         } else if (categoryDS.getNumLit() != null) {
             return new XDDFCategoryDataSource() {
                 private final CTNumData category = (CTNumData) categoryDS.getNumLit().copy();
+                // the points are read once, as the indexed accessor of XmlBeans walks
+                // the list of elements from the start on every call
+                private final CTNumVal[] points = category.getPtArray();
                 private final String formatCode = category.isSetFormatCode() ? category.getFormatCode() : null;
 
                 @Override
@@ -146,7 +157,7 @@ public class XDDFDataSourcesFactory {
 
                 @Override
                 public String getPointAt(int index) {
-                    return category.getPtArray(index).getV();
+                    return points[index].getV();
                 }
 
                 @Override
@@ -155,6 +166,9 @@ public class XDDFDataSourcesFactory {
         } else if (categoryDS.getStrLit() != null) {
             return new XDDFCategoryDataSource() {
                 private final CTStrData category = (CTStrData) categoryDS.getStrLit().copy();
+                // the points are read once, as the indexed accessor of XmlBeans walks
+                // the list of elements from the start on every call
+                private final CTStrVal[] points = category.getPtArray();
 
                 @Override
                 public boolean isCellRange() {
@@ -183,7 +197,7 @@ public class XDDFDataSourcesFactory {
 
                 @Override
                 public String getPointAt(int index) {
-                    return category.getPtArray(index).getV();
+                    return points[index].getV();
                 }
 
                 @Override
@@ -201,6 +215,9 @@ public class XDDFDataSourcesFactory {
         if (valuesDS.getNumRef() != null && valuesDS.getNumRef().getNumCache() != null) {
             return new XDDFNumericalDataSource<Double>() {
                 private final CTNumData values = (CTNumData) valuesDS.getNumRef().getNumCache().copy();
+                // the points are read once, as the indexed accessor of XmlBeans walks
+                // the list of elements from the start on every call
+                private final CTNumVal[] points = values.getPtArray();
                 private String formatCode = values.isSetFormatCode() ? values.getFormatCode() : null;
 
                 @Override
@@ -235,7 +252,7 @@ public class XDDFDataSourcesFactory {
 
                 @Override
                 public Double getPointAt(int index) {
-                    return Double.valueOf(values.getPtArray(index).getV());
+                    return Double.valueOf(points[index].getV());
                 }
 
                 @Override
@@ -251,6 +268,9 @@ public class XDDFDataSourcesFactory {
         } else if (valuesDS.getNumLit() != null) {
             return new XDDFNumericalDataSource<Double>() {
                 private final CTNumData values = (CTNumData) valuesDS.getNumLit().copy();
+                // the points are read once, as the indexed accessor of XmlBeans walks
+                // the list of elements from the start on every call
+                private final CTNumVal[] points = values.getPtArray();
                 private String formatCode = values.isSetFormatCode() ? values.getFormatCode() : null;
 
                 @Override
@@ -290,7 +310,7 @@ public class XDDFDataSourcesFactory {
 
                 @Override
                 public Double getPointAt(int index) {
-                    return Double.valueOf(values.getPtArray(index).getV());
+                    return Double.valueOf(points[index].getV());
                 }
 
                 @Override

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFRow.java
@@ -41,6 +41,7 @@ import org.apache.poi.util.Beta;
 import org.apache.poi.util.Internal;
 import org.apache.poi.xssf.model.StylesTable;
 import org.apache.poi.xssf.usermodel.helpers.XSSFRowShifter;
+import org.apache.xmlbeans.XmlCursor;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTCell;
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTRow;
 
@@ -581,33 +582,67 @@ public class XSSFRow implements Row, Comparable<XSSFRow> {
     }
 
     private void fixupCTCells(CTCell[] cArrayOrig) {
-        // copy all values to 2nd array and a map for lookup of index
-        CTCell[] cArrayCopy = new CTCell[cArrayOrig.length];
-        IdentityHashMap<CTCell, Integer> map = new IdentityHashMap<>(_cells.size());
+        // build a map for lookup of the index of a CTCell in the row
+        IdentityHashMap<CTCell, Integer> map = new IdentityHashMap<>(cArrayOrig.length);
         int i = 0;
         for (CTCell ctCell : cArrayOrig) {
-            cArrayCopy[i] = (CTCell) ctCell.copy();
             map.put(ctCell, i);
             i++;
         }
 
-        // populate _row.cArray correctly
+        // collect the CTCells in the order in which they need to appear in the XML
+        CTCell[] cArrayNew = new CTCell[_cells.size()];
+        boolean[] stillUsed = new boolean[cArrayOrig.length];
         i = 0;
         for (XSSFCell cell : _cells.values()) {
-            // no need to change anything if position is correct
             Integer correctPosition = map.get(cell.getCTCell());
             Objects.requireNonNull(correctPosition, "Should find CTCell in _row");
-            if(correctPosition != i) {
-                // we need to re-populate this CTCell
-                _row.setCArray(i, cArrayCopy[correctPosition]);
-                cell.setCTCell(_row.getCArray(i));
-            }
+            stillUsed[correctPosition] = true;
+            cArrayNew[i] = cArrayOrig[correctPosition];
             i++;
         }
 
-        // remove any remaining illegal references in _rows.cArray
-        while(_row.sizeOfCArray() > _cells.size()) {
-            _row.removeC(_cells.size());
+        // remove any remaining illegal references in _row.cArray
+        for (i = 0; i < cArrayOrig.length; i++) {
+            if (!stillUsed[i]) {
+                try (XmlCursor cursor = cArrayOrig[i].newCursor()) {
+                    cursor.removeXml();
+                }
+            }
+        }
+
+        // the CTCells at the start which are already in the correct order do not need to be moved
+        int matching = 0;
+        for (i = 0; i < cArrayOrig.length; i++) {
+            if (stillUsed[i]) {
+                if (matching < cArrayNew.length && cArrayNew[matching] == cArrayOrig[i]) {
+                    matching++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // move the remaining CTCells in front of the last one, in the order in which
+        // they need to appear - moving the XML via cursors avoids the indexed XmlBeans
+        // accessors, which walk the list of elements from the start on every call
+        if (matching < cArrayNew.length - 1) {
+            try (XmlCursor dest = cArrayNew[cArrayNew.length - 1].newCursor()) {
+                for (int j = matching; j < cArrayNew.length - 1; j++) {
+                    try (XmlCursor src = cArrayNew[j].newCursor()) {
+                        src.moveXml(dest);
+                    }
+                }
+            }
+        }
+
+        // moving the XML replaces the CTCell instances, so the cells need to be
+        // re-attached to the CTCells which are now stored in the row
+        CTCell[] cArrayUpdated = _row.getCArray();
+        i = 0;
+        for (XSSFCell cell : _cells.values()) {
+            cell.setCTCell(cArrayUpdated[i]);
+            i++;
         }
     }
 

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/helpers/ColumnHelper.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/helpers/ColumnHelper.java
@@ -53,7 +53,10 @@ public class ColumnHelper {
         int i;
         for (i = 0; i < colsArray.length; i++) {
             CTCols cols = colsArray[i];
-            for (CTCol col : cols.getColList()) {
+            // fetching the array is much quicker than iterating the list, as the
+            // list resolves each element via the indexed getter, which walks the
+            // list of elements from the start on every call
+            for (CTCol col : cols.getColArray()) {
                 addCleanColIntoCols(newCols, col, trackedCols);
             }
         }
@@ -73,7 +76,7 @@ public class ColumnHelper {
         // read above.
         TreeSet<CTCol> trackedCols = new TreeSet<>(
                 CTColComparator.BY_MIN_MAX);
-        trackedCols.addAll(cols.getColList());
+        trackedCols.addAll(Arrays.asList(cols.getColArray()));
         addCleanColIntoCols(cols, newCol, trackedCols);
         cols.setColArray(trackedCols.toArray(new CTCol[0]));
         return cols;
@@ -317,7 +320,7 @@ public class ColumnHelper {
     }
 
     private boolean columnExists(CTCols cols, long min, long max) {
-        for (CTCol col : cols.getColList()) {
+        for (CTCol col : cols.getColArray()) {
             if (col.getMin() == min && col.getMax() == max) {
                 return true;
             }
@@ -328,7 +331,7 @@ public class ColumnHelper {
     public int getIndexOfColumn(CTCols cols, CTCol searchCol) {
         if (cols == null || searchCol == null) return -1;
         int i = 0;
-        for (CTCol col : cols.getColList()) {
+        for (CTCol col : cols.getColArray()) {
             if (col.getMin() == searchCol.getMin() && col.getMax() == searchCol.getMax()) {
                 return i;
             }


### PR DESCRIPTION
XmlBeans indexed accessors walk the child list from the start, so `getXxxArray(i)` is O(i) and iterating the lazy `getXxxList()` is O(n²). Measured on xmlbeans 5.4.0, a single full pass over one element's children:

| n | `getCArray()` pass | `getCList()` iteration | `getCArray(i)` loop |
|---|---|---|---|
| 1,000 | 0.31 ms | 8.4 ms | 2.7 ms |
| 16,000 | 1.4 ms | 6,062 ms | 1,410 ms |

So `getXxxArray()` is the cheap way to scan, and the problem is repeated or indexed access. Three places paid for it.

### `XSSFRow.fixupCTCells()`

Runs on save for any row whose cells were created out of column order. It deep-copied every `CTCell` and reordered via indexed `setCArray(i, …)`/`getCArray(i)`, i.e. O(cells²) per affected row. It now reorders the existing beans with `XmlCursor.moveXml()` (linear) and re-attaches each `XSSFCell` from one `getCArray()` call.

Document-level timings, before → after: n=16000 reversed 3009 ms → 27 ms; last cell moved to front 1357 ms → 17 ms; last two swapped 21 ms → 4 ms; first/last swapped 20 ms → 21 ms.

Worth recording for future readers: a single `setCArray(CTCell[])` is *not* the fix. `XmlComplexContentImpl.arraySetterHelper` keeps the common prefix then appends copies and removes the originals by index, so a divergence at index 0 forces the whole tail to be rebuilt — measured 12x *slower* than the current code for a first/last swap, while only 2x faster for a full reversal.

Verified by diffing the serialised worksheet XML of the old and new implementations over 6400 generated cases (row widths 1-8, every subset size, randomised permutations, with and without a trailing `extLst` that must stay last): zero differences.

### `XDDFDataSourcesFactory`

The six anonymous `XDDFDataSource` implementations defined `getPointAt(index)` as `data.getPtArray(index)`, so `fillNumericalCache`/`XDDFChart.fillSheet` reading every point was O(n²). Each source already holds a private deep copy taken at construction and nothing mutates it, so the point array is now materialised once and indexed directly. `getPointCount()` and `getDataRangeReference()` are unchanged.

### `ColumnHelper`

Four read-only loops iterated `getColList()`, including `cleanColumns()`, which runs when every sheet is loaded. They now iterate `getColArray()`, turning each O(n²) pass into a single walk.

### Deliberately not included

`CalculationChain.removeItem()` is still O(m·n) for m removals. An index cache cannot be invalidated reliably: `getCTCalcChain()` hands out the live bean, the sheet id of an entry is positional (inherited from the previous entry when absent, so any insert/remove/`setI` shifts everything after it), and duplicate `(sheetId, ref)` entries must keep first-match-only semantics. Fixing it properly needs a batch-removal entry point plus caller changes, which belongs in its own change.

`ColumnHelper.getColumn1Based` still re-walks per call; removing that needs cached lookup state that callers outside the class would invalidate, since they obtain and mutate the `CTCols`/`CTCol` beans directly.

Full `poi-ooxml` suite run: the only failures are `TestXSSFBugs.stackoverflow23114397`, `TestSXSSFBugs.stackoverflow23114397` and `TestSXSSFSheetAutoSizeColumn[1]`, which fail identically on unmodified trunk on this machine (font-metric dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)