### PR TITLE
Avoid building XmlBeans objects for every shared string

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/ReadOnlySharedStringsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/ReadOnlySharedStringsTable.java
@@ -224,10 +224,28 @@ public class ReadOnlySharedStringsTable extends DefaultHandler implements Shared
 
     @Override
     public RichTextString getItemAt(int idx) {
+        return new XSSFRichTextString(getRawItemAt(idx));
+    }
+
+    /**
+     * Return the raw text of the string at the given index, ie the text as it was stored in the
+     * shared strings table, without wrapping it in a {@link RichTextString}. Note that any
+     * <code>_xHHHH_</code> escape sequences are <em>not</em> decoded, just like they are not
+     * decoded by {@link #getItemAt(int)} - the decoding happens in
+     * {@link XSSFRichTextString#toString()}.
+     * <p>
+     * This is kept package private on purpose - it exists so that
+     * {@link XSSFSheetXMLHandler} can avoid creating an {@link XSSFRichTextString}
+     * (and the XmlBeans object backing it) for every string cell.
+     *
+     * @param idx index of the string to return
+     * @return the raw text at the specified position in this Shared String table
+     */
+    String getRawItemAt(int idx) {
         if (strings == null || idx >= strings.size()) {
             throw new IllegalStateException("Cannot get item at " + idx + " with strings: " + strings);
         }
-        return new XSSFRichTextString(strings.get(idx));
+        return strings.get(idx);
     }
 
     //// ContentHandler methods ////

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFSheetXMLHandler.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/eventusermodel/XSSFSheetXMLHandler.java
@@ -413,8 +413,7 @@ public class XSSFSheetXMLHandler extends DefaultHandler {
 
                 case INLINE_STRING:
                     // TODO: Can these ever have formatting on them?
-                    XSSFRichTextString rtsi = new XSSFRichTextString(value.toString());
-                    thisStr = rtsi.toString();
+                    thisStr = decodeText(value.toString());
                     break;
 
                 case SST_STRING:
@@ -422,8 +421,14 @@ public class XSSFSheetXMLHandler extends DefaultHandler {
                     if (!sstIndex.isEmpty()) {
                         try {
                             int idx = parseInt(sstIndex);
-                            RichTextString rtss = sharedStringsTable.getItemAt(idx);
-                            thisStr = rtss.toString();
+                            if (sharedStringsTable instanceof ReadOnlySharedStringsTable roSst) {
+                                // this table holds plain strings anyway, so we can skip creating
+                                // a RichTextString (and its XmlBeans backing object) per cell
+                                thisStr = decodeText(roSst.getRawItemAt(idx));
+                            } else {
+                                RichTextString rtss = sharedStringsTable.getItemAt(idx);
+                                thisStr = rtss.toString();
+                            }
                         } catch (NumberFormatException ex) {
                             LOG.atError().withThrowable(ex).log("Failed to parse SST index '{}'", sstIndex);
                         }
@@ -460,6 +465,24 @@ public class XSSFSheetXMLHandler extends DefaultHandler {
 
         // Output
         output.cell(cellRef, thisStr, comment);
+    }
+
+    /**
+     * Returns the same text as <code>new XSSFRichTextString(text).toString()</code> would,
+     * but without building the XmlBeans object backing the rich text string.
+     * <p>
+     * The only transformation that such a round-trip applies to a plain string is the decoding
+     * of the <code>_xHHHH_</code> escape sequences, so the (rare) strings that may contain such
+     * a sequence are still handled by {@link XSSFRichTextString}.
+     */
+    private static String decodeText(String text) {
+        if (text == null) {
+            return "";
+        }
+        if (!text.contains("_x")) {
+            return text;
+        }
+        return new XSSFRichTextString(text).toString();
     }
 
     /**

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/model/SharedStringsTable.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/model/SharedStringsTable.java
@@ -70,9 +70,19 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
     private final List<CTRst> strings = new ArrayList<>();
 
     /**
-     *  Maps strings and their indexes in the <code>strings</code> arrays
+     *  Maps the XML fragments of the rich strings and their indexes in the <code>strings</code> arrays
      */
     private final Map<String, Integer> stmap = new HashMap<>();
+
+    /**
+     *  Maps plain strings and their indexes in the <code>strings</code> arrays.
+     *  <p>
+     *  Entries that hold nothing but a piece of text (see {@link #plainText(CTRst)}) can be keyed
+     *  by that text, which saves serialising them to XML just to be able to look them up. This map
+     *  is kept separate from {@link #stmap} so that the raw text can never collide with the XML
+     *  fragment of a rich string.
+     */
+    private final Map<String, Integer> plainmap = new HashMap<>();
 
     /**
      * An integer representing the total count of strings in the workbook. This count does not
@@ -128,7 +138,12 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
             uniqueCount = Math.toIntExact(sst.getUniqueCount());
             //noinspection deprecation
             for (CTRst st : sst.getSiArray()) {
-                stmap.put(xmlText(st), cnt);
+                String plain = plainText(st);
+                if (plain != null) {
+                    plainmap.put(plain, cnt);
+                } else {
+                    stmap.put(xmlText(st), cnt);
+                }
                 strings.add(st);
                 cnt++;
             }
@@ -139,6 +154,32 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
 
     protected String xmlText(CTRst st) {
         return st.xmlText(options);
+    }
+
+    /**
+     * Returns the text of the given entry if the entry can safely be identified by its plain text
+     * alone, or <code>null</code> if it has to be identified by its serialised XML fragment.
+     * <p>
+     * Only entries that consist of nothing but a piece of text qualify, ie no formatting runs and
+     * no phonetic information. Text with leading or trailing whitespace is excluded too, because
+     * for such entries the <code>xml:space="preserve"</code> attribute is significant but is not
+     * part of the text itself.
+     *
+     * @param st the entry to check
+     * @return the text to key the entry by, or <code>null</code> if the XML fragment has to be used
+     */
+    private static String plainText(CTRst st) {
+        if (!st.isSetT() || st.sizeOfRArray() != 0 || st.sizeOfRPhArray() != 0 || st.isSetPhoneticPr()) {
+            return null;
+        }
+        String text = st.getT();
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        if (Character.isWhitespace(text.charAt(0)) || Character.isWhitespace(text.charAt(text.length() - 1))) {
+            return null;
+        }
+        return text;
     }
 
     /**
@@ -188,10 +229,14 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
      */
     @Internal
     int addEntry(CTRst st) {
-        String s = xmlText(st);
+        // plain strings can be keyed by their text, which avoids serialising them to XML
+        String plain = plainText(st);
+        Map<String, Integer> map = plain != null ? plainmap : stmap;
+        String s = plain != null ? plain : xmlText(st);
         count++;
-        if (stmap.containsKey(s)) {
-            return stmap.get(s);
+        Integer existing = map.get(s);
+        if (existing != null) {
+            return existing;
         }
 
         uniqueCount++;
@@ -199,7 +244,7 @@ public class SharedStringsTable extends POIXMLDocumentPart implements SharedStri
         CTRst newSt = _sstDoc.getSst().addNewSi();
         newSt.set(st);
         int idx = strings.size();
-        stmap.put(s, idx);
+        map.put(s, idx);
         strings.add(newSt);
         return idx;
     }


### PR DESCRIPTION
String cells created an XmlBeans document store per cell on both the read and the write path.

### Writing: `SharedStringsTable` serialised XML to build a map key

`addEntry` called `xmlText(st)` to serialise the `CTRst` to an XML fragment purely to use as a `HashMap` key — for every string cell written, including duplicates. `readFrom` did the same for every entry when opening a workbook.

Entries that hold nothing but a piece of text are now keyed by that text in a separate map. Kept deliberately conservative:

- The fast path requires `isSetT() && sizeOfRArray() == 0 && sizeOfRPhArray() == 0 && !isSetPhoneticPr()`; anything else keeps the existing XML key.
- Plain text and XML fragments live in **separate maps**, so the two keyspaces cannot collide.
- Text with leading or trailing whitespace is excluded, because for those entries the `xml:space="preserve"` attribute is significant but is not part of the text — keying by text alone could point a new cell at an entry that would lose its edge whitespace on save.
- An unset `<t>` also falls back to the XML key, so `<si/>` and `<si><t/></si>` stay distinct.

This cannot split an existing group (equal `xmlText` implies equal text for qualifying entries) and cannot merge two entries that would save differently. `count`/`uniqueCount` bookkeeping, the `strings` list and every previously handed-out index are untouched, and `readFrom` and `addEntry` share the predicate so dedup still works across an open-then-write cycle. `TestSharedStringsTable.testCreateNew` is the adversarial case — a plain `"Second string"` and a rich-run `"Second string"` — and stays correct because the rich one keeps the XML key.

### Reading: the event model round-tripped every string through XmlBeans

`ReadOnlySharedStringsTable` stores plain `String`s, but `getItemAt` wrapped each in an `XSSFRichTextString` (a full `CTRst` document store) and `XSSFSheetXMLHandler` immediately called `toString()` to get the string back. The inline-string branch did `new XSSFRichTextString(value.toString()).toString()` on a string it already had.

That round trip is **not** the identity, so it is not simply dropped: `toString()` applies `utfDecode`, which rewrites `_xHHHH_` escape sequences. The handler now applies exactly that decoding, using the same `contains("_x")` short-circuit and still delegating to `XSSFRichTextString` for the rare strings that contain it, so the result is identical in every case including nulls and empty strings.

`getItemAt` keeps its signature, semantics and exception behaviour. The raw accessor added beside it is package private (the handler is in the same package), so nothing is added to the public `SharedStrings` interface, and third-party `SharedStrings` implementations keep the existing `getItemAt(...).toString()` path.

254 tests across `xssf.model`, `xssf.eventusermodel`, `xssf.extractor`, `TestXSSFRichTextString` and `TestXSSFCell` pass; the full `poi-ooxml` suite was also run against all three of these workstreams together with no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)