### PR TITLE
Release the temp file when ChunkedCipherOutputStream construction fails

### DIFF
--- a/poi/src/main/java/org/apache/poi/poifs/crypt/ChunkedCipherOutputStream.java
+++ b/poi/src/main/java/org/apache/poi/poifs/crypt/ChunkedCipherOutputStream.java
@@ -74,7 +74,17 @@ public abstract class ChunkedCipherOutputStream extends FilterOutputStream {
         this.fileOut = TempFile.createTempFile("encrypted_package", "crypt");
         this.out = Files.newOutputStream(fileOut.toPath());
         this.dir = dir;
-        this.cipher = initCipherForBlock(null, 0, false);
+        try {
+            this.cipher = initCipherForBlock(null, 0, false);
+        } catch (IOException | GeneralSecurityException | RuntimeException e) {
+            // the constructor did not complete, so the caller has no instance to close -
+            // release the stream and the temp file here instead of leaking both
+            IOUtils.closeQuietly(this.out);
+            if (!fileOut.delete()) {
+                LOG.atWarn().log("Can't delete temp file: {}", fileOut);
+            }
+            throw e;
+        }
     }
 
     public ChunkedCipherOutputStream(OutputStream stream, int chunkSize) throws IOException, GeneralSecurityException {


### PR DESCRIPTION
`ChunkedCipherOutputStream(DirectoryNode, int)` creates a temp file and opens an `OutputStream` on it, then calls the abstract `initCipherForBlock(null, 0, false)`:

```java
this.fileOut = TempFile.createTempFile("encrypted_package", "crypt");
this.out = Files.newOutputStream(fileOut.toPath());
this.dir = dir;
this.cipher = initCipherForBlock(null, 0, false);  // throws IOException, GeneralSecurityException
```

`initCipherForBlock` is declared `throws IOException, GeneralSecurityException` — a bad key or an unavailable JCE algorithm gets there. When it throws, the constructor never completes, so the caller has no instance to close, and both the open stream and the temp file leak.

### Fix

Wrap the `initCipherForBlock` call so the stream is closed and the temp file deleted before the original exception is rethrown.

The field assignments are deliberately left where they are rather than reordering `initCipherForBlock` above the temp-file creation — subclass implementations (`XOREncryptor`, `BinaryRC4Encryptor`, `CryptoAPIEncryptor`, `AgileEncryptor`) still see exactly the initialisation state they see today.

The other constructor, `ChunkedCipherOutputStream(OutputStream, int)`, is unaffected: it owns no temp file and wraps a stream the caller supplied.

No public signatures change, so there is nothing for MiMa to check. The `org.apache.poi.poifs.crypt.*` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)