### PR TITLE
Close the POIFS filesystem when MAPIMessage parsing fails

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hsmf/MAPIMessage.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hsmf/MAPIMessage.java
@@ -52,6 +52,7 @@ import org.apache.poi.hsmf.parsers.POIFSChunkParser;
 import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.util.CodePageUtil;
+import org.apache.poi.util.IOUtils;
 import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.util.StringUtil;
 
@@ -153,7 +154,17 @@ public class MAPIMessage extends POIReadOnlyDocument {
      *                          input format
      */
     public MAPIMessage(POIFSFileSystem fs) throws IOException {
-        this(fs.getRoot());
+        super(fs.getRoot());
+
+        // this instance takes ownership of fs - close() closes it via the directory - so
+        // close it here too if parsing fails, otherwise the file handle behind a
+        // MAPIMessage(File) or MAPIMessage(String) would leak on a malformed message
+        try {
+            parseChunks(fs.getRoot());
+        } catch (IOException | RuntimeException e) {
+            IOUtils.closeQuietly(fs);
+            throw e;
+        }
     }
 
     /**
@@ -167,7 +178,18 @@ public class MAPIMessage extends POIReadOnlyDocument {
      */
     public MAPIMessage(DirectoryNode poifsDir) throws IOException {
         super(poifsDir);
+        parseChunks(poifsDir);
+    }
 
+    /**
+     * Reads the chunks out of the given directory and populates this message.
+     *
+     * <p>Split out of {@link #MAPIMessage(DirectoryNode)} so that
+     * {@link #MAPIMessage(POIFSFileSystem)} can close the filesystem it owns if parsing
+     * fails. Note that the {@link DirectoryNode} constructor deliberately does not do
+     * that - it is used for messages embedded in a filesystem owned by someone else.</p>
+     */
+    private void parseChunks(DirectoryNode poifsDir) throws IOException {
         // Grab all the chunks
         ChunkGroup[] chunkGroups = POIFSChunkParser.parse(poifsDir);
 


### PR DESCRIPTION
`MAPIMessage(File)` and `MAPIMessage(String)` open a file-backed `POIFSFileSystem` and hand it to `MAPIMessage(POIFSFileSystem)`, which delegates to `MAPIMessage(DirectoryNode)`. That constructor runs `POIFSChunkParser.parse` and the chunk sorters with no cleanup, so a malformed `.msg` file leaks the `RandomAccessFile` behind the filesystem. `MAPIMessage(File)` is the constructor the javadoc recommends for lower memory use, so this is the path most likely to be hit.

### Fix

`MAPIMessage(POIFSFileSystem)` already takes ownership of the filesystem — `close()` closes it via `POIDocument.close()` — so it is also the right place to close it when construction does not complete.

The chunk parsing moves into a private `parseChunks` method, and `MAPIMessage(POIFSFileSystem)` now calls `super`/`parseChunks` directly instead of delegating with `this(fs.getRoot())`, so the parse can be wrapped in a try/catch. The original exception is rethrown unchanged.

`MAPIMessage(DirectoryNode)` deliberately keeps no cleanup: it is used for messages embedded in a filesystem owned by someone else (`AttachmentChunks.getEmbeddedMessage()`), so closing that filesystem there would be wrong.

`HSLFSlideShowImpl` solves the same problem the same way, at `HSLFSlideShowImpl.java:262`.

No public signatures change, so there is nothing for MiMa to check. The 18 `org.apache.poi.hsmf.*` test classes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)