### PR TITLE
Use try-with-resources for the PPTXMLDump output file

### DIFF
--- a/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/PPTXMLDump.java
+++ b/poi-scratchpad/src/main/java/org/apache/poi/hslf/dev/PPTXMLDump.java
@@ -21,7 +21,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -216,13 +215,16 @@ public final class PPTXMLDump {
                 System.out.println("Dumping " + arg);
 
                 if (outFile) {
-                    OutputStream fos = Files.newOutputStream(Path.of(ppt.getName() + ".xml"));
-                    OutputStreamWriter out = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
-                    dump.dump(out);
-                    out.close();
+                    try (Writer out = new OutputStreamWriter(
+                            Files.newOutputStream(Path.of(ppt.getName() + ".xml")), StandardCharsets.UTF_8)) {
+                        dump.dump(out);
+                    }
                 } else {
-                    dump.dump(new BufferedWriter(
-                            new OutputStreamWriter(System.out, StandardCharsets.UTF_8)));
+                    Writer out = new BufferedWriter(
+                            new OutputStreamWriter(System.out, StandardCharsets.UTF_8));
+                    dump.dump(out);
+                    // dump() does not flush, and System.out must not be closed here
+                    out.flush();
                 }
             }
         }


### PR DESCRIPTION
`PPTXMLDump.main` opened the `.xml` output stream and closed it only after `dump()` returned:

```java
OutputStream fos = Files.newOutputStream(Path.of(ppt.getName() + ".xml"));
OutputStreamWriter out = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
dump.dump(out);
out.close();
```

An `IOException` part way through the dump skips the `close()` and leaks the stream. Switched to try-with-resources.

### Also in the same block

The console branch wraps `System.out` in a `BufferedWriter` and never flushes it. `dump(Writer)` does not flush either — it ends at `write(out, "</Presentation>", padding)` — so running the tool **without** `-f` printed nothing at all. I've added the missing flush since it is the same six lines and the same class of mistake, but happy to split it out if you would rather keep this PR to the leak alone.

`System.out` is deliberately flushed rather than closed.

The now-unused `java.io.OutputStream` import is dropped.

This is a dev/debug tool (`org.apache.poi.hslf.dev`), so the leak itself has no production impact — it was the one spot in the file not already using try-with-resources.

No public signatures change, so there is nothing for MiMa to check. `:poi-scratchpad:compileJava` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)