### PR TITLE
Fix typos in comments/javadoc

### DIFF
--- a/poi-examples/src/main/java/org/apache/poi/examples/ss/AddDimensionedImage.java
+++ b/poi-examples/src/main/java/org/apache/poi/examples/ss/AddDimensionedImage.java
@@ -669,7 +669,7 @@ public class AddDimensionedImage {
 
             // When the required size is very close indded to the column size,
             // the calcaulation above can produce a negative value. To prevent
-            // problems occuring in later caculations, this is simply removed
+            // problems occurring in later caculations, this is simply removed
             // be setting the overlapMM value to zero.
             if (overlapMM < 0) {
                 overlapMM = 0.0D;
@@ -922,7 +922,7 @@ public class AddDimensionedImage {
      */
     public static class ConvertImageUnits {
 
-        // Each cell conatins a fixed number of co-ordinate points; this number
+        // Each cell contains a fixed number of co-ordinate points; this number
         // does not vary with row height or column width or with font. These two
         // constants are defined below.
         public static final int TOTAL_COLUMN_COORDINATE_POSITIONS = 1023;

--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/SignatureConfig.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/dsig/SignatureConfig.java
@@ -998,7 +998,7 @@ public class SignatureConfig {
     }
 
     /**
-     * The signature config can be updated if a document is succesful validated.
+     * The signature config can be updated if a document is successful validated.
      * This flag is used for activating these modifications.
      * Defaults to {@code false}
      *

--- a/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFSheet.java
+++ b/poi-ooxml/src/test/java/org/apache/poi/xssf/usermodel/TestXSSFSheet.java
@@ -1057,7 +1057,7 @@ public final class TestXSSFSheet extends BaseTestXSheet {
             //  <col min="5" max="5" customWidth="true" width="30.0" />
             //</cols>
 
-            //now the span is splitted into 5 individual columns
+            //now the span is split into 5 individual columns
             assertEquals(5, cols.sizeOfColArray());
             for (int i = 0; i < 5; i++) {
                 assertEquals(cw[i] * 256L, sheet.getColumnWidth(i));
@@ -1115,7 +1115,7 @@ public final class TestXSSFSheet extends BaseTestXSheet {
 
             //the check below failed prior to fix of Bug #47804
             ColumnHelper.sortColumns(cols);
-            //the span is now splitted into three parts
+            //the span is now split into three parts
             //<cols>
             //  <col min="2" max="2" customWidth="true" width="12.0" />
             //  <col min="3" max="3" customWidth="true" width="12.0" hidden="true"/>

--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFPictureShape.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFPictureShape.java
@@ -93,7 +93,7 @@ public class HSLFPictureShape extends HSLFSimpleShape implements PictureShape<HS
     }
 
     /**
-     * Create a new Picture and populate the inital structure of the <code>EscherSp</code> record which holds information about this picture.
+     * Create a new Picture and populate the initial structure of the <code>EscherSp</code> record which holds information about this picture.
 
      * @param idx the index of the picture which refers to <code>EscherBSE</code> container.
      * @return the create Picture object

--- a/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/Picture.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hwpf/usermodel/Picture.java
@@ -595,7 +595,7 @@ public final class Picture {
      * @param out
      *            a stream to write to
      * @throws IOException
-     *             if some exception is occured while writing to specified out
+     *             if some exception is occurred while writing to specified out
      */
     public void writeImageContent( OutputStream out ) throws IOException
     {

--- a/poi/src/main/java/org/apache/poi/hpsf/UnicodeString.java
+++ b/poi/src/main/java/org/apache/poi/hpsf/UnicodeString.java
@@ -94,7 +94,7 @@ public class UnicodeString {
         }
         
         if ( terminator != result.length() - 1 ) {
-            LOG.atWarn().log("String terminator (\\0) for UnicodeString property value occured before the end of " +
+            LOG.atWarn().log("String terminator (\\0) for UnicodeString property value occurred before the end of " +
                     "string. Trimming and hope for the best.");
         }
         return result.substring( 0, terminator );

--- a/poi/src/main/java/org/apache/poi/hssf/model/InternalWorkbook.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/InternalWorkbook.java
@@ -2237,7 +2237,7 @@ public final class InternalWorkbook {
      * Changes an external referenced file to another file.
      * A formular in Excel which refers a cell in another file is saved in two parts:
      * The referenced file is stored in an reference table. the row/cell information is saved separate.
-     * This method invokation will only change the reference in the lookup-table itself.
+     * This method invocation will only change the reference in the lookup-table itself.
      * @param oldUrl The old URL to search for and which is to be replaced
      * @param newUrl The URL replacement
      * @return true if the oldUrl was found and replaced with newUrl. Otherwise false

--- a/poi/src/main/java/org/apache/poi/hssf/model/LinkTable.java
+++ b/poi/src/main/java/org/apache/poi/hssf/model/LinkTable.java
@@ -692,7 +692,7 @@ final class LinkTable {
      * Changes an external referenced file to another file.
      * A formular in Excel which refers a cell in another file is saved in two parts:
      * The referenced file is stored in an reference table. the row/cell information is saved separate.
-     * This method invokation will only change the reference in the lookup-table itself.
+     * This method invocation will only change the reference in the lookup-table itself.
      *
      * @param oldUrl The old URL to search for and which is to be replaced
      * @param newUrl The URL replacement


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.