### PR TITLE
Fix off-by-one when stripping the [] wrapper from an external book name

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/BaseXSSFEvaluationWorkbook.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/BaseXSSFEvaluationWorkbook.java
@@ -101,7 +101,7 @@ public abstract class BaseXSSFEvaluationWorkbook implements FormulaRenderingWork
     private int resolveBookIndex(String bookName) {
         // Strip the [] wrapper, if still present
         if (bookName.startsWith("[") && bookName.endsWith("]")) {
-            bookName = bookName.substring(1, bookName.length()-2);
+            bookName = bookName.substring(1, bookName.length()-1);
         }
 
         // Is it already in numeric form?
@@ -115,9 +115,9 @@ public abstract class BaseXSSFEvaluationWorkbook implements FormulaRenderingWork
         if (index != -1) return index;
 
         // Is it an absolute file reference?
-        if (bookName.startsWith("'file:///") && bookName.endsWith("'")) {
-            String relBookName = bookName.substring(bookName.lastIndexOf('/')+1);
-            relBookName = relBookName.substring(0, relBookName.length()-1); // Trailing '
+        String fileRef = asFileReference(bookName);
+        if (fileRef != null) {
+            String relBookName = fileRef.substring(fileRef.lastIndexOf('/')+1);
 
             // Try with this name
             index = findExternalLinkIndex(relBookName, tables);
@@ -128,14 +128,33 @@ public abstract class BaseXSSFEvaluationWorkbook implements FormulaRenderingWork
             // Note - this is really rather nasty...
             ExternalLinksTable fakeLinkTable = new FakeExternalLinksTable(relBookName);
             _uBook.addExternalLinksTable(fakeLinkTable);
-            return tables.size(); // 1 based results, 0 = current workbook
+            // 1 based results, 0 = current workbook. Re-fetch rather than trusting the
+            // list we looked up above to be the live one (it may also have been null)
+            return _uBook.getExternalLinksTables().size();
         }
 
         // Not properly referenced
         throw new IllegalStateException("Book not linked for filename " + bookName);
     }
+    /**
+     * The formula parser leaves the single quotes around a quoted book name in place, but
+     * don't rely on them being there - callers may hand us an unquoted name just as easily.
+     *
+     * @return the file reference with any surrounding quotes removed, or {@code null} if
+     *  {@code bookName} isn't an absolute file reference
+     */
+    private static String asFileReference(String bookName) {
+        String name = bookName;
+        if (name.length() > 1 && name.startsWith("'") && name.endsWith("'")) {
+            name = name.substring(1, name.length()-1);
+        }
+        return name.startsWith("file:///") ? name : null;
+    }
     /* This is case-sensitive. Is that correct? */
     private int findExternalLinkIndex(String bookName, List<ExternalLinksTable> tables) {
+        if (tables == null) {
+            return -1;
+        }
         int i = 0;
         for (ExternalLinksTable table : tables) {
             if (table.getLinkedFileName().equals(bookName)) {

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFEvaluationWorkbook.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFEvaluationWorkbook.java
@@ -19,12 +19,19 @@ package org.apache.poi.xssf.usermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.IOException;
+
+import org.apache.poi.ss.formula.NameIdentifier;
+import org.apache.poi.ss.formula.SheetIdentifier;
+import org.apache.poi.ss.formula.ptg.Ref3DPxg;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.XSSFTestDataSamples;
 import org.junit.jupiter.api.Test;
 
 class TestXSSFEvaluationWorkbook {
@@ -75,6 +82,52 @@ class TestXSSFEvaluationWorkbook {
         assertEquals("1", cellA3.getStringCellValue());
         assertEquals(0,cellB3.getNumericCellValue(), 0.00001);
         assertEquals("3",cellC3.getStringCellValue());
+    }
+
+    @Test
+    void testResolveBookIndexWithBracketedName() throws IOException {
+        try (XSSFWorkbook wb = XSSFTestDataSamples.openSampleWorkbook("ref-56737.xlsx")) {
+            XSSFEvaluationWorkbook ewb = XSSFEvaluationWorkbook.create(wb);
+            SheetIdentifier sheet = new SheetIdentifier("[56737.xlsx]", new NameIdentifier("Uses", false));
+
+            Ref3DPxg ptg = (Ref3DPxg) ewb.get3DReferencePtg(new CellReference("A1"), sheet);
+            // 1 based results, 0 = current workbook
+            assertEquals(1, ptg.getExternalWorkbookNumber());
+        }
+    }
+
+    @Test
+    void testResolveBookIndexForQuotedFileReference() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFEvaluationWorkbook ewb = XSSFEvaluationWorkbook.create(wb);
+            SheetIdentifier sheet = new SheetIdentifier("'file:///C:/temp/Book1.xlsx'",
+                    new NameIdentifier("Sheet1", false));
+
+            // no link table for this file yet, so a placeholder one is added
+            Ref3DPxg ptg = (Ref3DPxg) ewb.get3DReferencePtg(new CellReference("A1"), sheet);
+            assertEquals(1, ptg.getExternalWorkbookNumber());
+            assertEquals(1, wb.getExternalLinksTables().size());
+            assertEquals("Book1.xlsx", wb.getExternalLinksTable(0).getLinkedFileName());
+
+            // asking again finds the placeholder rather than adding a second one
+            ptg = (Ref3DPxg) ewb.get3DReferencePtg(new CellReference("A1"), sheet);
+            assertEquals(1, ptg.getExternalWorkbookNumber());
+            assertEquals(1, wb.getExternalLinksTables().size());
+        }
+    }
+
+    @Test
+    void testResolveBookIndexForUnquotedFileReference() throws IOException {
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            XSSFEvaluationWorkbook ewb = XSSFEvaluationWorkbook.create(wb);
+            // the formula parser leaves the quotes in place, but we shouldn't depend on that
+            SheetIdentifier sheet = new SheetIdentifier("file:///C:/temp/Book1.xlsx",
+                    new NameIdentifier("Sheet1", false));
+
+            Ref3DPxg ptg = (Ref3DPxg) ewb.get3DReferencePtg(new CellReference("A1"), sheet);
+            assertEquals(1, ptg.getExternalWorkbookNumber());
+            assertEquals("Book1.xlsx", wb.getExternalLinksTable(0).getLinkedFileName());
+        }
     }
 
 }


### PR DESCRIPTION
### The bug

`BaseXSSFEvaluationWorkbook.resolveBookIndex` strips the `[]` wrapper from a book name with `substring(1, length()-2)`, which drops the trailing `]`, the leading `[`, **and** the last character of the name itself:

```java
if (bookName.startsWith("[") && bookName.endsWith("]")) {
    bookName = bookName.substring(1, bookName.length()-2);   // "[Book1.xlsx]" -> "Book1.xls"
}
```

The external-links lookup then misses, and unless the truncated name happens to look like a `'file:///…'` reference the call ends in `IllegalStateException: Book not linked for filename …`.

`FormulaParser.getBookName()` already strips the brackets, so the normal parser path masks this. The branch is reached when a caller hands `get3DReferencePtg` / `getNameXPtg` a `SheetIdentifier` whose book name still has its brackets — which is what the "if still present" comment is there for.

### Also in the same method

* The absolute-file-reference check only matched `'file:///…'` **with** the surrounding single quotes, working only because `getBookName()` happens to leave them in place. It now accepts the reference with or without them.
* `findExternalLinkIndex` iterated the list from `XSSFWorkbook.getExternalLinksTables()` without a null check, even though `getExternalLinksTable(int)` and `addExternalLinksTable` both treat null as possible. It now returns `-1` for a null list, and the placeholder-added case re-fetches the list instead of assuming the one looked up earlier is the live one.

### Tests

Three cases added to `TestXSSFEvaluationWorkbook`, each verified to fail without the corresponding change:

* `testResolveBookIndexWithBracketedName` — uses the existing `ref-56737.xlsx` sample (linked file name `56737.xlsx`); without the fix it fails with `Book not linked for filename 56737.xls`.
* `testResolveBookIndexForUnquotedFileReference` — without the fix, `file:///C:/temp/Book1.xlsx` is rejected.
* `testResolveBookIndexForQuotedFileReference` — covers the pre-existing quoted form, including that a repeat lookup finds the placeholder rather than adding a second one.

536 tests across `TestFormulaEvaluatorOnXSSF`, `TestXSSFFormulaEvaluation`, `TestXSSFFormulaParser`, `TestExternalLinksTable` and the rest of the XSSF formula suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)