### PR TITLE
Reduce the per-run work done when opening a Word document

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFParagraph.java
@@ -71,6 +71,13 @@ public class XWPFParagraph implements IBodyElement, IRunBody, ISDTContents, Para
         for (XWPFRun run : runs) {
             CTR r = run.getCTR();
 
+            // Footnote/endnote references are rare - only pay for the cursor walk below
+            // when the run actually holds at least one of them. CTFtnEdnRef can only occur
+            // as a w:footnoteReference or a w:endnoteReference child of the run.
+            if (r.sizeOfFootnoteReferenceArray() == 0 && r.sizeOfEndnoteReferenceArray() == 0) {
+                continue;
+            }
+
             // Check for bits that only apply when attached to a core document
             // TODO Make this nicer by tracking the XWPFFootnotes directly
             try (XmlCursor c = r.newCursor()) {

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFRun.java
@@ -75,6 +75,21 @@ import org.xml.sax.SAXException;
  * XWPFRun object defines a region of text with a common set of properties
  */
 public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
+    /**
+     * XPath selecting the {@code w:drawing} elements held in an {@code mc:AlternateContent} choice.
+     * Hoisted out of the constructor so that it is not rebuilt for every run of every document.
+     */
+    private static final String ALTERNATE_CONTENT_DRAWING_PATH =
+            "declare namespace w='" + XSSFRelation.NS_WORDPROCESSINGML + "' " +
+            "declare namespace mc='" + PackageNamespaces.MARKUP_COMPATIBILITY + "' " +
+            "./mc:AlternateContent/mc:Choice/w:drawing";
+
+    /**
+     * XPath selecting all the {@code w:t} elements below a picture or drawing.
+     */
+    private static final String PICTURE_TEXT_PATH =
+            "declare namespace w='" + XSSFRelation.NS_WORDPROCESSINGML + "' .//w:t";
+
     private final CTR run;
     private final String pictureText;
     private final IRunBody parent;
@@ -93,17 +108,29 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
          * reserve already occupied drawing ids, so reserving new ids later will
          * not corrupt the document
          */
-        for (CTDrawing ctDrawing : r.getDrawingArray()) {
-            for (CTAnchor anchor : ctDrawing.getAnchorArray()) {
-                if (anchor.getDocPr() != null) {
-                    getDocument().getDrawingIdManager().reserve(anchor.getDocPr().getId());
+        if (r.sizeOfDrawingArray() > 0) {
+            for (CTDrawing ctDrawing : r.getDrawingArray()) {
+                for (CTAnchor anchor : ctDrawing.getAnchorArray()) {
+                    if (anchor.getDocPr() != null) {
+                        getDocument().getDrawingIdManager().reserve(anchor.getDocPr().getId());
+                    }
+                }
+                for (CTInline inline : ctDrawing.getInlineArray()) {
+                    if (inline.getDocPr() != null) {
+                        getDocument().getDrawingIdManager().reserve(inline.getDocPr().getId());
+                    }
                 }
             }
-            for (CTInline inline : ctDrawing.getInlineArray()) {
-                if (inline.getDocPr() != null) {
-                    getDocument().getDrawingIdManager().reserve(inline.getDocPr().getId());
-                }
-            }
+        }
+
+        pictures = new ArrayList<>();
+        charts = new ArrayList<>();
+
+        // The vast majority of runs are plain text and hold neither a picture nor a drawing,
+        // so check for that cheaply first and skip the XPath queries altogether if we can.
+        if (!mayHavePictureContent(r)) {
+            pictureText = "";
+            return;
         }
 
         // Look for any text in any of our pictures or drawings
@@ -111,12 +138,9 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         List<XmlObject> pictTextObjs = new ArrayList<>();
         pictTextObjs.addAll(Arrays.asList(r.getPictArray()));
         pictTextObjs.addAll(Arrays.asList(r.getDrawingArray()));
-        pictTextObjs.addAll(Arrays.asList(r.selectPath(
-                "declare namespace w='" + XSSFRelation.NS_WORDPROCESSINGML + "' " +
-                "declare namespace mc='" + PackageNamespaces.MARKUP_COMPATIBILITY + "' " +
-                "./mc:AlternateContent/mc:Choice/w:drawing")));
+        pictTextObjs.addAll(Arrays.asList(r.selectPath(ALTERNATE_CONTENT_DRAWING_PATH)));
         for (XmlObject o : pictTextObjs) {
-            XmlObject[] ts = o.selectPath("declare namespace w='" + XSSFRelation.NS_WORDPROCESSINGML + "' .//w:t");
+            XmlObject[] ts = o.selectPath(PICTURE_TEXT_PATH);
             for (XmlObject t : ts) {
                 NodeList kids = t.getDomNode().getChildNodes();
                 for (int n = 0; n < kids.getLength(); n++) {
@@ -134,8 +158,6 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
         // Do we have any embedded pictures or charts?
         // Pictures are a different CTPicture, under the drawingml namespace.
         // Charts are relations and use the CTRelId type.
-        pictures = new ArrayList<>();
-        charts = new ArrayList<>();
         for (XmlObject o : pictTextObjs) {
             for (CTPicture pict : getCTPictures(o)) {
                 XWPFPicture picture = new XWPFPicture(pict, this);
@@ -151,6 +173,30 @@ public class XWPFRun implements ISDTContents, IRunElement, CharacterRun {
                 }
             }
         }
+    }
+
+    /**
+     * Cheap test for whether the run could possibly hold a picture, a drawing or an
+     * {@code mc:AlternateContent} element (which in turn may hold a {@code w:drawing}
+     * in one of its choices). Only if this returns {@code true} is it worth running the
+     * XPath queries that collect the picture text, pictures and charts.
+     *
+     * @param r the run to inspect
+     * @return {@code true} if the run may hold picture/drawing content
+     */
+    private static boolean mayHavePictureContent(CTR r) {
+        if (r.sizeOfPictArray() > 0 || r.sizeOfDrawingArray() > 0) {
+            return true;
+        }
+        // ./mc:AlternateContent - direct children only, matching the XPath below
+        for (Node node = r.getDomNode().getFirstChild(); node != null; node = node.getNextSibling()) {
+            if (node.getNodeType() == Node.ELEMENT_NODE
+                    && "AlternateContent".equals(node.getLocalName())
+                    && PackageNamespaces.MARKUP_COMPATIBILITY.equals(node.getNamespaceURI())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFTable.java
@@ -35,7 +35,6 @@ import org.apache.xmlbeans.XmlObject;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTBorder;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTDecimalNumber;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTJcTable;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTP;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTRow;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSdtContentRow;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTSdtRow;
@@ -45,7 +44,6 @@ import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTblBorders;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTblCellMar;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTblPr;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTblWidth;
-import org.openxmlformats.schemas.wordprocessingml.x2006.main.CTTc;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STBorder;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STJcTable;
 import org.openxmlformats.schemas.wordprocessingml.x2006.main.STTblWidth;
@@ -196,9 +194,13 @@ public class XWPFTable implements IBodyElement, ISDTContents {
         StringBuilder rowText = new StringBuilder();
         XWPFTableRow tableRow = new XWPFTableRow(row, this);
         tableRows.add(tableRow);
-        for (CTTc cell : row.getTcList()) {
-            for (CTP ctp : cell.getPList()) {
-                XWPFParagraph p = new XWPFParagraph(ctp, part);
+        // Reuse the paragraphs that XWPFTableRow has just built for the cells of this row,
+        // rather than parsing every cell a second time into throw-away XWPFParagraph/XWPFRun
+        // objects. The cells are the same CTTc elements in the same order (XWPFTableRow uses
+        // ctRow.getTcArray()) and each cell's paragraphs are its direct w:p children in
+        // document order, so the resulting text is identical.
+        for (XWPFTableCell cell : tableRow.getTableCells()) {
+            for (XWPFParagraph p : cell.getParagraphs()) {
                 if (!rowText.isEmpty()) {
                     rowText.append('\t');
                 }


### PR DESCRIPTION
Opening a .docx eagerly constructs an `XWPFParagraph` for every paragraph and an `XWPFRun` for every run, so anything done per run in those constructors is paid by every document. Three things were.

### `XWPFRun` ran an XPath query on every run

The constructor built a ~200-character query string by concatenation and called `r.selectPath(...)` looking for `./mc:AlternateContent/mc:Choice/w:drawing`, on every run — while almost every real run is plain text with no picture content at all.

The two query strings are now `static final` constants (they were built from compile-time constants, so they are byte-identical), and the whole picture/drawing block is skipped unless the run can actually hold such content: `sizeOfPictArray() > 0 || sizeOfDrawingArray() > 0`, or a direct `mc:AlternateContent` child found by a plain DOM sibling scan.

The guard is a strict superset of the three sources that feed `pictTextObjs`. The XPath is anchored at `./mc:AlternateContent`, i.e. direct children only, and the DOM scan checks exactly those children by namespace and local name — so the case where `selectPath` matches while both `sizeOf` counts are zero still passes the guard. When the guard is false all three sources are provably empty, so `pictureText` would have been `""` and both loops no-ops.

### `XWPFParagraph` walked every run's children with a cursor

After building the runs it opened an `XmlCursor` and ran `selectPath("child::*")` over the children of every run to find `CTFtnEdnRef` footnote references, which are rare. Checked against the generated schema: `CTFtnEdnRef` occurs in `CTR` only as `w:footnoteReference` and `w:endnoteReference`, so the walk is now skipped when the run has neither.

The cursor walk itself is deliberately unchanged rather than replaced with the typed accessors, because `getFootnoteReferenceArray()` + `getEndnoteReferenceArray()` would group all footnote refs before all endnote refs and change the append order for a run that mixes both.

### `XWPFTable` parsed every cell twice

`processCTRow` constructed a full `XWPFParagraph` — and therefore all its `XWPFRun`s — for every paragraph of every cell, purely to precompute the `text` field, then discarded the objects. But the line above it already did `new XWPFTableRow(row, this)`, which builds an `XWPFTableCell` per cell, each of which already builds an `XWPFParagraph` per paragraph. Every table cell was being parsed twice on open. It now reads the paragraphs from the row it just built.

Same set and order (`XWPFTableRow` uses `ctRow.getTcArray()`; a cell's paragraphs are its direct `w:p` children in document order), and both paragraph sets resolve to the same `XWPFDocument`, so `getText()` is unchanged. The drawing-id reservations that the discarded objects performed were duplicates of ones the cell paragraphs had already made.

I did not make `getText()` lazy: `text` is captured at construction today and never updated by `addRow`/`createRow`/`setText`, so a lazy version would start reflecting later mutations, and `text` is a `protected` field an out-of-tree subclass could read.

All 313 `org.apache.poi.xwpf.*` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)