### PR TITLE
Stop MainExtractorFactory swallowing fatal errors

### DIFF
--- a/poi/src/main/java/org/apache/poi/extractor/MainExtractorFactory.java
+++ b/poi/src/main/java/org/apache/poi/extractor/MainExtractorFactory.java
@@ -31,7 +31,7 @@ import org.apache.poi.hssf.record.crypto.Biff8EncryptionKey;
 import org.apache.poi.poifs.filesystem.DirectoryNode;
 import org.apache.poi.poifs.filesystem.FileMagic;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
-import org.apache.poi.util.ExceptionUtil;
+import org.apache.poi.util.IOUtils;
 
 /**
  * ExtractorFactory for HSSF and Old Excel format
@@ -46,14 +46,14 @@ public class MainExtractorFactory implements ExtractorProvider {
     @Override
     public POITextExtractor create(File file, String password) throws IOException {
         POIFSFileSystem fs = new POIFSFileSystem(file, true);
-        POITextExtractor extractor = null;
+        POITextExtractor extractor;
         try {
             extractor = create(fs.getRoot(), password);
         } catch (Throwable t) {
-            if (!ExceptionUtil.isFatal(t)) {
-                fs.close();
-                throw t;
-            }
+            // this method owns fs and construction did not complete, so close it and let
+            // every throwable through - including fatal ones such as VirtualMachineError
+            IOUtils.closeQuietly(fs);
+            throw t;
         }
         if (extractor == null) {
             fs.close();
@@ -64,14 +64,14 @@ public class MainExtractorFactory implements ExtractorProvider {
     @Override
     public POITextExtractor create(InputStream inputStream, String password) throws IOException {
         POIFSFileSystem fs = new POIFSFileSystem(inputStream);
-        POITextExtractor extractor = null;
+        POITextExtractor extractor;
         try {
             extractor = create(fs.getRoot(), password);
         } catch (Throwable t) {
-            if (!ExceptionUtil.isFatal(t)) {
-                fs.close();
-                throw t;
-            }
+            // this method owns fs and construction did not complete, so close it and let
+            // every throwable through - including fatal ones such as VirtualMachineError
+            IOUtils.closeQuietly(fs);
+            throw t;
         }
         if (extractor == null) {
             fs.close();


### PR DESCRIPTION
Both `create(File, String)` and `create(InputStream, String)` guard their cleanup with an inverted fatal check:

```java
} catch (Throwable t) {
    if (!ExceptionUtil.isFatal(t)) {
        fs.close();
        throw t;
    }
}
```

For a **fatal** throwable — `VirtualMachineError`, `ThreadDeath` — the catch body does nothing at all. Execution falls through to the `if (extractor == null)` branch and the method returns `null`. So an `OutOfMemoryError` raised while building the extractor is reported to the caller as "no extractor for this file".

The rest of the codebase uses the opposite form, rethrowing fatal throwables rather than suppressing them — `XMLHelper.java:177`, `CleanerUtil.java:184`, `HSSFParser.java:53`.

### Fix

There is nothing here that needs to treat fatal throwables differently: the only work in the catch block is closing a filesystem this method opened and owns. So rather than correcting the condition to `if (ExceptionUtil.isFatal(t)) ExceptionUtil.rethrow(t);`, the check is dropped entirely and every throwable propagates.

`fs.close()` also becomes `IOUtils.closeQuietly(fs)` so a failure while closing cannot mask the original throwable — `ExtractorFactory.createExtractor(File, String)` uses the same closeQuietly-then-rethrow shape.

The filesystem is still closed on every failure path, so this does not reintroduce the leak that the original catch block was there to prevent.

This came out of the same review as #1248 — #1253, but it is a correctness bug rather than a leak, so it is separate.

No public signatures change, so there is nothing for MiMa to check. `TestMainExtractorFactory` and `TestExtractorFactory` (120 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)