### PR TITLE
Close file-backed resources when workbook/extractor construction fails

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/ooxml/extractor/POIXMLExtractorFactory.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/ooxml/extractor/POIXMLExtractorFactory.java
@@ -157,7 +157,7 @@ public final class POIXMLExtractorFactory implements ExtractorProvider {
             return ex;
         } catch (InvalidFormatException ife) {
             throw new IOException(ife);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             if (pkg != null) {
                 pkg.revert();
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbookFactory.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xssf/usermodel/XSSFWorkbookFactory.java
@@ -116,7 +116,7 @@ public class XSSFWorkbookFactory implements WorkbookProvider {
     public static XSSFWorkbook createWorkbook(OPCPackage pkg) throws IOException {
         try {
             return new XSSFWorkbook(pkg);
-        } catch (RuntimeException ioe) {
+        } catch (IOException | RuntimeException ioe) {
             // ensure that file handles are closed (use revert() to not re-write the file)
             pkg.revert();
             //pkg.close();

--- a/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbookFactory.java
+++ b/poi/src/main/java/org/apache/poi/hssf/usermodel/HSSFWorkbookFactory.java
@@ -91,7 +91,7 @@ public class HSSFWorkbookFactory implements WorkbookProvider {
         try {
             final char[] passwordChars = password == null ? null : password.toCharArray();
             return new HSSFWorkbook(fs, true, passwordChars);
-        } catch (RuntimeException e) {
+        } catch (IOException | RuntimeException e) {
             // we need to close the filesystem if we encounter an exception to not leak file handles
             fs.close();
             throw e;


### PR DESCRIPTION
Three factory methods open a file-backed resource, then only clean it up for a subset of the exceptions the following call can actually throw. The remaining exception types leak the underlying file handle.

### `HSSFWorkbookFactory.create(File, String, boolean)`

Catches only `RuntimeException`, but `HSSFWorkbook(POIFSFileSystem, boolean, char[])` is declared `throws IOException`. A corrupt or truncated `.xls` that fails with an `IOException` leaks the `RandomAccessFile` behind the `POIFSFileSystem`.

### `XSSFWorkbookFactory.createWorkbook(OPCPackage)`

Same gap — catches only `RuntimeException` while `new XSSFWorkbook(pkg)` throws `IOException`. Reached from `create(File, String, boolean)`, the package is `ZipFile`-backed, so the zip handle leaks.

### `POIXMLExtractorFactory.create(File, String)`

Handles `InvalidFormatException` and `IOException` but not `RuntimeException`. The `InputStream` overload directly below it already has that arm, and it is the `File` variant that actually holds a descriptor.

### Fix

Each catch clause is widened to a multi-catch that reverts/closes and rethrows the original exception unchanged — no exception types are wrapped or swallowed, so caller-visible behaviour is unchanged apart from the resource now being released. `ExtractorFactory.createExtractor(File, String)` already uses this `catch (IOException | RuntimeException)` shape.

No public signatures change, so there is nothing for MiMa to check. `:poi:compileJava` and `:poi-ooxml:compileJava` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)