### PR TITLE
Close the filesystem if HSLF dual-storage lookup fails

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/usermodel/HSLFSlideShowImpl.java
@@ -273,7 +273,16 @@ public final class HSLFSlideShowImpl extends POIDocument implements Closeable {
         if (!dir.hasEntryCaseInsensitive(PP97_DOCUMENT)) {
             return dir;
         }
-        return (DirectoryNode) dir.getEntryCaseInsensitive(PP97_DOCUMENT);
+        try {
+            return (DirectoryNode) dir.getEntryCaseInsensitive(PP97_DOCUMENT);
+        } catch (IOException | RuntimeException e) {
+            // this runs in the super(...) argument of the constructor below, so the
+            // constructor's own catch block cannot clean up after it. A malformed file whose
+            // PP97_DUALSTORAGE entry is a document rather than a directory fails the cast
+            // here, and without this the file handle would leak.
+            IOUtils.closeQuietly(dir.getFileSystem());
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
`HSLFSlideShowImpl(DirectoryNode, char[])` already closes the underlying filesystem when parsing fails, so that `HSLFSlideShowImpl(String fileName)` does not leak the file handle it opened:

```java
public HSLFSlideShowImpl(DirectoryNode dir, char[] password) throws IOException {
    super(handleDualStorage(dir));
    try {
        ...
    } catch (RuntimeException | IOException e) {
        dir.getFileSystem().close();
        throw e;
    }
}
```

That cleanup does not cover `handleDualStorage`, which runs in the `super(...)` argument and therefore completes before the constructor body — and its try block — is entered.

`handleDualStorage` casts the `PP97_DUALSTORAGE` entry to `DirectoryNode`. A malformed file where that entry is a document rather than a directory fails the cast with a `ClassCastException` that escapes past the constructor's catch, leaking the file handle opened by `new POIFSFileSystem(new File(fileName))`.

### Fix

Close the filesystem in `handleDualStorage` itself and rethrow the original exception, matching what the constructor already does for the parsing stage.

The cast is deliberately left as-is rather than replaced with an explicit type check, so the exception type callers see for a malformed file does not change — this PR is only about releasing the handle.

No public signatures change, so there is nothing for MiMa to check. The 99 `org.apache.poi.hslf.*` test classes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)