### PR TITLE
Fix typos in comments/javadoc

### DIFF
--- a/poi/src/main/java/org/apache/poi/hssf/record/aggregates/CFRecordsAggregate.java
+++ b/poi/src/main/java/org/apache/poi/hssf/record/aggregates/CFRecordsAggregate.java
@@ -52,7 +52,7 @@ import static org.apache.logging.log4j.util.Unbox.box;
  *  not a file format one.</p>
  */
 public final class CFRecordsAggregate extends RecordAggregate implements GenericRecord {
-    /** Excel 97-2003 allows up to 3 conditional formating rules */
+    /** Excel 97-2003 allows up to 3 conditional formatting rules */
     private static final int MAX_97_2003_CONDTIONAL_FORMAT_RULES = 3;
     private static final Logger LOG = PoiLogManager.getLogger(CFRecordsAggregate.class);
 

--- a/poi/src/main/java/org/apache/poi/ss/formula/functions/DateFunc.java
+++ b/poi/src/main/java/org/apache/poi/ss/formula/functions/DateFunc.java
@@ -68,7 +68,7 @@ public final class DateFunc extends Fixed3ArgFunction {
         // Negative days are handled by the Java Calendar
         
         // Excel has bugs around leap years in 1900, handle them
-        // Special case for the non-existant 1900 leap year
+        // Special case for the non-existent 1900 leap year
         if (year == 1900 && month == Calendar.FEBRUARY && pDay == 29) {
             return 60.0;
         }

--- a/poi/src/main/java/org/apache/poi/ss/usermodel/Table.java
+++ b/poi/src/main/java/org/apache/poi/ss/usermodel/Table.java
@@ -117,7 +117,7 @@ public interface Table {
      * checks if the given cell is part of the table.  Includes checking that they are on the same sheet.
      * @return true if the table and cell are on the same sheet and the cell is within the table range.
      * @since 3.17 beta 1
-     * @see #contains(CellReference) (prefered, faster execution and handles undefined cells)
+     * @see #contains(CellReference) (preferred, faster execution and handles undefined cells)
      */
     default boolean contains(Cell cell) {
         if (cell == null) return false;

--- a/poi/src/main/java/org/apache/poi/ss/util/cellwalk/CellHandler.java
+++ b/poi/src/main/java/org/apache/poi/ss/util/cellwalk/CellHandler.java
@@ -26,7 +26,7 @@ public interface CellHandler {
 
     /**
      * @param cell current cell
-     * @param ctx information about invokation context
+     * @param ctx information about invocation context
      */
     void onCell(Cell cell, CellWalkContext ctx);
 

--- a/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestSheetAutosizeColumn.java
+++ b/poi/src/test/java/org/apache/poi/ss/usermodel/BaseTestSheetAutosizeColumn.java
@@ -218,7 +218,7 @@ public abstract class BaseTestSheetAutosizeColumn {
         row.createCell(0).setCellValue("x");
         row.createCell(1).setCellValue("xxxx");
         row.createCell(2).setCellValue("xxxxxxxxxxxx");
-        row.createCell(3).setCellValue("Apache\nSoftware Foundation"); // the text is splitted into two lines
+        row.createCell(3).setCellValue("Apache\nSoftware Foundation"); // the text is split into two lines
         row.createCell(4).setCellValue("Software Foundation");
 
         Cell cell5 = row.createCell(5);


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.