### PR TITLE
Build the cipher before opening the zip entry in AesZipFileZipEntrySource

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/AesZipFileZipEntrySource.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/poifs/crypt/temp/AesZipFileZipEntrySource.java
@@ -89,8 +89,11 @@ public final class AesZipFileZipEntrySource implements ZipEntrySource {
 
     @Override
     public InputStream getInputStream(ZipArchiveEntry entry) throws IOException {
+        // build the cipher before opening the entry - getCipher can throw
+        // EncryptedDocumentException, which would otherwise leak the open stream
+        Cipher ciDec = getCipher(Cipher.DECRYPT_MODE);
         InputStream is = zipFile.getInputStream(entry);
-        return new CipherInputStream(is, getCipher(Cipher.DECRYPT_MODE));
+        return new CipherInputStream(is, ciDec);
     }
 
     @Override


### PR DESCRIPTION
`AesZipFileZipEntrySource.getInputStream` opens the entry's stream first and then builds the decryption cipher:

```java
InputStream is = zipFile.getInputStream(entry);
return new CipherInputStream(is, getCipher(Cipher.DECRYPT_MODE));
```

`getCipher` delegates to `CryptoFunctions.getCipher`, which throws `EncryptedDocumentException` when the JCE cannot supply the cipher. That happens after the entry stream is already open and before anything has taken ownership of it, so the stream leaks.

### Fix

Swap the order — build the cipher first, and open the entry only once that is known to have succeeded. No try/catch needed.

`EncryptedTempData.getInputStream` already uses this ordering.

No public signatures change, so there is nothing for MiMa to check. `TestSecureTempZip`, `TestEncryptedTempZipThreshold` and `TestSXSSFWorkbookWithCustomZipEntrySource` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)